### PR TITLE
Restore sustained LP accounting and ingestion catchup

### DIFF
--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -263,9 +263,9 @@ responses distinguish complete collected-fee totals from partial evidence:
   `episode_selection: "last_activity_within_window"` and
   `financial_scope: "lifetime_of_selected_episodes"`. Do not treat these
   values as cash flows earned exclusively during the requested window.
-- Owner-list `financials.through_order` is the canonical
-  `[block_number, transaction_index, log_index]` boundary captured in the same
-  WAL snapshot as the financial aggregates. `financials.as_of` describes that
+- Owner-list `financials.through_order` contains the canonical `block_number`,
+  `tx_index`, and `log_index` boundary captured in the same WAL snapshot as the
+  financial aggregates. `financials.as_of` describes that
   boundary, not the time of the latest observed activity. Pending projection
   work or later activity keeps `financials.pending` true without advancing the
   captured boundary. A completed snapshot is distinct from complete history,

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -263,6 +263,13 @@ responses distinguish complete collected-fee totals from partial evidence:
   `episode_selection: "last_activity_within_window"` and
   `financial_scope: "lifetime_of_selected_episodes"`. Do not treat these
   values as cash flows earned exclusively during the requested window.
+- Owner-list `financials.through_order` is the canonical
+  `[block_number, transaction_index, log_index]` boundary captured in the same
+  WAL snapshot as the financial aggregates. `financials.as_of` describes that
+  boundary, not the time of the latest observed activity. Pending projection
+  work or later activity keeps `financials.pending` true without advancing the
+  captured boundary. A completed snapshot is distinct from complete history,
+  trace attribution, pricing, and fee evidence.
 
 Fresh canonical activity does not imply complete transaction enrichment or
 historical accounting. Preserve both freshness and completeness qualifications.

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -30,6 +30,12 @@ ABI revert data. The pinned-state decoder uses that evidence to recognize
 Keeping only the provider message loses this proof and retries valid receipts
 indefinitely. Unproven absence and unrelated errors still fail enrichment.
 
+Pinned-state batches retain successful siblings when one contract call reverts;
+they do not repeat the batch serially. A verified same-receipt mint proves the
+parent-block position absent, but the current-block position read remains
+required. V3 receipts do not wait for trace capability. Successful receipts
+containing V4 PoolManager liquidity modifications still require `callTracer`.
+
 ## Goldsky measurements and limits
 
 A small anonymous-output probe from the production host verified the donated provider privately: chain 4663; exact matching block/header and log digests against the local node; old block headers; USDG `decimals()` at blocks 30,000,000 and 56,400,000; receipts; `debug_traceTransaction` with `callTracer`; and a four-item JSON-RPC batch. The local pruned node could not answer those archive-state calls. Individual successful Goldsky requests in this probe took roughly 76–352 ms; these are samples, not percentile/SLA claims.
@@ -51,12 +57,18 @@ Separate durable cursor progress from the live observed feed. A moving live tape
 
 Production sampling found wallet aggregation repeatedly restarting whenever ingestion advanced its revision. This could keep LP Wallets at `SYNCING` indefinitely while consuming CPU needed by the indexer. Wallet totals, gas and coverage now come from one completed WAL read snapshot; appends trigger a later refresh instead of recursive recomputation. Canonical-branch changes still invalidate service publications. The regression exercises an indexer append during an actual wallet read.
 
-Late historical events rebuild only the affected position's changed accounting rows rather than deleting and rewriting its entire projection. This preserves synchronous, atomic financial updates while reducing write amplification. Existing durable metadata counters are reused on restart; full-table counts initialize missing counters only.
+The running service commits raw events, cursors, balance jobs, and coalesced
+accounting jobs atomically. A separate accounting worker replays each affected
+position from an immutable WAL snapshot without holding the ingestion writer.
+Its short publication transaction writes only changed accounting rows. A newer
+same-branch generation retains the job after publishing the coherent snapshot;
+a changed canonical epoch rejects it. Existing financial rows remain readable
+while the queue drains, but cannot be represented as current accounting.
 
 Header, event, and search writes use parameterized multi-row inserts bounded by
 SQLite's variable limit. This avoids handing the Python interpreter to competing
-valuation workers between every inserted row. The outer durable transaction and
-its atomic accounting/cursor boundary are unchanged.
+valuation workers between every inserted row. The outer durable transaction
+preserves the raw event/cursor/job boundary.
 
 The CLI caps Python's thread-switch interval at 1 ms before starting workers,
 preserving an already-shorter interval. This reduces interpreter handoff delays
@@ -116,14 +128,26 @@ balance, and repricing batches reserve historical work while preferring recent
 ready records; a delayed retry no longer stops unrelated repricing. Identity
 replay likewise alternates recent and historical work.
 
-Metadata RPC fetches use the bounded enrichment workers and commit one batch.
+Schema version 8 adds a generation to receipt jobs. Completion checks the
+canonical block hash and generation inside the same transaction as enrichment;
+an older in-flight receipt cannot erase newer identity or retry work.
+The accounting queue and its bootstrap checkpoint survive restart without
+discarding published positions, episodes, coverage, or cursors.
+
+Receipt enrichment, repricing, and accounting continue during live catch-up.
+Receipt workers refill independently rather than waiting for the slowest member
+of a batch. Metadata, identity replay, and bounded source repairs run separately
+from receipt scheduling. Follow `pending_accounting` as well as enrichment and
+repricing queues; a small block gap does not prove those queues are complete.
+
+Metadata RPC fetches remain bounded and commit one batch.
 V3 balances use a batched pinned-state request and atomic snapshot commit.
 Identity replay commits canonical events and queue completion together.
 Price sample, reserve, mark, and state inserts use the same multi-row helper
 as event ingestion.
 
 Existing V3 NFT positions whose initial add precedes a verified mint in the
-same transaction are repaired by the normal projection lane. A default pass
+same transaction are repaired by the separate source-repair lane. A default pass
 examines at most 8,192 indexed add events newest-first, selects only affected
 positions within reviewed V3-manager ranges, and reprojects at most 32 positions.
 The event cursor stops at the last selected repair when the write limit is
@@ -133,6 +157,14 @@ repairs final collect-before-burn allocation. The
 the accounting schema version is unchanged, so startup does not replay the
 entire ledger. A read-only production probe admitted 16 repairs from 8,192
 events in 0.092 s.
+
+V4 source repair correlates already-traced manager positions with canonical NFT
+transfers from the same receipt, including receipts without an auxiliary
+PositionManager modification event. It preserves the owner at each action's
+log order and retains the stored trace, state, cash-flow, and fee evidence.
+The bounded `v4_owner_correlation_repair_v1` checkpoint resumes after restart.
+Fees before a transfer stay with the prior owner; receiving the NFT does not
+prove its acquisition basis.
 
 Wallet-only requests skip the unused custody aggregate. On a warm, read-only
 production snapshot of 10,540 wallets, this reduced owner-query time from

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -72,6 +72,11 @@ Skipped head notifications are not fork evidence and must not clear wallet
 snapshots. Same-height replacements and confirmed parent mismatches still
 withdraw orphaned activity and invalidate wallets.
 
+The browser refreshes durable index status on its one-second heartbeat,
+independently of the slower overview refresh. Requests do not overlap and
+are aborted while the page is hidden. The moving chain head is no longer
+compared against an index cursor held back by a twelve-second overview timer.
+
 The running service commits raw events, cursors, balance jobs, and coalesced
 accounting jobs atomically. A separate accounting worker replays each affected
 position from an immutable WAL snapshot without holding the ingestion writer.

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -85,6 +85,12 @@ recent ledger before returning its newest event and exceeded 30 seconds on the
 production snapshot; the ordered lookup returned the same boundary in under
 0.25 seconds including process startup.
 
+Closed-position queries count and select the requested page in one WAL snapshot
+with one frozen time cutoff. Only selected episode payloads are materialized.
+Fee sorting uses qualified fee values; incomplete-history amounts remain
+unknown rather than outranking verified fees. Text filtering retains Unicode
+substring matching and literal `%` and `_` characters.
+
 The CLI caps Python's thread-switch interval at 1 ms before starting workers,
 preserving an already-shorter interval. This reduces interpreter handoff delays
 when SQLite releases the GIL during ingestion while valuation threads run.
@@ -153,8 +159,9 @@ Schema version 9 records pending accounting scope and actor hints atomically
 with source changes, including both sides of NFT transfers. Wallet requests
 read those hints and published episodes instead of expanding every queued
 position's raw history. Legacy jobs start unqualified; bounded off-writer
-pages recover their hints without discarding existing financial rows. Recovery
-checks the canonical epoch and per-key cursor before publication.
+pages recover their hints on an independent worker, without waiting behind
+full position replays or discarding existing financial rows. Recovery checks
+the canonical epoch and per-key cursor before publication.
 
 Legacy V4 identity seeding checks each canonical candidate transaction's queue
 entry by transaction hash. It no longer searches every serialized error

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -70,6 +70,19 @@ SQLite's variable limit. This avoids handing the Python interpreter to competing
 valuation workers between every inserted row. The outer durable transaction
 preserves the raw event/cursor/job boundary.
 
+Adaptive scan sizing targets 50 ms of writer residency, half the observed
+100 ms block interval. Growth is capped by measured store throughput as well as
+log density, and history starts with eight blocks before adapting. This is a
+feedback target, not a hard transaction deadline; indivisible block work can
+exceed it. Multi-second history commits previously starved both the live lane
+and financial workers.
+
+Wallet freshness reads walk the canonical event-order index after checking
+whether the requested scope is empty. A timestamp-range plan sorted the entire
+recent ledger before returning its newest event and exceeded 30 seconds on the
+production snapshot; the ordered lookup returned the same boundary in under
+0.25 seconds including process startup.
+
 The CLI caps Python's thread-switch interval at 1 ms before starting workers,
 preserving an already-shorter interval. This reduces interpreter handoff delays
 when SQLite releases the GIL during ingestion while valuation threads run.

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -102,8 +102,11 @@ preserves the raw event/cursor/job boundary.
 Adaptive scan sizing uses separate writer targets: two seconds for live
 catch-up and 200 ms for background history. Growth is capped by measured store
 throughput and log density; history starts with eight blocks before adapting.
-History starts a scan only when the live cursor has caught up to the observed
-head, rather than competing with live catch-up below a 512-block threshold.
+History yields when the recent gap exceeds one adaptive live batch, rather than
+requiring the durable cursor to equal a continuously advancing head. Exact-tip
+admission starved history even while live ingestion stayed only a few blocks
+behind. The adaptive batch is the amount the live worker can commit next, not
+an unrelated fixed lag allowance.
 A new block can arrive during an in-flight transaction; the reported gap
 remains the actual head-minus-cursor difference, without rounding it to zero.
 These are feedback targets, not hard transaction deadlines; indivisible block
@@ -201,10 +204,22 @@ event IDs before materializing event payloads; owner selection preserves
 Historical owner activity uses the same block/transaction/log ordering.
 Allow temporary-sort disk space when installing these indexes on a large ledger.
 
+Schema version 11 adds an `append_only` proof to pending accounting jobs.
+Existing jobs default to full replay; accounting state schema remains 3, with
+no bootstrap or ledger rebuild. Before rolling back to a pre-11 writer, reset
+pending `append_only` values to 0 so that writer cannot leave stale proofs.
+
 Overview and bucket-sorted pool pages share one per-pool interval aggregation,
 keyed by event revision, canonical epoch, and the exact bucket boundaries.
 An advancing empty block still changes the window boundary. Pool metadata
 changes invalidate pool candidates and responses without rescanning buckets.
+
+Owner gas totals resolve exactly attributed transactions through their episode,
+even when other transactions require shared-cost qualification. Shared costs
+still use the effects relation and are counted once. A production read-only
+comparison preserved every value across all-history, 24-hour, protocol and pool
+scopes: all-history took 0.43 seconds versus 0.78 for 24,169 owners; a 1,207-owner
+pool scope took 0.12 versus 0.41 seconds. The 24-hour query remained about 0.54 seconds.
 
 Legacy V4 identity seeding checks each canonical candidate transaction's queue
 entry by transaction hash. It no longer searches every serialized error
@@ -249,8 +264,14 @@ controls matching. This is a smoke measurement, not loaded production capacity.
 
 Identity replay admits up to 64 queue records per pass. Already-known or
 rejected identities need no current-state RPC and do not wait for unrelated
-live pool discoveries. New identity work remains bounded to eight addresses.
-Canonical events and queue completion commit together.
+live pool discoveries. Each pass admits at most 64 distinct fresh identities,
+without taking identities reserved by the current lane. Independent factory
+probes share a state wave; membership checks follow in a dependent wave.
+V4 PoolKey reads and transaction/receipt/header fallbacks are likewise batched.
+Canonical anchor checks precede publication; per-row generation, marker and
+stored-hash checks remain inside bounded shared writer transactions. Network
+work stays outside the writer. Transient failures retain their obligations;
+canonical events and queue completion commit together.
 Price sample, reserve, mark, and state inserts use the same multi-row helper
 as event ingestion.
 
@@ -261,6 +282,12 @@ indivisible position can exceed the target. Epoch checks reject reorged work,
 and generation-guarded completion preserves same-epoch input that arrived during
 preparation. Repricing updates the source revision before projections without
 rewriting every event index; search terms refresh only when identity changes.
+New, previously unprojected events can use the existing incremental append path.
+Persisted state must be compatible and the events must start in a later block.
+An existing-event correction, remap, uncertain trigger or mixed queue generation
+requires full replay; a newer maximum priority does not prove append safety.
+Incremental publication preserves untouched historical episodes, effects and
+ownership intervals.
 
 Episode IDs remain tied to their opening event when older history arrives;
 backfill no longer renumbers every later episode and rewrites its effects.

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -192,10 +192,11 @@ entry by transaction hash. It no longer searches every serialized error
 payload for a pool ID, and it preserves existing candidate retry schedules.
 
 Receipt enrichment, repricing, and accounting continue during live catch-up.
-Receipt fetches run in four-transaction waves, with up to 32 transactions in
-flight. V4 trace work uses a separate four-worker pool and two-transaction
-waves, so an unavailable or slow trace does not block V3 receipts. The coordinator
-refills completed waves before waiting for the database writer. Receipt fields
+Receipt fetches run in eight-transaction waves, with up to 64 transactions in
+flight. V4 trace work has its own eight-transaction capacity, four-worker pool,
+and two-transaction waves, so slow traces cannot consume receipt-worker capacity.
+The coordinator refills completed waves before waiting for the database writer.
+Receipt fields
 provide payer and effective gas price when available; only incomplete receipts
 need transaction-body requests. Headers and pinned-state calls are deduplicated
 within each wave. The shared provider item-rate and HTTP-concurrency limits
@@ -218,6 +219,21 @@ indivisible position can exceed the target. Epoch checks reject reorged work,
 and generation-guarded completion preserves same-epoch input that arrived during
 preparation. Repricing updates the source revision before projections without
 rewriting every event index; search terms refresh only when identity changes.
+
+Episode IDs remain tied to their opening event when older history arrives;
+backfill no longer renumbers every later episode and rewrites its effects.
+Deferred rollback preserves opening identities separately from financial rows,
+including across a restart before replay.
+Replay compares source fields separately from derived valuation and costs,
+while receipt changes still refresh dependent gas and net P/L.
+
+Core-position identities include protocol and pool. An EVM core hash alone is
+not globally unique: different pools can share owner, ticks, and salt. Bounded
+source repair moves legacy rows to pool-scoped keys without changing event IDs,
+receipt evidence, or discovery cursors. Accounting retires a legacy key after
+its source mappings have moved rather than replaying the conflated history.
+During a partial move, legacy financial rows remain explicitly unqualified;
+their overlapping liquidity and fees cannot inflate qualified wallet or pool totals.
 
 Wallet requests reserve bounded receipt and accounting priority without writing
 to SQLite on the request thread. Historical work retains its reserved quarter.

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -55,7 +55,13 @@ Goldsky primary references:
 
 Separate durable cursor progress from the live observed feed. A moving live tape is not evidence of complete historical financial accounting. Compare cursor gain and chain gain over the same interval. Live ingestion and historical backfill share one serialized writer; inspect `history_scheduling` and the lane measurements rather than assuming that backfill is paused.
 
-Production sampling found wallet aggregation repeatedly restarting whenever ingestion advanced its revision. This could keep LP Wallets at `SYNCING` indefinitely while consuming CPU needed by the indexer. Wallet totals, gas and coverage now come from one completed WAL read snapshot; appends trigger a later refresh instead of recursive recomputation. Canonical-branch changes still invalidate service publications. The regression exercises an indexer append during an actual wallet read.
+Production sampling found wallet aggregation repeatedly restarting whenever
+ingestion advanced its revision. Wallet totals, gas and coverage now come from
+one completed WAL read snapshot. Stream consumers reuse the completed snapshot
+while a newer revision or an expired window refreshes asynchronously; one
+consumer cannot take that snapshot away from another. Blocking wallet reads
+still refresh changed revisions and expired windows. Canonical-branch changes
+invalidate both cached and in-flight publications.
 
 The running service commits raw events, cursors, balance jobs, and coalesced
 accounting jobs atomically. A separate accounting worker replays each affected
@@ -75,6 +81,10 @@ preserves the raw event/cursor/job boundary.
 Adaptive scan sizing uses separate writer targets: two seconds for live
 catch-up and 200 ms for background history. Growth is capped by measured store
 throughput and log density; history starts with eight blocks before adapting.
+History starts a scan only when the live cursor has caught up to the observed
+head, rather than competing with live catch-up below a 512-block threshold.
+A new block can arrive during an in-flight transaction; the reported gap
+remains the actual head-minus-cursor difference, without rounding it to zero.
 These are feedback targets, not hard transaction deadlines; indivisible block
 work can exceed them. Applying a 50 ms target to the live lane shrank it to
 one-block commits and left fixed commit costs unamortized.

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -295,6 +295,15 @@ Deferred rollback preserves opening identities separately from financial rows,
 including across a restart before replay.
 Replay compares source fields separately from derived valuation and costs,
 while receipt changes still refresh dependent gas and net P/L.
+Financial-only replay retains derived episode values until revaluation. Gas is
+refreshed when transaction-cost evidence or episode/transaction membership changes,
+not for every unrelated episode correction. Cost-incomplete episodes stop at the
+first missing or inexact transaction; complete episodes still count each transaction
+once.
+Receipt-only pending work can publish gas and net results without replaying event
+history when existing projected events are included solely because their transaction
+record changed. Explicit event corrections, remaps, mixed generations and uncertain
+work invalidate that proof and retain full replay.
 
 Core-position identities include protocol and pool. An EVM core hash alone is
 not globally unique: different pools can share owner, ticks, and salt. Bounded

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -241,6 +241,9 @@ The current-claims worker admits the full selected owner page, keeps at most 512
 wallet interests for 180 seconds, and renews interest when cached API/SSE results
 are served. Each pass walks four active positions, four historical position keys,
 and bounded transaction pages; it does not scan a wallet's entire history.
+Those pages also compare persisted receipt evidence with published gas costs.
+Stale attribution is repaired in 32-transaction, epoch-checked writer batches,
+so an inactive wallet can recover gas and net P/L without another LP action.
 
 Current claims use canonical end-of-block V3/NFPM or V4 StateView fee growth,
 owner and liquidity proof, and integer Q128 fee arithmetic. They borrow at most

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -40,11 +40,18 @@ containing V4 PoolManager liquidity modifications still require `callTracer`.
 
 A small anonymous-output probe from the production host verified the donated provider privately: chain 4663; exact matching block/header and log digests against the local node; old block headers; USDG `decimals()` at blocks 30,000,000 and 56,400,000; receipts; `debug_traceTransaction` with `callTracer`; and a four-item JSON-RPC batch. The local pruned node could not answer those archive-state calls. Individual successful Goldsky requests in this probe took roughly 76–352 ms; these are samples, not percentile/SLA claims.
 
-Goldsky supports HTTPS JSON-RPC, not WSS subscriptions. Keep the existing independent WSS head/activity source. Route cheap local headers/logs locally and use Goldsky for archive state, receipts/traces, current state, and fallback. Enrichment remains bounded; enabling archive access does not instantly complete historical ownership or P/L.
+Goldsky supports HTTPS JSON-RPC, not WSS subscriptions. Keep the independent WSS head/activity source. Route cheap local headers/logs locally. An explicit `LP_RPC_RECEIPT_URLS` can also put the local node ahead of the archive fallback: a production probe returned 12 historical/current receipts with matching canonical hashes, plus three complete block-receipt results, in 32 ms. This does not establish archive-state or trace availability; those capabilities remain separately routed to Goldsky.
 
 The donated allowance is 6,000 requests/minute. This process paces Goldsky at at most 80 JSON-RPC items/second on average per endpoint, counting batch elements conservatively, with four concurrent HTTP requests. Bursts are bounded by the batch size (100). This leaves nominal headroom under 100/s but does not account for other applications sharing the key. Provider billing/rate accounting remains authoritative.
 
 `/api/lp/status` includes per-source `traffic`: total HTTP attempts, total JSON-RPC items, and rolling approximately 60-second rates. Failed attempts and chain verification count. Traffic is endpoint-wide and repeated under capabilities using that endpoint: **do not sum repeated capability rows**. WSS messages and explorer fallback GETs are not included in these HTTP JSON-RPC counters.
+
+Shared RPC clients no longer serialize complete network requests. Chain
+verification is single-flight, and rate waiting does not occupy an HTTP
+response slot. Shutdown waits for admitted requests before closing pooled
+sessions. Batch failover retains successful siblings and retries only failed
+items. `batch_results` exposes failures by input position for trace waves;
+ordinary `batch` still raises on non-revert failures.
 
 Goldsky primary references:
 
@@ -187,14 +194,26 @@ pages recover their hints on an independent worker, without waiting behind
 full position replays or discarding existing financial rows. Recovery checks
 the canonical epoch and per-key cursor before publication.
 
+Schema version 10 adds sparse LP-tape and owner/custody canonical-order indexes.
+It does not rebuild accounting or change canonical rows. Tape selects bounded
+event IDs before materializing event payloads; owner selection preserves
+`COALESCE(owner,custody)` rather than treating custody as a second owner.
+Historical owner activity uses the same block/transaction/log ordering.
+Allow temporary-sort disk space when installing these indexes on a large ledger.
+
+Overview and bucket-sorted pool pages share one per-pool interval aggregation,
+keyed by event revision, canonical epoch, and the exact bucket boundaries.
+An advancing empty block still changes the window boundary. Pool metadata
+changes invalidate pool candidates and responses without rescanning buckets.
+
 Legacy V4 identity seeding checks each canonical candidate transaction's queue
 entry by transaction hash. It no longer searches every serialized error
 payload for a pool ID, and it preserves existing candidate retry schedules.
 
 Receipt enrichment, repricing, and accounting continue during live catch-up.
 Receipt fetches run in eight-transaction waves, with up to 64 transactions in
-flight. V4 trace work has its own eight-transaction capacity, four-worker pool,
-and two-transaction waves, so slow traces cannot consume receipt-worker capacity.
+flight. V4 trace work has its own 32-transaction capacity, four-worker pool,
+and eight-transaction batches with independent per-transaction outcomes.
 Each lane rotates historical, requested, recent, and recent admissions across
 refills. Even a one- or two-slot refill must serve requested and current evidence;
 sorting a mixed candidate page oldest-first before truncating a trace lane
@@ -211,8 +230,27 @@ scheduling. Follow `pending_accounting` as well as enrichment and repricing queu
 a small block gap does not prove those queues are complete.
 
 Metadata RPC fetches remain bounded and commit one batch.
-V3 balances use a batched pinned-state request and atomic snapshot commit.
-Identity replay commits canonical events and queue completion together.
+V3 balances have an independent worker rather than waiting behind repricing or
+WAL checkpoints. Each wave selects at most 64 exact `(pool,block)` obligations,
+reserving a quarter for old history. Multicall3 groups caller-independent reads
+by their block pin; balance calls use `blockHash` and `requireCanonical`.
+Failed subcalls remain unknown, retain their revert data, and do not discard
+successful siblings. Missing or unsupported aggregate responses fall back to
+the original pinned calls.
+Bulk publication verifies each canonical hash and pending obligation under
+the writer, updates latest metadata once per pool, and advances one revision.
+No historical snapshots are coalesced or discarded; no fixed per-lane rate
+ceiling prevents balances from borrowing unused provider capacity.
+
+A pre-change 122-second production sample created 10.33 balance snapshots/s
+and completed only 5.30/s. The new worker completed 128 real-provider snapshots
+in 0.775 seconds against an isolated temporary store, with direct canonical
+controls matching. This is a smoke measurement, not loaded production capacity.
+
+Identity replay admits up to 64 queue records per pass. Already-known or
+rejected identities need no current-state RPC and do not wait for unrelated
+live pool discoveries. New identity work remains bounded to eight addresses.
+Canonical events and queue completion commit together.
 Price sample, reserve, mark, and state inserts use the same multi-row helper
 as event ingestion.
 
@@ -293,6 +331,12 @@ production snapshot of 10,540 wallets, this reduced owner-query time from
 1.34 s to 0.78 s; the reported single-wallet query fell from 1.65 s to 0.63 s.
 Existing financial fields had identical digests. Retain the short-circuit
 missing-gas query: a grouped replacement was slower for the full wallet table.
+Complete episode-gas coverage now permits owner costs to qualify their scope
+through the attributed episode instead of probing effects per transaction.
+Owners with incomplete or shared episode attribution retain the missing-cost
+short circuit. A read-only comparison across 48 real wallets returned identical
+values and NULLs: all-time gas lookup fell from 21.5 ms to 2.6 ms; the finite
+window changed from 67.7 ms to 62.8 ms. These samples are not full-table timings.
 
 For 32 production pools containing 52,393 active positions, selecting the
 covering index reduced inventory reads from 0.524 s to 0.093 s and LP-count

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -285,6 +285,9 @@ indivisible position can exceed the target. Epoch checks reject reorged work,
 and generation-guarded completion preserves same-epoch input that arrived during
 preparation. Repricing updates the source revision before projections without
 rewriting every event index; search terms refresh only when identity changes.
+Effect cleanup is scoped to its prepared position. An upsert can take an effect
+from another position only when the current canonical event mapping names that
+target; stale remap snapshots cannot remove or reclaim a newer position's gas.
 New, previously unprojected events can use the existing incremental append path.
 Persisted state must be compatible and the events must start in a later block.
 An existing-event correction, remap, uncertain trigger or mixed queue generation

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -195,6 +195,10 @@ Receipt enrichment, repricing, and accounting continue during live catch-up.
 Receipt fetches run in eight-transaction waves, with up to 64 transactions in
 flight. V4 trace work has its own eight-transaction capacity, four-worker pool,
 and two-transaction waves, so slow traces cannot consume receipt-worker capacity.
+Each lane rotates historical, requested, recent, and recent admissions across
+refills. Even a one- or two-slot refill must serve requested and current evidence;
+sorting a mixed candidate page oldest-first before truncating a trace lane
+starves both. In-flight hashes are excluded before candidate limits.
 The coordinator refills completed waves before waiting for the database writer.
 Receipt fields
 provide payer and effective gas price when available; only incomplete receipts
@@ -236,7 +240,12 @@ During a partial move, legacy financial rows remain explicitly unqualified;
 their overlapping liquidity and fees cannot inflate qualified wallet or pool totals.
 
 Wallet requests reserve bounded receipt and accounting priority without writing
-to SQLite on the request thread. Historical work retains its reserved quarter.
+to SQLite on the request thread. Historical work retains its reserved quarter
+within each receipt lane. Requested evidence follows the newest renewed wallet
+interest; bounded lookup pages stop once enough eligible work is found.
+Pool-identity replay likewise reserves a requested turn, so a wallet's deferred
+identity prerequisite can reach receipt enrichment without waiting for the
+entire chronological backlog.
 The current-claims worker admits the full selected owner page, keeps at most 512
 wallet interests for 180 seconds, and renews interest when cached API/SSE results
 are served. Each pass walks four active positions, four historical position keys,

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -301,9 +301,11 @@ not for every unrelated episode correction. Cost-incomplete episodes stop at the
 first missing or inexact transaction; complete episodes still count each transaction
 once.
 Receipt-only pending work can publish gas and net results without replaying event
-history when existing projected events are included solely because their transaction
-record changed. Explicit event corrections, remaps, mixed generations and uncertain
-work invalidate that proof and retain full replay.
+history when existing projected events are unchanged, including byte-equivalent
+explicit receipt rows. Their normalized source is compared again after preceding
+price projections; repricing, explicit corrections, remaps, mixed generations and
+uncertain work invalidate that proof and retain full replay. The transient proof
+is not serialized into canonical event evidence.
 
 Core-position identities include protocol and pool. An EVM core hash alone is
 not globally unique: different pools can share owner, ticks, and salt. Bounded

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -62,6 +62,11 @@ while a newer revision or an expired window refreshes asynchronously; one
 consumer cannot take that snapshot away from another. Blocking wallet reads
 still refresh changed revisions and expired windows. Canonical-branch changes
 invalidate both cached and in-flight publications.
+Cold blocking wallet reads materialize in their existing request thread instead
+of waiting behind unrelated background frames. Concurrent reads of the same
+view still share one future. Its producer assigns and caches the publication
+once, so a waiting request can deliver that exact completed snapshot even if
+a stream consumer has already read it.
 
 The running service commits raw events, cursors, balance jobs, and coalesced
 accounting jobs atomically. A separate accounting worker replays each affected

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -275,8 +275,11 @@ canonical events and queue completion commit together.
 Price sample, reserve, mark, and state inserts use the same multi-row helper
 as event ingestion.
 
-Accounting prepares bounded groups off the writer and publishes each group with
-one valuation, shared-transaction attribution, episode-cost refresh, and cache
+Accounting prepares bounded groups in two spawned, read-only processes, with at
+most four positions submitted ahead. These workers do not inherit the service's
+writer connection, locks or Python interpreter contention from web queries.
+Only the existing accounting coordinator publishes: each group gets one
+valuation, shared-transaction attribution, episode-cost refresh, and cache
 invalidation pass. Preparation and publication target 0.2 seconds each; one
 indivisible position can exceed the target. Epoch checks reject reorged work,
 and generation-guarded completion preserves same-epoch input that arrived during

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -192,16 +192,53 @@ entry by transaction hash. It no longer searches every serialized error
 payload for a pool ID, and it preserves existing candidate retry schedules.
 
 Receipt enrichment, repricing, and accounting continue during live catch-up.
-Receipt workers refill independently rather than waiting for the slowest member
-of a batch. Metadata, identity replay, and bounded source repairs run separately
-from receipt scheduling. Follow `pending_accounting` as well as enrichment and
-repricing queues; a small block gap does not prove those queues are complete.
+Receipt fetches run in four-transaction waves, with up to 32 transactions in
+flight. V4 trace work uses a separate four-worker pool and two-transaction
+waves, so an unavailable or slow trace does not block V3 receipts. The coordinator
+refills completed waves before waiting for the database writer. Receipt fields
+provide payer and effective gas price when available; only incomplete receipts
+need transaction-body requests. Headers and pinned-state calls are deduplicated
+within each wave. The shared provider item-rate and HTTP-concurrency limits
+still apply.
+
+Metadata, identity replay, and bounded source repairs run separately from receipt
+scheduling. Follow `pending_accounting` as well as enrichment and repricing queues;
+a small block gap does not prove those queues are complete.
 
 Metadata RPC fetches remain bounded and commit one batch.
 V3 balances use a batched pinned-state request and atomic snapshot commit.
 Identity replay commits canonical events and queue completion together.
 Price sample, reserve, mark, and state inserts use the same multi-row helper
 as event ingestion.
+
+Accounting prepares bounded groups off the writer and publishes each group with
+one valuation, shared-transaction attribution, episode-cost refresh, and cache
+invalidation pass. Preparation and publication target 0.2 seconds each; one
+indivisible position can exceed the target. Epoch checks reject reorged work,
+and generation-guarded completion preserves same-epoch input that arrived during
+preparation. Repricing updates the source revision before projections without
+rewriting every event index; search terms refresh only when identity changes.
+
+Wallet requests reserve bounded receipt and accounting priority without writing
+to SQLite on the request thread. Historical work retains its reserved quarter.
+The current-claims worker admits the full selected owner page, keeps at most 512
+wallet interests for 180 seconds, and renews interest when cached API/SSE results
+are served. Each pass walks four active positions, four historical position keys,
+and bounded transaction pages; it does not scan a wallet's entire history.
+
+Current claims use canonical end-of-block V3/NFPM or V4 StateView fee growth,
+owner and liquidity proof, and integer Q128 fee arithmetic. They borrow at most
+eight state RPC items/second from the existing shared allowance. Pool spot prices
+qualify only with positive pinned active liquidity. Publication checks the
+canonical hash/epoch, absence of pending accounting, and the exact position-state
+snapshot; source corrections cannot reuse a claim against different accounting
+state. Reorgs clear dependent values before pool-price rollback, rather than
+publishing an orphan price. Missing state, trace, gas attribution, acquisition
+basis, or price evidence still leaves dependent totals unknown.
+
+The claims table and owner lookup indexes install without rebuilding the ledger.
+`current_claims` in `/api/lp/status` reports admitted wallets, refreshed positions,
+and the last successful refresh or error.
 
 Existing V3 NFT positions whose initial add precedes a verified mint in the
 same transaction are repaired by the separate source-repair lane. A default pass

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -67,6 +67,10 @@ of waiting behind unrelated background frames. Concurrent reads of the same
 view still share one future. Its producer assigns and caches the publication
 once, so a waiting request can deliver that exact completed snapshot even if
 a stream consumer has already read it.
+The browser compares parent hashes only for consecutive block heights.
+Skipped head notifications are not fork evidence and must not clear wallet
+snapshots. Same-height replacements and confirmed parent mismatches still
+withdraw orphaned activity and invalidate wallets.
 
 The running service commits raw events, cursors, balance jobs, and coalesced
 accounting jobs atomically. A separate accounting worker replays each affected

--- a/docs/RPC_OPERATIONS.md
+++ b/docs/RPC_OPERATIONS.md
@@ -60,22 +60,24 @@ Production sampling found wallet aggregation repeatedly restarting whenever inge
 The running service commits raw events, cursors, balance jobs, and coalesced
 accounting jobs atomically. A separate accounting worker replays each affected
 position from an immutable WAL snapshot without holding the ingestion writer.
-Its short publication transaction writes only changed accounting rows. A newer
-same-branch generation retains the job after publishing the coherent snapshot;
-a changed canonical epoch rejects it. Existing financial rows remain readable
-while the queue drains, but cannot be represented as current accounting.
+It prepares up to 128 positions outside the writer, then shares publication
+transactions across their changed rows, releasing the writer after roughly
+200 ms of publication work. A newer same-branch generation retains the job
+after publishing the coherent snapshot; a changed canonical epoch rejects it.
+Existing financial rows remain readable while the queue drains, but cannot be
+represented as current accounting.
 
 Header, event, and search writes use parameterized multi-row inserts bounded by
 SQLite's variable limit. This avoids handing the Python interpreter to competing
 valuation workers between every inserted row. The outer durable transaction
 preserves the raw event/cursor/job boundary.
 
-Adaptive scan sizing targets 50 ms of writer residency, half the observed
-100 ms block interval. Growth is capped by measured store throughput as well as
-log density, and history starts with eight blocks before adapting. This is a
-feedback target, not a hard transaction deadline; indivisible block work can
-exceed it. Multi-second history commits previously starved both the live lane
-and financial workers.
+Adaptive scan sizing uses separate writer targets: two seconds for live
+catch-up and 200 ms for background history. Growth is capped by measured store
+throughput and log density; history starts with eight blocks before adapting.
+These are feedback targets, not hard transaction deadlines; indivisible block
+work can exceed them. Applying a 50 ms target to the live lane shrank it to
+one-block commits and left fixed commit costs unamortized.
 
 Wallet freshness reads walk the canonical event-order index after checking
 whether the requested scope is empty. A timestamp-range plan sorted the entire
@@ -146,6 +148,17 @@ canonical block hash and generation inside the same transaction as enrichment;
 an older in-flight receipt cannot erase newer identity or retry work.
 The accounting queue and its bootstrap checkpoint survive restart without
 discarding published positions, episodes, coverage, or cursors.
+
+Schema version 9 records pending accounting scope and actor hints atomically
+with source changes, including both sides of NFT transfers. Wallet requests
+read those hints and published episodes instead of expanding every queued
+position's raw history. Legacy jobs start unqualified; bounded off-writer
+pages recover their hints without discarding existing financial rows. Recovery
+checks the canonical epoch and per-key cursor before publication.
+
+Legacy V4 identity seeding checks each canonical candidate transaction's queue
+entry by transaction hash. It no longer searches every serialized error
+payload for a pool ID, and it preserves existing candidate retry schedules.
 
 Receipt enrichment, repricing, and accounting continue during live catch-up.
 Receipt workers refill independently rather than waiting for the slowest member

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -21,6 +21,7 @@ import time
 from typing import Any, Iterable, NamedTuple, Sequence
 
 from .lp_math import principal_raw
+from .lp_market_protocols import core_position_key
 
 
 _ZERO_ADDRESS = "0x" + "0" * 40
@@ -208,6 +209,12 @@ CREATE INDEX IF NOT EXISTS lp_accounting_episodes_closed_order
 CREATE INDEX IF NOT EXISTS lp_accounting_episodes_owner_position
     ON lp_accounting_episodes(owner,position_key);
 
+CREATE TABLE IF NOT EXISTS lp_accounting_replay_identities (
+    position_key TEXT PRIMARY KEY,
+    episode_ordinal INTEGER NOT NULL,
+    episodes TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS lp_accounting_effects (
     event_id INTEGER PRIMARY KEY,
     position_key TEXT NOT NULL,
@@ -371,6 +378,38 @@ class _ReplayWrites:
         self._prepared_rows: dict[str, list[tuple[Any, ...]]] | None = None
         self._affected_txs: set[str] = set()
         self._changed_episodes: set[str] = set()
+        self.episode_ids: dict[tuple[int, int, int], tuple[str, int]] = {}
+
+    def restore_episode_identity(
+        self, conn: sqlite3.Connection, state: dict[str, Any],
+    ) -> None:
+        """Keep persisted episode IDs when backfill adds earlier boundaries."""
+        ordinal = int(state.get("episode_ordinal") or 0)
+        prior = conn.execute(
+            "SELECT json_extract(state_json,'$.episode_ordinal') "
+            "FROM lp_accounting_positions WHERE position_key=?", (self.position_key,),
+        ).fetchone()
+        if prior is not None:
+            ordinal = max(ordinal, int(prior[0] or 0))
+        saved = conn.execute(
+            "SELECT episode_ordinal,episodes FROM lp_accounting_replay_identities "
+            "WHERE position_key=?", (self.position_key,),
+        ).fetchone()
+        if saved is not None:
+            ordinal = max(ordinal, int(saved[0]))
+            for row in json.loads(saved[1]):
+                self.episode_ids[(int(row[2]), int(row[3]), int(row[4]))] = (
+                    str(row[0]), int(row[1]),
+                )
+        for row in conn.execute(
+            "SELECT id,ordinal,opened_block,opened_tx_index,opened_log_index "
+            "FROM lp_accounting_episodes WHERE position_key=?", (self.position_key,),
+        ):
+            self.episode_ids[(int(row[2]), int(row[3]), int(row[4]))] = (
+                str(row[0]), int(row[1]),
+            )
+            ordinal = max(ordinal, int(row[1]))
+        state["episode_ordinal"] = ordinal
 
     def add(
         self, group: str, key: Any, sql: str, row: tuple[Any, ...],
@@ -407,10 +446,20 @@ class _ReplayWrites:
             deletes[group] = [
                 key if isinstance(key, tuple) else (key,) for key in stale
             ]
-            changed_keys = [
-                key for key, row in desired.items()
-                if existing.get(key) != row
-            ]
+            if group == "episodes":
+                # Valuation and costs (columns 44:52) are derived after
+                # publication. Cleared replay placeholders must not dirty
+                # otherwise unchanged episodes.
+                changed_keys = [
+                    key for key, row in desired.items()
+                    if (prior := existing.get(key)) is None
+                    or prior[:44] != row[:44] or prior[52:] != row[52:]
+                ]
+            else:
+                changed_keys = [
+                    key for key, row in desired.items()
+                    if existing.get(key) != row
+                ]
             changed[group] = [desired[key] for key in changed_keys]
             if group == "episodes":
                 self._changed_episodes.update(
@@ -423,48 +472,73 @@ class _ReplayWrites:
                 )
 
         desired_effects = self._rows["effects"]
-        desired_ids = sorted(int(key) for key in desired_effects)
-        existing_effects: dict[int, tuple[Any, ...]] = {}
-        for batch in _batches(desired_ids):
+        remaining_ids = set(desired_effects)
+        changed_effects: list[int] = []
+        stale_effects: list[int] = []
+        columns = ",".join(_EFFECT_COLUMNS)
+        # Stream the position range instead of retaining a second full history
+        # of Python rows and probing every effect again by primary key.
+        for row in conn.execute(
+            f"SELECT {columns} FROM lp_accounting_effects WHERE position_key=?",
+            (self.position_key,),
+        ):
+            event_id = int(row[0])
+            desired = desired_effects.get(event_id)
+            if desired is None:
+                stale_effects.append(event_id)
+                if row[5]:
+                    self._affected_txs.add(str(row[5]))
+                if row[2]:
+                    self._changed_episodes.add(str(row[2]))
+                continue
+            remaining_ids.discard(event_id)
+            if tuple(row) != desired:
+                changed_effects.append(event_id)
+                if row[5]:
+                    self._affected_txs.add(str(row[5]))
+                if row[2] and row[2] != desired[2]:
+                    self._changed_episodes.add(str(row[2]))
+                if desired[5]:
+                    self._affected_txs.add(str(desired[5]))
+        # A newly mapped event may still belong to another position. Preserve
+        # that prior transaction's attribution when moving the effect.
+        for batch in _batches(sorted(remaining_ids)):
             marks = ",".join("?" for _ in batch)
-            existing_effects.update({
-                int(row[0]): tuple(row)
-                for row in conn.execute(
-                    f"SELECT {','.join(_EFFECT_COLUMNS)} "
-                    f"FROM lp_accounting_effects WHERE event_id IN ({marks})",
-                    batch,
-                ).fetchall()
-            })
-        existing_ids = {
-            int(row[0]) for row in conn.execute(
-                "SELECT event_id FROM lp_accounting_effects "
-                "WHERE position_key=?",
-                (self.position_key,),
-            ).fetchall()
-        }
-        stale_effects = sorted(existing_ids - desired_effects.keys())
-        deletes["effects"] = [(event_id,) for event_id in stale_effects]
-        for batch in _batches(stale_effects):
-            marks = ",".join("?" for _ in batch)
-            self._affected_txs.update(str(row[0]) for row in conn.execute(
-                "SELECT DISTINCT tx_hash FROM lp_accounting_effects "
-                f"WHERE event_id IN ({marks}) AND tx_hash<>''",
-                batch,
-            ).fetchall())
-        changed_effects = [
-            event_id for event_id in desired_ids
-            if existing_effects.get(event_id) != desired_effects[event_id]
-        ]
+            existing = {
+                int(row[0]): tuple(row) for row in conn.execute(
+                    f"SELECT {columns} FROM lp_accounting_effects "
+                    f"WHERE event_id IN ({marks})", batch,
+                )
+            }
+            for event_id in batch:
+                desired = desired_effects[event_id]
+                prior = existing.get(event_id)
+                if prior == desired:
+                    continue
+                changed_effects.append(event_id)
+                if prior is not None and prior[5]:
+                    self._affected_txs.add(str(prior[5]))
+                if prior is not None and prior[2] and prior[2] != desired[2]:
+                    self._changed_episodes.add(str(prior[2]))
+                if desired[5]:
+                    self._affected_txs.add(str(desired[5]))
+        deletes["effects"] = [(event_id,) for event_id in sorted(stale_effects)]
         changed["effects"] = [
-            desired_effects[event_id] for event_id in changed_effects
+            desired_effects[event_id] for event_id in sorted(changed_effects)
         ]
-        for event_id in changed_effects:
-            row = desired_effects[event_id]
-            prior = existing_effects.get(event_id)
-            if prior is not None and prior[5]:
-                self._affected_txs.add(str(prior[5]))
-            if row[5]:
-                self._affected_txs.add(str(row[5]))
+        if desired_effects:
+            # Receipt or price enrichment can change gas without changing any
+            # LP effect. Retain those dependencies instead of waiting for a
+            # later liquidity action to refresh transaction attribution.
+            self._affected_txs.update(str(row[0]) for row in conn.execute(
+                "SELECT observed.tx_hash FROM (SELECT DISTINCT tx_hash "
+                "FROM lp_accounting_effects WHERE position_key=? AND tx_hash<>'') observed "
+                "LEFT JOIN transactions t ON t.tx_hash=observed.tx_hash "
+                "LEFT JOIN lp_accounting_tx_costs c ON c.tx_hash=observed.tx_hash "
+                "WHERE c.tx_hash IS NULL OR (t.tx_hash IS NOT NULL AND "
+                "(c.payer IS NOT t.payer OR c.gas_usd IS NOT t.gas_usd))",
+                (self.position_key,),
+            ))
         for batch in _batches(sorted(owner_changed_episodes)):
             marks = ",".join("?" for _ in batch)
             self._affected_txs.update(str(row[0]) for row in conn.execute(
@@ -474,6 +548,8 @@ class _ReplayWrites:
             ).fetchall())
         self._prepared_deletes = deletes
         self._prepared_rows = changed
+        self._rows.clear()
+        self.episode_ids.clear()
 
     def flush(
         self, conn: sqlite3.Connection,
@@ -490,6 +566,10 @@ class _ReplayWrites:
             statement = self._statements.get(group)
             if changed_rows and statement is not None:
                 conn.executemany(statement, changed_rows)
+        conn.execute(
+            "DELETE FROM lp_accounting_replay_identities WHERE position_key=?",
+            (self.position_key,),
+        )
         return set(self._affected_txs), set(self._changed_episodes)
 
 
@@ -749,6 +829,11 @@ class AccountBook:
                 )
             with self.store.transaction() as conn:
                 self.store._install_accounting_pending_identities(conn)
+                conn.execute(
+                    "CREATE INDEX IF NOT EXISTS lp_accounting_pending_identities_pool "
+                    "ON lp_accounting_pending_identities(pool_id,position_key) "
+                    "WHERE kind='scope'"
+                )
                 prior = {
                     str(row[0]): str(row[1])
                     for row in conn.execute(
@@ -838,7 +923,11 @@ class AccountBook:
         # of allocator arenas after the rebuild had finished.
         conn.execute(
             "INSERT INTO lp_accounting_event_keys(event_id,position_key,token_id) "
-            "SELECT id,LOWER(TRIM(position_key)),"
+            "SELECT id,CASE WHEN protocol IN ('v3','v4') AND pool_id IS NOT NULL "
+            "AND TRIM(pool_id)<>'' AND LENGTH(TRIM(position_key))=66 "
+            "AND LOWER(TRIM(position_key)) LIKE '0x%' "
+            "THEN protocol||':'||LOWER(TRIM(pool_id))||':'||LOWER(TRIM(position_key)) "
+            "ELSE LOWER(TRIM(position_key)) END,"
             "CASE WHEN token_id IS NULL THEN NULL ELSE CAST(token_id AS TEXT) END "
             "FROM events WHERE position_key IS NOT NULL AND TRIM(position_key)<>'' "
             "ON CONFLICT(event_id) DO UPDATE SET "
@@ -854,6 +943,9 @@ class AccountBook:
             key = str(
                 _json(event.get("data")).get("position_key") or ""
             ).strip().lower()
+        protocol = str(event.get("protocol") or "").lower()
+        if len(key) == 66 and key.startswith("0x") and protocol in ("v3", "v4") and event.get("pool_id"):
+            return core_position_key(protocol, str(event["pool_id"]), key)
         return key
 
     @staticmethod
@@ -1291,6 +1383,18 @@ class AccountBook:
         requested_capacity = min(
             max(0, limit - historical), max(1, limit // 4),
         )
+        # Raw hashes are not global identities. Source repair moves their
+        # mappings into pool scopes; retire the legacy projection only after
+        # those scoped projections finish, without replaying conflated history.
+        eligible = (
+            "(LENGTH(position_key)<>66 OR position_key NOT LIKE '0x%' OR (NOT EXISTS("
+            "SELECT 1 FROM lp_accounting_event_keys k "
+            "WHERE k.position_key=lp_accounting_pending.position_key) AND NOT EXISTS("
+            "SELECT 1 FROM lp_accounting_pending_identities h "
+            "JOIN lp_accounting_pending scoped ON scoped.position_key="
+            "h.protocol||':'||h.pool_id||':'||lp_accounting_pending.position_key "
+            "WHERE h.position_key=lp_accounting_pending.position_key AND h.kind='scope')))"
+        )
         now = time.monotonic()
         with self._priority_lock:
             while self._priority_positions:
@@ -1308,7 +1412,7 @@ class AccountBook:
                 str(row["position_key"]): row
                 for row in _dict_rows(conn.execute(
                     "SELECT * FROM lp_accounting_pending "
-                    f"WHERE position_key IN ({marks})",
+                    f"WHERE position_key IN ({marks}) AND {eligible}",
                     batch,
                 ))
             })
@@ -1329,6 +1433,7 @@ class AccountBook:
         if recent_capacity:
             recent = _dict_rows(conn.execute(
                 "SELECT * FROM lp_accounting_pending "
+                f"WHERE {eligible} "
                 "ORDER BY priority_block DESC,priority_tx_index DESC,"
                 "priority_log_index DESC,id DESC LIMIT ?",
                 (recent_capacity + len(seen),),
@@ -1341,7 +1446,7 @@ class AccountBook:
                     if len(selected) >= limit - historical:
                         break
         oldest = _dict_rows(conn.execute(
-            "SELECT * FROM lp_accounting_pending ORDER BY id LIMIT ?",
+            f"SELECT * FROM lp_accounting_pending WHERE {eligible} ORDER BY id LIMIT ?",
             (historical + len(seen),),
         ))
         for row in oldest:
@@ -1467,9 +1572,10 @@ class AccountBook:
                         affected_txs.update(changes.tx_hashes)
                         changed_episodes.update(changes.episode_ids)
                     if position_keys:
-                        self._refresh_position_values(
+                        values = self._refresh_position_values(
                             conn, sorted(position_keys),
                         )
+                        self._refresh_active_episode_values(conn, values)
                         self._rebuild_tx_costs(conn, affected_txs)
                         self._refresh_episode_costs(
                             conn, affected_txs,
@@ -1573,126 +1679,164 @@ class AccountBook:
                 candidates[position_key] = candidate
         if not candidates:
             return False
-
-        with self._projection_lock:
-            with self.store.transaction() as conn:
-                current_epoch = self._store_metadata_int(conn, "epoch")
-                positions: dict[str, dict[str, Any]] = {}
-                existing_claims: dict[str, dict[str, Any]] = {}
-                for batch in _batches(sorted(candidates)):
-                    marks = ",".join("?" for _ in batch)
-                    positions.update({
-                        str(row["position_key"]): row
-                        for row in _dict_rows(conn.execute(
-                            "SELECT p.position_key,p.pool_id,p.protocol,"
-                            "p.active_episode_id,p.last_block,p.last_tx_index,"
-                            "p.last_log_index,p.liquidity,p.liquidity_known,"
-                            "p.pending_principal0,p.pending_principal1,p.pending_known,p.state_json,"
-                            "q.position_key AS pending_position "
-                            "FROM lp_accounting_positions p "
-                            "LEFT JOIN lp_accounting_pending q "
-                            "ON q.position_key=p.position_key "
-                            f"WHERE p.position_key IN ({marks})",
-                            batch,
-                        ))
-                    })
-                    existing_claims.update({
-                        str(row["position_key"]): row
-                        for row in _dict_rows(conn.execute(
-                            "SELECT * FROM lp_accounting_claims "
-                            f"WHERE position_key IN ({marks})",
-                            batch,
-                        ))
-                    })
-                block_numbers = sorted({
-                    int(candidate[2]) for candidate in candidates.values()
+        with self.store.transaction() as conn:
+            current_epoch = self._store_metadata_int(conn, "epoch")
+            positions: dict[str, dict[str, Any]] = {}
+            existing_claims: dict[str, dict[str, Any]] = {}
+            for batch in _batches(sorted(candidates)):
+                marks = ",".join("?" for _ in batch)
+                positions.update({
+                    str(row["position_key"]): row
+                    for row in _dict_rows(conn.execute(
+                        "SELECT p.position_key,p.pool_id,p.protocol,"
+                        "p.active_episode_id,p.last_block,p.last_tx_index,"
+                        "p.last_log_index,p.liquidity,p.liquidity_known,"
+                        "p.pending_principal0,p.pending_principal1,p.pending_known,p.state_json,"
+                        "q.position_key AS pending_position "
+                        "FROM lp_accounting_positions p "
+                        "LEFT JOIN lp_accounting_pending q "
+                        "ON q.position_key=p.position_key "
+                        f"WHERE p.position_key IN ({marks})",
+                        batch,
+                    ))
                 })
-                blocks: dict[int, dict[str, Any]] = {}
-                for batch in _batches(block_numbers):
-                    marks = ",".join("?" for _ in batch)
-                    blocks.update({
-                        int(row["number"]): row
-                        for row in _dict_rows(conn.execute(
-                            "SELECT number,hash,timestamp FROM blocks "
-                            f"WHERE number IN ({marks})",
-                            batch,
-                        ))
-                    })
-
-                accepted: list[tuple[Any, ...]] = []
-                affected_pools: set[str] = set()
-                claim_columns = (
-                    "position_key", "epoch", "block_number", "block_hash",
-                    "timestamp", "position_last_block",
-                    "position_last_tx_index", "position_last_log_index",
-                    "liquidity", "sqrt_price_x96", "tick",
-                    "price0_usd", "price1_usd", "claim0", "claim1",
-                    "position_state_json",
-                )
-                for position_key, candidate in candidates.items():
-                    position = positions.get(position_key)
-                    block = blocks.get(int(candidate[2]))
+                existing_claims.update({
+                    str(row["position_key"]): row
+                    for row in _dict_rows(conn.execute(
+                        "SELECT * FROM lp_accounting_claims "
+                        f"WHERE position_key IN ({marks})",
+                        batch,
+                    ))
+                })
+            block_numbers = sorted({
+                int(candidate[2]) for candidate in candidates.values()
+            })
+            blocks: dict[int, dict[str, Any]] = {}
+            for batch in _batches(block_numbers):
+                marks = ",".join("?" for _ in batch)
+                blocks.update({
+                    int(row["number"]): row
+                    for row in _dict_rows(conn.execute(
+                        "SELECT number,hash,timestamp FROM blocks "
+                        f"WHERE number IN ({marks})",
+                        batch,
+                    ))
+                })
+    
+            accepted: list[tuple[Any, ...]] = []
+            affected_pools: set[str] = set()
+            claim_columns = (
+                "position_key", "epoch", "block_number", "block_hash",
+                "timestamp", "position_last_block",
+                "position_last_tx_index", "position_last_log_index",
+                "liquidity", "sqrt_price_x96", "tick",
+                "price0_usd", "price1_usd", "claim0", "claim1",
+                "position_state_json",
+            )
+            for position_key, candidate in candidates.items():
+                position = positions.get(position_key)
+                block = blocks.get(int(candidate[2]))
+                if (
+                    int(candidate[1]) != current_epoch
+                    or position is None
+                    or position.get("pending_position") is not None
+                    or position.get("active_episode_id") is None
+                    or str(position.get("protocol") or "") not in ("v3", "v4")
+                    or not position.get("liquidity_known")
+                    or _raw_int(position.get("liquidity")) != int(candidate[8])
+                    or _raw_int(position.get("last_block")) != int(candidate[5])
+                    or _raw_int(position.get("last_tx_index")) != int(candidate[6])
+                    or _raw_int(position.get("last_log_index")) != int(candidate[7])
+                    or _raw_int(position.get("pending_known")) != int(candidate[15])
+                    or (
+                        _raw_int(position.get("pending_principal0"))
+                        != _raw_int(candidate[16])
+                    )
+                    or (
+                        _raw_int(position.get("pending_principal1"))
+                        != _raw_int(candidate[17])
+                    )
+                    or position.get("state_json") != candidate[18]
+                    or int(candidate[2]) < int(candidate[5])
+                    or block is None
+                    or str(block.get("hash") or "").lower() != candidate[3]
+                    or _raw_int(block.get("timestamp")) != int(candidate[4])
+                ):
+                    continue
+                existing = existing_claims.get(position_key)
+                if existing is not None:
                     if (
-                        int(candidate[1]) != current_epoch
-                        or position is None
-                        or position.get("pending_position") is not None
-                        or position.get("active_episode_id") is None
-                        or str(position.get("protocol") or "") not in ("v3", "v4")
-                        or not position.get("liquidity_known")
-                        or _raw_int(position.get("liquidity")) != int(candidate[8])
-                        or _raw_int(position.get("last_block")) != int(candidate[5])
-                        or _raw_int(position.get("last_tx_index")) != int(candidate[6])
-                        or _raw_int(position.get("last_log_index")) != int(candidate[7])
-                        or _raw_int(position.get("pending_known")) != int(candidate[15])
-                        or (
-                            _raw_int(position.get("pending_principal0"))
-                            != _raw_int(candidate[16])
-                        )
-                        or (
-                            _raw_int(position.get("pending_principal1"))
-                            != _raw_int(candidate[17])
-                        )
-                        or position.get("state_json") != candidate[18]
-                        or int(candidate[2]) < int(candidate[5])
-                        or block is None
-                        or str(block.get("hash") or "").lower() != candidate[3]
-                        or _raw_int(block.get("timestamp")) != int(candidate[4])
+                        _raw_int(existing.get("epoch")) == current_epoch
+                        and _raw_int(existing.get("block_number")) is not None
+                        and _raw_int(existing.get("block_number")) > int(candidate[2])
                     ):
                         continue
-                    existing = existing_claims.get(position_key)
-                    if existing is not None:
-                        if (
-                            _raw_int(existing.get("epoch")) == current_epoch
-                            and _raw_int(existing.get("block_number")) is not None
-                            and _raw_int(existing.get("block_number")) > int(candidate[2])
-                        ):
-                            continue
-                        if tuple(
-                            existing.get(column) for column in claim_columns
-                        ) == candidate[:15] + candidate[18:]:
-                            continue
-                    accepted.append(candidate[:15] + candidate[18:])
-                    pool_id = position.get("pool_id")
-                    if pool_id:
-                        affected_pools.add(str(pool_id).lower())
-                if not accepted:
-                    return False
-                conn.executemany(
-                    "INSERT INTO lp_accounting_claims("
-                    + ",".join(claim_columns)
-                    + ") VALUES(" + ",".join("?" for _ in claim_columns) + ") "
-                    "ON CONFLICT(position_key) DO UPDATE SET "
-                    + ",".join(
-                        f"{column}=excluded.{column}"
-                        for column in claim_columns[1:]
-                    ),
-                    accepted,
-                )
-                accepted_keys = [str(row[0]) for row in accepted]
-                self._refresh_position_values(conn, accepted_keys)
-                self._refresh_active_episode_values(conn, accepted_keys)
-                self._invalidate_cache(conn, affected_pools)
-                return True
+                    if tuple(
+                        existing.get(column) for column in claim_columns
+                    ) == candidate[:15] + candidate[18:]:
+                        continue
+                accepted.append(candidate[:15] + candidate[18:])
+                pool_id = position.get("pool_id")
+                if pool_id:
+                    affected_pools.add(str(pool_id).lower())
+            if not accepted:
+                return False
+            conn.executemany(
+                "INSERT INTO lp_accounting_claims("
+                + ",".join(claim_columns)
+                + ") VALUES(" + ",".join("?" for _ in claim_columns) + ") "
+                "ON CONFLICT(position_key) DO UPDATE SET "
+                + ",".join(
+                    f"{column}=excluded.{column}"
+                    for column in claim_columns[1:]
+                ),
+                accepted,
+            )
+            accepted_keys = [str(row[0]) for row in accepted]
+            values = self._refresh_position_values(conn, accepted_keys)
+            self._refresh_active_episode_values(conn, values)
+            self._invalidate_cache(conn, affected_pools)
+            return True
+
+    @staticmethod
+    def _invalidate_legacy_core_values(
+            conn: sqlite3.Connection, keys: Iterable[str],
+    ) -> dict[str, str | None]:
+        legacy = set()
+        for key in keys:
+            raw = key.rsplit(":", 1)[-1] if key.startswith(("v3:", "v4:")) else key
+            if len(raw) == 66 and raw.startswith("0x"):
+                legacy.add(raw)
+        positions: dict[str, str | None] = {}
+        for batch in _batches(sorted(legacy)):
+            marks = ",".join("?" for _ in batch)
+            positions.update(conn.execute(
+                "SELECT position_key,pool_id FROM lp_accounting_positions "
+                f"WHERE position_key IN ({marks}) "
+                "AND valuation_basis IS NOT 'unqualified_pool_scope'",
+                batch,
+            ).fetchall())
+        for batch in _batches(list(positions)):
+            marks = ",".join("?" for _ in batch)
+            # Keep unresolved rows until retirement so pool and owner aggregates
+            # cannot qualify a partial scoped copy as the complete inventory.
+            conn.execute(
+                "UPDATE lp_accounting_positions SET liquidity=NULL,liquidity_known=0,"
+                "pending_known=0,owed_known=0,history_complete=0,principal0=NULL,"
+                "principal1=NULL,principal_usd=NULL,uncollected_fees_usd=NULL,"
+                "equity_usd=NULL,valuation_block=NULL,valuation_timestamp=NULL,"
+                "valuation_basis='unqualified_pool_scope' "
+                f"WHERE position_key IN ({marks})", batch,
+            )
+            conn.execute(
+                "UPDATE lp_accounting_episodes SET history_complete=0,identity_complete=0,"
+                "fees_complete=0,fees_usd=NULL,current_equity_usd=NULL,lp_value_usd=NULL,"
+                "hold_value_usd=NULL,lp_vs_hold_usd=NULL,gross_pnl_usd=NULL,gas_usd=NULL,"
+                "net_pnl_usd=NULL,return_pct=NULL,accounting_basis='unqualified_pool_scope',"
+                "qualifiers=json_insert(qualifiers,'$[#]','unqualified_pool_scope') "
+                f"WHERE position_key IN ({marks})", batch,
+            )
+        return positions
 
     def _apply(
         self, conn: sqlite3.Connection,
@@ -1765,6 +1909,8 @@ class AccountBook:
             mapped_rows,
         )
         keys = sorted(old_keys | new_keys)
+        legacy_positions = self._invalidate_legacy_core_values(conn, keys)
+        inventory_pools.update(pool for pool in legacy_positions.values() if pool)
         if self.deferred:
             priorities: dict[str, tuple[int, int, int]] = {}
             identity_hints: dict[
@@ -1803,6 +1949,11 @@ class AccountBook:
                     ).fetchall()
                 )
             self._queue_position_keys(conn, priorities, hinted=True)
+            if unqueued_legacy := legacy_positions.keys() - priorities.keys():
+                latest = max(_order(event)[:3] for event in events)
+                self._queue_position_keys(
+                    conn, {key: latest for key in unqueued_legacy},
+                )
             self._merge_pending_identity_hints(
                 conn,
                 (
@@ -1858,7 +2009,8 @@ class AccountBook:
                 f"WHERE position_key IN ({marks}) AND pool_id IS NOT NULL",
                 batch,
             ).fetchall())
-        self._refresh_position_values(conn, keys)
+        values = self._refresh_position_values(conn, keys)
+        self._refresh_active_episode_values(conn, values)
         self._rebuild_tx_costs(conn, affected_txs)
         self._refresh_episode_costs(
             conn, affected_txs, episode_ids=changed_episodes,
@@ -2033,6 +2185,19 @@ class AccountBook:
         )
         for batch in _batches(sorted(keys)):
             marks = ",".join("?" for _ in batch)
+            # Financial rows must disappear immediately after rollback, but
+            # surviving openings must retain their published identities even
+            # if the process restarts before deferred replay.
+            conn.execute(
+                "INSERT OR REPLACE INTO lp_accounting_replay_identities "
+                "SELECT p.position_key,"
+                "COALESCE(json_extract(p.state_json,'$.episode_ordinal'),0),"
+                "(SELECT json_group_array(json_array("
+                "e.id,e.ordinal,e.opened_block,e.opened_tx_index,e.opened_log_index)) "
+                "FROM lp_accounting_episodes e WHERE e.position_key=p.position_key) "
+                "FROM lp_accounting_positions p "
+                f"WHERE p.position_key IN ({marks})", batch,
+            )
             for table in (
                 "lp_accounting_effects", "lp_ownership_intervals",
                 "lp_accounting_episodes", "lp_accounting_positions",
@@ -2209,6 +2374,8 @@ class AccountBook:
                 state_events[int(event.get("block_number") or 0)].append(index)
         if state is None:
             state = self._new_state(key, prepared_events[0])
+        if writes is not None:
+            writes.restore_episode_identity(conn, state)
         # V3 manager transactions emit the pool event before the ERC-721 mint
         # and the final Collect before the ERC-721 burn.  Those verified
         # transfers prove the missing boundary state even though their logs
@@ -2411,7 +2578,7 @@ class AccountBook:
             if regular_transfer and has_transferred_inventory:
                 state["active_episode"] = self._new_episode(
                     state, event, history_complete=bool(state.get("history_complete")),
-                    transferred_basis=True,
+                    transferred_basis=True, writes=writes,
                 )
                 state["settled"] = False
         elif burn:
@@ -2600,7 +2767,7 @@ class AccountBook:
             active = self._new_episode(
                 state, event,
                 history_complete=zero_proven and bool(state.get("history_complete")),
-                transferred_basis=False,
+                transferred_basis=False, writes=writes,
             )
             if ambiguous_reentry:
                 active["ambiguous_reentry"] = True
@@ -2609,7 +2776,7 @@ class AccountBook:
             state["active_episode"] = active
         elif active is None and kind in ("remove", "collect", "checkpoint"):
             active = self._new_episode(
-                state, event, history_complete=False, transferred_basis=False,
+                state, event, history_complete=False, transferred_basis=False, writes=writes,
             )
             active["status"] = "partial_history"
             state["active_episode"] = active
@@ -2676,14 +2843,18 @@ class AccountBook:
 
     def _new_episode(self, state: Mapping[str, Any], event: Mapping[str, Any],
                      *, history_complete: bool,
-                     transferred_basis: bool) -> dict[str, Any]:
-        ordinal = int(state.get("episode_ordinal") or 0) + 1
-        # state is always a mutable dict at call sites.
-        state["episode_ordinal"] = ordinal  # type: ignore[index]
+                     transferred_basis: bool,
+                     writes: _ReplayWrites | None = None) -> dict[str, Any]:
         protocol = str(state.get("protocol") or event.get("protocol") or "unknown")
         order = _order(event)
+        prior = writes.episode_ids.get(order[:3]) if writes is not None else None
+        if prior is None:
+            ordinal = int(state.get("episode_ordinal") or 0) + 1
+            state["episode_ordinal"] = ordinal  # type: ignore[index]
+            episode_id = f"{state['position_key']}:{ordinal}"
+        else:
+            episode_id, ordinal = prior
         owner = _address(state.get("owner"))
-        episode_id = f"{state['position_key']}:{ordinal}"
         return {
             "id": episode_id, "position_key": state["position_key"],
             "ordinal": ordinal, "token_id": state.get("token_id"),
@@ -3320,7 +3491,7 @@ class AccountBook:
 
     def _refresh_position_values(
         self, conn: sqlite3.Connection, keys: Sequence[str],
-    ) -> None:
+    ) -> dict[str, dict[str, Any]]:
         values = self._current_values(conn, position_keys=keys)
         conn.executemany(
             "UPDATE lp_accounting_positions SET principal0=?,principal1=?,principal_usd=?,"
@@ -3336,6 +3507,7 @@ class AccountBook:
                 for key, value in values.items()
             ),
         )
+        return values
 
     def _refresh_episode_value(
         self, conn: sqlite3.Connection, episode_id: str,
@@ -3351,6 +3523,12 @@ class AccountBook:
                 (episode_id,),
             ))
         if episode is None:
+            return
+        if episode.get("accounting_basis") == "unqualified_pool_scope":
+            conn.execute(
+                "UPDATE lp_accounting_episodes SET gas_usd=NULL WHERE id=?",
+                (episode_id,),
+            )
             return
         current_equity: float | None = 0.0 if episode.get("status") == "complete" else None
         mark0, mark1 = episode.get("close_price0_usd"), episode.get("close_price1_usd")
@@ -3406,10 +3584,9 @@ class AccountBook:
 
     def _refresh_active_episode_values(
             self, conn: sqlite3.Connection,
-            position_keys: Iterable[str],
+            current_values: Mapping[str, Mapping[str, Any]],
     ) -> None:
-        selected = sorted({str(key) for key in position_keys})
-        for batch in _batches(selected):
+        for batch in _batches(list(current_values)):
             marks = ",".join("?" for _ in batch)
             episodes = _dict_rows(conn.execute(
                 "SELECT e.*,p.active_episode_id,m.decimals0,m.decimals1 "
@@ -3419,9 +3596,6 @@ class AccountBook:
                 f"WHERE p.position_key IN ({marks})",
                 batch,
             ))
-            current_values = self._current_values(
-                conn, position_keys=batch,
-            )
             for episode in episodes:
                 self._refresh_episode_value(
                     conn, str(episode["id"]),
@@ -5237,6 +5411,20 @@ class AccountBook:
                         )
                     )
                 )
+                unknown_scope = conn.execute(
+                    "SELECT 1 FROM lp_accounting_pending WHERE identities_ready=0 LIMIT 1"
+                ).fetchone() is not None
+                pending_pools = {
+                    str(row[0]) for row in conn.execute(
+                        "SELECT DISTINCT h.pool_id FROM lp_accounting_pending_identities h "
+                        "JOIN lp_accounting_pending p ON p.position_key=h.position_key "
+                        f"WHERE h.kind='scope' AND h.pool_id IN ({marks})", requested,
+                    )
+                } if backfill_done and not unknown_scope else set()
+                complete_pools = (
+                    set(requested) - pending_pools
+                    if backfill_done and not unknown_scope else set()
+                )
                 cache_keys: dict[str, tuple[Any, ...]] = {}
                 inventory_hits: dict[str, _PoolInventory] = {}
                 missing_results: list[str] = []
@@ -5256,7 +5444,7 @@ class AccountBook:
                             pool.get("decimals0"),
                             pool.get("decimals1"),
                             history_from,
-                            backfill_done,
+                            pool_id in complete_pools,
                         )
                         cache_keys[pool_id] = cache_key
                         cached = self._pool_cache.get(cache_key)
@@ -5285,7 +5473,7 @@ class AccountBook:
                         mark=state.get(pool_id, {}),
                         metadata=metadata.get(pool_id, {}),
                         history_from=history_from,
-                        backfill_done=backfill_done,
+                        backfill_done=pool_id in complete_pools,
                         retain_inventory=False,
                     )
                     results[pool_id] = result
@@ -5340,7 +5528,7 @@ class AccountBook:
                             mark=state.get(pool_id, {}),
                             metadata=metadata.get(pool_id, {}),
                             history_from=history_from,
-                            backfill_done=backfill_done,
+                            backfill_done=pool_id in complete_pools,
                             retain_inventory=True,
                         )
                         evaluated.add(pool_id)
@@ -5359,7 +5547,7 @@ class AccountBook:
                             mark=state.get(pool_id, {}),
                             metadata=metadata.get(pool_id, {}),
                             history_from=history_from,
-                            backfill_done=backfill_done,
+                            backfill_done=pool_id in complete_pools,
                             retain_inventory=True,
                         )
                         results[pool_id] = result

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -342,11 +342,15 @@ _EFFECT_WRITE_SQL = (
     + ",".join(
         f"{column}=excluded.{column}" for column in _EFFECT_MUTABLE_COLUMNS
     )
-    + " WHERE "
+    + " WHERE ("
     + " OR ".join(
         f"{column} IS NOT excluded.{column}"
         for column in _EFFECT_MUTABLE_COLUMNS
     )
+    + ") AND (lp_accounting_effects.position_key=excluded.position_key "
+    "OR EXISTS (SELECT 1 FROM lp_accounting_event_keys k "
+    "WHERE k.event_id=excluded.event_id "
+    "AND k.position_key=excluded.position_key))"
 )
 
 
@@ -372,7 +376,7 @@ class _ReplayWrites:
         "effects": (
             "lp_accounting_effects",
             lambda row: int(row[0]),
-            "DELETE FROM lp_accounting_effects WHERE event_id=?",
+            "DELETE FROM lp_accounting_effects WHERE event_id=? AND position_key=?",
         ),
         "positions": (
             "lp_accounting_positions",
@@ -626,7 +630,9 @@ class _ReplayWrites:
                             self._changed_episodes.add(str(prior[2]))
                     if desired[5]:
                         self._affected_txs.add(str(desired[5]))
-        deletes["effects"] = [(event_id,) for event_id in sorted(stale_effects)]
+        deletes["effects"] = [
+            (event_id, self.position_key) for event_id in sorted(stale_effects)
+        ]
         changed["effects"] = [
             desired_effects[event_id] for event_id in sorted(changed_effects)
         ]

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -238,6 +238,21 @@ CREATE TABLE IF NOT EXISTS lp_accounting_tx_costs (
 CREATE INDEX IF NOT EXISTS lp_accounting_tx_costs_owner
     ON lp_accounting_tx_costs(owner, block_number);
 
+CREATE TABLE IF NOT EXISTS lp_accounting_pending (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    position_key TEXT NOT NULL UNIQUE,
+    generation INTEGER NOT NULL,
+    requested_revision INTEGER NOT NULL,
+    requested_epoch INTEGER NOT NULL,
+    priority_block INTEGER NOT NULL,
+    priority_tx_index INTEGER NOT NULL,
+    priority_log_index INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS lp_accounting_pending_recent
+    ON lp_accounting_pending(
+        priority_block DESC,priority_tx_index DESC,priority_log_index DESC,id DESC
+    );
+
 CREATE TABLE IF NOT EXISTS lp_accounting_meta (
     key TEXT PRIMARY KEY,
     value TEXT NOT NULL
@@ -284,7 +299,7 @@ def _dict_rows(cursor: sqlite3.Cursor) -> list[dict[str, Any]]:
 
 
 class _ReplayWrites:
-    """Coalesce a full position replay into its final durable rows."""
+    """Coalesce and pre-diff a full position replay outside the writer."""
 
     _GROUPS = {
         "ownership": (
@@ -302,6 +317,11 @@ class _ReplayWrites:
             lambda row: int(row[0]),
             "DELETE FROM lp_accounting_effects WHERE event_id=?",
         ),
+        "positions": (
+            "lp_accounting_positions",
+            lambda row: str(row[0]),
+            "DELETE FROM lp_accounting_positions WHERE position_key=?",
+        ),
     }
 
     def __init__(self, position_key: str) -> None:
@@ -310,23 +330,34 @@ class _ReplayWrites:
         self._rows: dict[str, dict[Any, tuple[Any, ...]]] = {
             group: {} for group in self._GROUPS
         }
+        self._prepared_deletes: dict[str, list[tuple[Any, ...]]] | None = None
+        self._prepared_rows: dict[str, list[tuple[Any, ...]]] | None = None
+        self._affected_txs: set[str] = set()
+        self._changed_episodes: set[str] = set()
 
     def add(
         self, group: str, key: Any, sql: str, row: tuple[Any, ...],
     ) -> None:
+        if self._prepared_rows is not None:
+            raise RuntimeError("cannot append to a prepared replay")
         prior = self._statements.setdefault(group, sql)
         if prior != sql:
             raise RuntimeError(f"conflicting replay statement for {group}")
         self._rows[group][key] = row
 
-    def flush(
-        self, conn: sqlite3.Connection,
-    ) -> tuple[set[str], set[str]]:
-        affected_txs: set[str] = set()
-        changed_episodes: set[str] = set()
+    def prepare(self, conn: sqlite3.Connection) -> None:
+        """Load and diff existing rows on the caller's consistent snapshot."""
+        if self._prepared_rows is not None:
+            return
+        deletes: dict[str, list[tuple[Any, ...]]] = {
+            group: [] for group in self._GROUPS
+        }
+        changed: dict[str, list[tuple[Any, ...]]] = {
+            group: [] for group in self._GROUPS
+        }
         owner_changed_episodes: set[str] = set()
-        for group in ("ownership", "episodes"):
-            table, row_key, delete_sql = self._GROUPS[group]
+        for group in ("ownership", "episodes", "positions"):
+            table, row_key, _delete_sql = self._GROUPS[group]
             desired = self._rows[group]
             existing: dict[Any, tuple[Any, ...]] = {
                 row_key(row): tuple(row)
@@ -336,32 +367,37 @@ class _ReplayWrites:
                 ).fetchall()
             }
             stale = sorted(existing.keys() - desired.keys())
-            conn.executemany(
-                delete_sql,
-                (
-                    key if isinstance(key, tuple) else (key,)
-                    for key in stale
-                ),
-            )
+            deletes[group] = [
+                key if isinstance(key, tuple) else (key,) for key in stale
+            ]
             changed_keys = [
                 key for key, row in desired.items()
                 if existing.get(key) != row
             ]
+            changed[group] = [desired[key] for key in changed_keys]
             if group == "episodes":
-                changed_episodes.update(str(key) for key in changed_keys)
+                self._changed_episodes.update(
+                    str(key) for key in changed_keys
+                )
                 owner_changed_episodes.update(
                     str(key) for key in changed_keys
                     if key not in existing
                     or existing[key][6] != desired[key][6]
                 )
-            statement = self._statements.get(group)
-            if statement is not None:
-                conn.executemany(
-                    statement, (desired[key] for key in changed_keys),
-                )
 
         desired_effects = self._rows["effects"]
         desired_ids = sorted(int(key) for key in desired_effects)
+        existing_effects: dict[int, tuple[Any, ...]] = {}
+        for batch in _batches(desired_ids):
+            marks = ",".join("?" for _ in batch)
+            existing_effects.update({
+                int(row[0]): tuple(row)
+                for row in conn.execute(
+                    f"SELECT {','.join(_EFFECT_COLUMNS)} "
+                    f"FROM lp_accounting_effects WHERE event_id IN ({marks})",
+                    batch,
+                ).fetchall()
+            })
         existing_ids = {
             int(row[0]) for row in conn.execute(
                 "SELECT event_id FROM lp_accounting_effects "
@@ -370,52 +406,61 @@ class _ReplayWrites:
             ).fetchall()
         }
         stale_effects = sorted(existing_ids - desired_effects.keys())
+        deletes["effects"] = [(event_id,) for event_id in stale_effects]
         for batch in _batches(stale_effects):
             marks = ",".join("?" for _ in batch)
-            affected_txs.update(str(row[0]) for row in conn.execute(
-                f"SELECT DISTINCT tx_hash FROM lp_accounting_effects "
+            self._affected_txs.update(str(row[0]) for row in conn.execute(
+                "SELECT DISTINCT tx_hash FROM lp_accounting_effects "
                 f"WHERE event_id IN ({marks}) AND tx_hash<>''",
                 batch,
             ).fetchall())
-        conn.executemany(
-            self._GROUPS["effects"][2],
-            ((event_id,) for event_id in stale_effects),
-        )
-
-        existing_costs: dict[int, tuple[Any, ...]] = {}
-        for batch in _batches(desired_ids):
-            marks = ",".join("?" for _ in batch)
-            existing_costs.update({
-                int(row[0]): tuple(row[1:])
-                for row in conn.execute(
-                    "SELECT event_id,position_key,episode_id,owner,tx_hash,"
-                    f"block_number FROM lp_accounting_effects WHERE event_id IN ({marks})",
-                    batch,
-                ).fetchall()
-            })
-        for event_id in desired_ids:
+        changed_effects = [
+            event_id for event_id in desired_ids
+            if existing_effects.get(event_id) != desired_effects[event_id]
+        ]
+        changed["effects"] = [
+            desired_effects[event_id] for event_id in changed_effects
+        ]
+        for event_id in changed_effects:
             row = desired_effects[event_id]
-            cost = (row[1], row[2], row[3], row[5], row[6])
-            prior = existing_costs.get(event_id)
-            if prior != cost:
-                if prior is not None and prior[3]:
-                    affected_txs.add(str(prior[3]))
-                if row[5]:
-                    affected_txs.add(str(row[5]))
-        effect_sql = self._statements.get("effects")
-        if effect_sql is not None:
-            conn.executemany(
-                effect_sql, (desired_effects[event_id] for event_id in desired_ids),
-            )
-
+            prior = existing_effects.get(event_id)
+            if prior is not None and prior[5]:
+                self._affected_txs.add(str(prior[5]))
+            if row[5]:
+                self._affected_txs.add(str(row[5]))
         for batch in _batches(sorted(owner_changed_episodes)):
             marks = ",".join("?" for _ in batch)
-            affected_txs.update(str(row[0]) for row in conn.execute(
-                f"SELECT DISTINCT tx_hash FROM lp_accounting_effects "
+            self._affected_txs.update(str(row[0]) for row in conn.execute(
+                "SELECT DISTINCT tx_hash FROM lp_accounting_effects "
                 f"WHERE episode_id IN ({marks}) AND tx_hash<>''",
                 batch,
             ).fetchall())
-        return affected_txs, changed_episodes
+        self._prepared_deletes = deletes
+        self._prepared_rows = changed
+
+    def flush(
+        self, conn: sqlite3.Connection,
+    ) -> tuple[set[str], set[str]]:
+        if self._prepared_rows is None or self._prepared_deletes is None:
+            self.prepare(conn)
+        assert self._prepared_rows is not None
+        assert self._prepared_deletes is not None
+        for group in ("effects", "ownership", "episodes", "positions"):
+            delete_rows = self._prepared_deletes[group]
+            if delete_rows:
+                conn.executemany(self._GROUPS[group][2], delete_rows)
+            changed_rows = self._prepared_rows[group]
+            statement = self._statements.get(group)
+            if changed_rows and statement is not None:
+                conn.executemany(statement, changed_rows)
+        return set(self._affected_txs), set(self._changed_episodes)
+
+
+class _PreparedProjection(NamedTuple):
+    position_key: str
+    generation: int
+    epoch: int
+    writes: _ReplayWrites
 
 
 def _batches(values: Sequence[Any], size: int = 500) -> Iterable[Sequence[Any]]:
@@ -573,9 +618,11 @@ def _pair(pool: Mapping[str, Any]) -> str:
 class AccountBook:
     """Canonical, reorg-safe LP ownership and episode projection."""
 
-    def __init__(self, store: Any):
+    def __init__(self, store: Any, *, deferred: bool = False):
         self.store = store
+        self.deferred = bool(deferred)
         self._installed = False
+        self._projection_lock = threading.Lock()
         self._cache_lock = threading.RLock()
         self._pool_cache: OrderedDict[tuple[Any, ...], dict[str, Any]] = OrderedDict()
         self._pool_inventory_cache: OrderedDict[
@@ -607,8 +654,28 @@ class AccountBook:
             return int(json.loads(row[0]))
         except (TypeError, ValueError, json.JSONDecodeError):
             return 0
+
+    @staticmethod
+    def _accounting_meta(
+        conn: sqlite3.Connection, key: str, default: str = "",
+    ) -> str:
+        row = conn.execute(
+            "SELECT value FROM lp_accounting_meta WHERE key=?", (key,),
+        ).fetchone()
+        return default if row is None else str(row[0])
+
+    @staticmethod
+    def _set_accounting_meta(
+        conn: sqlite3.Connection, key: str, value: Any,
+    ) -> None:
+        conn.execute(
+            "INSERT INTO lp_accounting_meta(key,value) VALUES(?,?) "
+            "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
+            (key, str(value)),
+        )
+
     def install(self) -> "AccountBook":
-        """Create the projection, catch up existing events and register callbacks."""
+        """Create the projection and register its atomic ledger callbacks."""
         if self._installed:
             return self
         lock = getattr(self.store, "lock", threading.RLock())
@@ -624,34 +691,76 @@ class AccountBook:
                 }
                 current_revision = self._store_metadata_int(conn, "events_revision")
                 current_epoch = self._store_metadata_int(conn, "epoch")
+                pending = int(conn.execute(
+                    "SELECT COUNT(*) FROM lp_accounting_pending",
+                ).fetchone()[0])
                 clean = (
                     prior.get("schema_version") == str(_SCHEMA_VERSION)
                     and prior.get("applied_revision") == str(current_revision)
                     and prior.get("applied_epoch") == str(current_epoch)
                     and prior.get("dirty") == "0"
+                    and pending == 0
                 )
-                if not clean:
-                    self._map_existing_events(conn)
-                    keys = {str(row[0]) for row in conn.execute(
-                        "SELECT DISTINCT position_key FROM lp_accounting_event_keys"
-                    ).fetchall()}
-                    keys.update(str(row[0]) for row in conn.execute(
-                        "SELECT position_key FROM lp_accounting_positions").fetchall())
-                    for key in sorted(keys):
-                        self._rebuild_position(conn, key)
-                    self._rebuild_tx_costs(conn, None)
-                    self._refresh_episode_costs(conn, None)
-                for name, value in (
-                    ("schema_version", _SCHEMA_VERSION),
-                    ("applied_revision", current_revision),
-                    ("applied_epoch", current_epoch),
-                    ("dirty", 0),
-                ):
-                    conn.execute(
-                        "INSERT INTO lp_accounting_meta(key,value) VALUES(?,?) "
-                        "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
-                        (name, str(value)),
+                if self.deferred:
+                    phase = prior.get("bootstrap_phase")
+                    if clean:
+                        phase = "complete"
+                    elif phase not in {"events", "stale", "positions", "complete"}:
+                        if pending:
+                            phase = "complete"
+                        else:
+                            ledger = conn.execute(
+                                "SELECT EXISTS(SELECT 1 FROM events LIMIT 1) OR "
+                                "EXISTS(SELECT 1 FROM lp_accounting_positions LIMIT 1)"
+                            ).fetchone()[0]
+                            phase = "events" if ledger else "complete"
+                            self._set_accounting_meta(
+                                conn, "bootstrap_event_cursor", 0,
+                            )
+                            self._set_accounting_meta(
+                                conn, "bootstrap_position_cursor", "",
+                            )
+                    self._set_accounting_meta(conn, "bootstrap_phase", phase)
+                    self._set_accounting_meta(
+                        conn, "schema_version", _SCHEMA_VERSION,
                     )
+                    if clean or (phase == "complete" and pending == 0):
+                        self._set_accounting_meta(
+                            conn, "applied_revision", current_revision,
+                        )
+                        self._set_accounting_meta(
+                            conn, "applied_epoch", current_epoch,
+                        )
+                        self._set_accounting_meta(conn, "dirty", 0)
+                    else:
+                        self._set_accounting_meta(conn, "dirty", 1)
+                else:
+                    if not clean:
+                        self._map_existing_events(conn)
+                        keys = {str(row[0]) for row in conn.execute(
+                            "SELECT DISTINCT position_key "
+                            "FROM lp_accounting_event_keys"
+                        ).fetchall()}
+                        keys.update(str(row[0]) for row in conn.execute(
+                            "SELECT position_key FROM lp_accounting_positions"
+                        ).fetchall())
+                        for key in sorted(keys):
+                            self._rebuild_position(conn, key)
+                        self._rebuild_tx_costs(conn, None)
+                        self._refresh_episode_costs(conn, None)
+                    conn.execute("DELETE FROM lp_accounting_pending")
+                    for name, value in (
+                        ("schema_version", _SCHEMA_VERSION),
+                        ("applied_revision", current_revision),
+                        ("applied_epoch", current_epoch),
+                        ("bootstrap_phase", "complete"),
+                        ("dirty", 0),
+                    ):
+                        self._set_accounting_meta(conn, name, value)
+                    pending = 0
+                self.store._set_metadata(
+                    conn, "pending_accounting", pending,
+                )
             self.store.register_projection(
                 self._apply, self._rollback, persists_events=True,
             )
@@ -673,12 +782,334 @@ class AccountBook:
             "OR lp_accounting_event_keys.token_id IS NOT excluded.token_id"
         )
 
-    def _apply(self, conn: sqlite3.Connection,
-               events: Sequence[Mapping[str, Any]]) -> None:
+    @staticmethod
+    def _event_position_key(event: Mapping[str, Any]) -> str:
+        key = str(event.get("position_key") or "").strip().lower()
+        if not key:
+            key = str(
+                _json(event.get("data")).get("position_key") or ""
+            ).strip().lower()
+        return key
+
+    def _queue_position_keys(
+        self,
+        conn: sqlite3.Connection,
+        priorities: Mapping[str, tuple[int, int, int]],
+        *,
+        revision: int | None = None,
+        epoch: int | None = None,
+    ) -> None:
+        if not priorities:
+            self._finish_if_idle(conn)
+            return
+        requested_revision = (
+            self._store_metadata_int(conn, "events_revision")
+            if revision is None else int(revision)
+        )
+        requested_epoch = (
+            self._store_metadata_int(conn, "epoch")
+            if epoch is None else int(epoch)
+        )
+        rows = [
+            (
+                key, 0, requested_revision, requested_epoch,
+                int(order[0]), int(order[1]), int(order[2]),
+            )
+            for key, order in sorted(priorities.items())
+        ]
+        before = conn.total_changes
+        conn.executemany(
+            "INSERT OR IGNORE INTO lp_accounting_pending("
+            "position_key,generation,requested_revision,requested_epoch,"
+            "priority_block,priority_tx_index,priority_log_index"
+            ") VALUES(?,?,?,?,?,?,?)",
+            rows,
+        )
+        inserted = conn.total_changes - before
+        conn.executemany(
+            "UPDATE lp_accounting_pending SET generation=generation+1,"
+            "requested_revision=MAX(requested_revision,?),requested_epoch=?,"
+            "priority_block=MAX(priority_block,?),"
+            "priority_tx_index=MAX(priority_tx_index,?),"
+            "priority_log_index=MAX(priority_log_index,?) WHERE position_key=?",
+            (
+                (
+                    requested_revision, requested_epoch,
+                    int(order[0]), int(order[1]), int(order[2]), key,
+                )
+                for key, order in sorted(priorities.items())
+            ),
+        )
+        if inserted:
+            self.store._bump(conn, "pending_accounting", inserted)
+        self._set_accounting_meta(conn, "dirty", 1)
+
+    def _finish_if_idle(
+        self, conn: sqlite3.Connection, *, epoch: int | None = None,
+    ) -> None:
+        if self._accounting_meta(conn, "bootstrap_phase") != "complete":
+            return
+        if conn.execute(
+            "SELECT 1 FROM lp_accounting_pending LIMIT 1",
+        ).fetchone() is not None:
+            return
+        self._set_accounting_meta(
+            conn, "applied_revision",
+            self._store_metadata_int(conn, "events_revision"),
+        )
+        self._set_accounting_meta(
+            conn, "applied_epoch",
+            self._store_metadata_int(conn, "epoch") if epoch is None else epoch,
+        )
+        self._set_accounting_meta(conn, "dirty", 0)
+
+    def _resume_bootstrap(self, limit: int) -> bool:
+        batch_size = max(64, min(2048, int(limit) * 32))
+        with self.store.transaction() as conn:
+            phase = self._accounting_meta(conn, "bootstrap_phase", "complete")
+            if phase == "complete":
+                return False
+            if phase == "events":
+                cursor = int(self._accounting_meta(
+                    conn, "bootstrap_event_cursor", "0",
+                ))
+                rows = _dict_rows(conn.execute(
+                    "SELECT id,position_key,token_id,data,block_number,"
+                    "tx_index,log_index,revision FROM events "
+                    "WHERE id>? ORDER BY id LIMIT ?",
+                    (cursor, batch_size),
+                ))
+                ids = [int(row["id"]) for row in rows]
+                old_mapping: dict[int, str] = {}
+                for batch in _batches(ids):
+                    marks = ",".join("?" for _ in batch)
+                    old_mapping.update({
+                        int(item[0]): str(item[1])
+                        for item in conn.execute(
+                            "SELECT event_id,position_key "
+                            "FROM lp_accounting_event_keys "
+                            f"WHERE event_id IN ({marks})",
+                            batch,
+                        ).fetchall()
+                    })
+                mapped_rows = []
+                mapped_ids: set[int] = set()
+                priorities: dict[str, tuple[int, int, int]] = {}
+                for row in rows:
+                    event_id = int(row["id"])
+                    order = (
+                        int(row["block_number"]), int(row["tx_index"]),
+                        int(row["log_index"]),
+                    )
+                    old_key = old_mapping.get(event_id)
+                    if old_key:
+                        priorities[old_key] = max(
+                            priorities.get(old_key, order), order,
+                        )
+                    key = self._event_position_key(row)
+                    if not key:
+                        continue
+                    mapped_ids.add(event_id)
+                    mapped_rows.append((
+                        event_id, key,
+                        None if row.get("token_id") is None
+                        else str(row["token_id"]),
+                    ))
+                    priorities[key] = max(priorities.get(key, order), order)
+                stale_ids = sorted(set(old_mapping) - mapped_ids)
+                for batch in _batches(stale_ids):
+                    marks = ",".join("?" for _ in batch)
+                    conn.execute(
+                        "DELETE FROM lp_accounting_event_keys "
+                        f"WHERE event_id IN ({marks})",
+                        batch,
+                    )
+                conn.executemany(
+                    "INSERT INTO lp_accounting_event_keys("
+                    "event_id,position_key,token_id) VALUES(?,?,?) "
+                    "ON CONFLICT(event_id) DO UPDATE SET "
+                    "position_key=excluded.position_key,"
+                    "token_id=excluded.token_id",
+                    mapped_rows,
+                )
+                self._queue_position_keys(conn, priorities)
+                if rows:
+                    self._set_accounting_meta(
+                        conn, "bootstrap_event_cursor", int(rows[-1]["id"]),
+                    )
+                else:
+                    self._set_accounting_meta(conn, "bootstrap_phase", "stale")
+                return True
+            if phase == "stale":
+                rows = conn.execute(
+                    "SELECT k.event_id,k.position_key "
+                    "FROM lp_accounting_event_keys k "
+                    "LEFT JOIN events e ON e.id=k.event_id "
+                    "WHERE e.id IS NULL ORDER BY k.event_id LIMIT ?",
+                    (batch_size,),
+                ).fetchall()
+                if rows:
+                    priorities = {
+                        str(row["position_key"]): (0, 0, int(row["event_id"]))
+                        for row in rows
+                    }
+                    self._queue_position_keys(conn, priorities)
+                    conn.executemany(
+                        "DELETE FROM lp_accounting_event_keys WHERE event_id=?",
+                        ((int(row["event_id"]),) for row in rows),
+                    )
+                else:
+                    self._set_accounting_meta(
+                        conn, "bootstrap_phase", "positions",
+                    )
+                return True
+            cursor = self._accounting_meta(
+                conn, "bootstrap_position_cursor", "",
+            )
+            rows = conn.execute(
+                "SELECT position_key,last_block,last_tx_index,last_log_index "
+                "FROM lp_accounting_positions WHERE position_key>? "
+                "ORDER BY position_key LIMIT ?",
+                (cursor, batch_size),
+            ).fetchall()
+            if rows:
+                self._queue_position_keys(conn, {
+                    str(row["position_key"]): (
+                        int(row["last_block"]), int(row["last_tx_index"]),
+                        int(row["last_log_index"]),
+                    )
+                    for row in rows
+                })
+                self._set_accounting_meta(
+                    conn, "bootstrap_position_cursor",
+                    str(rows[-1]["position_key"]),
+                )
+            else:
+                self._set_accounting_meta(conn, "bootstrap_phase", "complete")
+                self._finish_if_idle(conn)
+            return True
+
+    def _pending_rows(self, limit: int) -> list[dict[str, Any]]:
+        historical = max(1, limit // 4)
+        recent = max(0, limit - historical)
+        conn = self.store.read()
+        selected: list[dict[str, Any]] = []
+        if recent:
+            selected.extend(_dict_rows(conn.execute(
+                "SELECT * FROM lp_accounting_pending "
+                "ORDER BY priority_block DESC,priority_tx_index DESC,"
+                "priority_log_index DESC,id DESC LIMIT ?",
+                (recent,),
+            )))
+        seen = {str(row["position_key"]) for row in selected}
+        oldest = _dict_rows(conn.execute(
+            "SELECT * FROM lp_accounting_pending ORDER BY id LIMIT ?",
+            (historical + len(seen),),
+        ))
+        selected.extend(
+            row for row in oldest
+            if str(row["position_key"]) not in seen
+        )
+        return selected[:limit]
+
+    def _prepare_pending(self, position_key: str) -> _PreparedProjection | None:
+        with self._reader() as conn:
+            pending = conn.execute(
+                "SELECT generation FROM lp_accounting_pending "
+                "WHERE position_key=?",
+                (position_key,),
+            ).fetchone()
+            if pending is None:
+                return None
+            epoch = self._store_metadata_int(conn, "epoch")
+            events = self._event_rows(conn, position_key)
+            writes = _ReplayWrites(position_key)
+            if events:
+                self._derive(
+                    conn, position_key, events, None,
+                    refresh_values=False, writes=writes, flush_writes=False,
+                )
+            writes.prepare(conn)
+            return _PreparedProjection(
+                position_key, int(pending["generation"]), epoch, writes,
+            )
+
+
+    def _publish_pending(self, prepared: _PreparedProjection) -> bool:
+        with self.store.transaction() as conn:
+            if self._store_metadata_int(conn, "epoch") != prepared.epoch:
+                return False
+            pending = conn.execute(
+                "SELECT generation FROM lp_accounting_pending "
+                "WHERE position_key=?",
+                (prepared.position_key,),
+            ).fetchone()
+            if pending is None:
+                return False
+            # Projection publication is serialized. Same-epoch event changes
+            # therefore cannot race a newer accounting publish: commit this
+            # coherent older snapshot, and let the generation-guarded delete
+            # retain the key for the newer snapshot. Reorgs are rejected above.
+            affected_pools = {
+                str(row[0]).lower()
+                for row in conn.execute(
+                    "SELECT pool_id FROM lp_accounting_positions "
+                    "WHERE position_key=? AND pool_id IS NOT NULL",
+                    (prepared.position_key,),
+                ).fetchall()
+            }
+            affected_txs, changed_episodes = prepared.writes.flush(conn)
+            affected_pools.update(
+                str(row[0]).lower()
+                for row in conn.execute(
+                    "SELECT pool_id FROM lp_accounting_positions "
+                    "WHERE position_key=? AND pool_id IS NOT NULL",
+                    (prepared.position_key,),
+                ).fetchall()
+            )
+            self._refresh_position_values(conn, [prepared.position_key])
+            self._rebuild_tx_costs(conn, affected_txs)
+            self._refresh_episode_costs(
+                conn, affected_txs, episode_ids=changed_episodes,
+            )
+            removed = conn.execute(
+                "DELETE FROM lp_accounting_pending "
+                "WHERE position_key=? AND generation=?",
+                (prepared.position_key, prepared.generation),
+            ).rowcount
+            if removed:
+                self.store._bump(conn, "pending_accounting", -removed)
+            self._finish_if_idle(conn)
+            self._invalidate_cache(conn, affected_pools)
+            return True
+
+    def project_pending(self, limit: int = 32) -> bool:
+        """Prepare bounded queued histories off-writer, then publish atomically."""
+        if not self.deferred:
+            return False
+        bounded = max(1, min(int(limit), 128))
+        with self._projection_lock:
+            worked = self._resume_bootstrap(bounded)
+            pending = self._pending_rows(bounded)
+            if pending:
+                worked = True
+            for row in pending:
+                prepared = self._prepare_pending(str(row["position_key"]))
+                if prepared is not None:
+                    self._publish_pending(prepared)
+            return worked
+
+    def _apply(
+        self, conn: sqlite3.Connection,
+        events: Sequence[Mapping[str, Any]],
+    ) -> None:
         if not events:
             return
         inventory_pools: set[str] = set()
-        ids = [int(event["id"]) for event in events if event.get("id") is not None]
+        ids = [
+            int(event["id"]) for event in events
+            if event.get("id") is not None
+        ]
         old_mapping: dict[int, str] = {}
         affected_txs: set[str] = set()
         for batch in _batches(ids):
@@ -686,71 +1117,109 @@ class AccountBook:
             old_mapping.update({
                 int(row[0]): str(row[1])
                 for row in conn.execute(
-                    f"SELECT event_id,position_key FROM lp_accounting_event_keys "
-                    f"WHERE event_id IN ({marks})", batch,
+                    "SELECT event_id,position_key "
+                    "FROM lp_accounting_event_keys "
+                    f"WHERE event_id IN ({marks})",
+                    batch,
                 ).fetchall()
             })
-            affected_txs.update(str(row[0]) for row in conn.execute(
-                f"SELECT DISTINCT tx_hash FROM lp_accounting_effects "
-                f"WHERE event_id IN ({marks})", batch,
-            ).fetchall())
+            if not self.deferred:
+                affected_txs.update(str(row[0]) for row in conn.execute(
+                    "SELECT DISTINCT tx_hash FROM lp_accounting_effects "
+                    f"WHERE event_id IN ({marks})",
+                    batch,
+                ).fetchall())
         old_keys = set(old_mapping.values())
         new_keys: set[str] = set()
         ids_by_key: dict[str, list[int]] = defaultdict(list)
-        mapped_rows = []
-        mapped_ids = set()
+        mapped_rows: list[tuple[int, str, str | None]] = []
+        mapped_ids: set[int] = set()
         for event in events:
-            event_id = event.get("id")
-            if event_id is None:
+            raw_event_id = event.get("id")
+            if raw_event_id is None:
                 continue
-            key = str(event.get("position_key") or "").strip().lower()
+            event_id = int(raw_event_id)
+            key = self._event_position_key(event)
             if not key:
-                key = str(
-                    _json(event.get("data")).get("position_key") or ""
-                ).strip().lower()
-            if not key:
-                # An unlinked NFT transfer cannot safely be attached by token id alone:
-                # token ids collide across managers.  The protocol adapter supplies a
-                # manager-qualified position_key when the manager is verified.
+                # Token ids collide across managers; only a manager-qualified
+                # protocol position key can safely connect a transfer.
                 continue
             token_id = event.get("token_id")
-            event_id = int(event_id)
             mapped_rows.append((
-                event_id, key, None if token_id is None else str(token_id),
+                event_id, key,
+                None if token_id is None else str(token_id),
             ))
             mapped_ids.add(event_id)
             new_keys.add(key)
             ids_by_key[key].append(event_id)
-            if event.get("tx_hash"):
+            if not self.deferred and event.get("tx_hash"):
                 affected_txs.add(str(event["tx_hash"]).lower())
         stale_ids = sorted(set(old_mapping) - mapped_ids)
         for batch in _batches(stale_ids):
             marks = ",".join("?" for _ in batch)
             conn.execute(
-                f"DELETE FROM lp_accounting_event_keys WHERE event_id IN ({marks})",
+                "DELETE FROM lp_accounting_event_keys "
+                f"WHERE event_id IN ({marks})",
                 batch,
             )
         conn.executemany(
-            "INSERT INTO lp_accounting_event_keys(event_id,position_key,token_id) "
-            "VALUES(?,?,?) ON CONFLICT(event_id) DO UPDATE SET "
+            "INSERT INTO lp_accounting_event_keys("
+            "event_id,position_key,token_id) VALUES(?,?,?) "
+            "ON CONFLICT(event_id) DO UPDATE SET "
             "position_key=excluded.position_key,token_id=excluded.token_id",
             mapped_rows,
         )
         keys = sorted(old_keys | new_keys)
+        if self.deferred:
+            priorities: dict[str, tuple[int, int, int]] = {}
+            for event in events:
+                if event.get("id") is None:
+                    continue
+                event_id = int(event["id"])
+                order = _order(event)[:3]
+                for key in (
+                    old_mapping.get(event_id),
+                    self._event_position_key(event),
+                ):
+                    if key:
+                        priorities[key] = max(
+                            priorities.get(key, order), order,
+                        )
+                if event.get("pool_id"):
+                    inventory_pools.add(str(event["pool_id"]).lower())
+            for batch in _batches(keys):
+                marks = ",".join("?" for _ in batch)
+                inventory_pools.update(
+                    str(row[0]).lower()
+                    for row in conn.execute(
+                        "SELECT pool_id FROM lp_accounting_positions "
+                        f"WHERE position_key IN ({marks}) "
+                        "AND pool_id IS NOT NULL",
+                        batch,
+                    ).fetchall()
+                )
+            self._queue_position_keys(conn, priorities)
+            self._invalidate_cache(
+                conn, inventory_pools, owners=bool(priorities),
+            )
+            return
+
         prior_positions = {}
         effect_keys: set[str] = set()
         for batch in _batches(keys):
             marks = ",".join("?" for _ in batch)
             for row in _dict_rows(conn.execute(
-                f"SELECT * FROM lp_accounting_positions "
-                f"WHERE position_key IN ({marks})", batch,
+                "SELECT * FROM lp_accounting_positions "
+                f"WHERE position_key IN ({marks})",
+                batch,
             )):
                 prior_positions[str(row["position_key"])] = row
                 if row.get("pool_id") is not None:
                     inventory_pools.add(str(row["pool_id"]).lower())
             effect_keys.update(str(row[0]) for row in conn.execute(
-                f"SELECT DISTINCT position_key FROM lp_accounting_effects "
-                f"WHERE position_key IN ({marks})", batch,
+                "SELECT DISTINCT position_key FROM lp_accounting_effects "
+                f"WHERE position_key IN ({marks})",
+                batch,
             ).fetchall())
         changed_episodes: set[str] = set()
         for key in keys:
@@ -774,8 +1243,9 @@ class AccountBook:
         for batch in _batches(keys):
             marks = ",".join("?" for _ in batch)
             inventory_pools.update(str(row[0]).lower() for row in conn.execute(
-                f"SELECT pool_id FROM lp_accounting_positions "
-                f"WHERE position_key IN ({marks}) AND pool_id IS NOT NULL", batch,
+                "SELECT pool_id FROM lp_accounting_positions "
+                f"WHERE position_key IN ({marks}) AND pool_id IS NOT NULL",
+                batch,
             ).fetchall())
         self._refresh_position_values(conn, keys)
         self._rebuild_tx_costs(conn, affected_txs)
@@ -787,17 +1257,16 @@ class AccountBook:
             ("applied_epoch", self._store_metadata_int(conn, "epoch")),
             ("dirty", 0),
         ):
-            conn.execute(
-                "INSERT INTO lp_accounting_meta(key,value) VALUES(?,?) "
-                "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
-                (name, str(value)),
-            )
+            self._set_accounting_meta(conn, name, value)
         self._invalidate_cache(
             conn, inventory_pools, owners=bool(old_keys or new_keys),
         )
 
     def _rollback(self, conn: sqlite3.Connection, ancestor_number: int) -> None:
         ancestor = int(ancestor_number)
+        if self.deferred:
+            self._rollback_deferred(conn, ancestor)
+            return
         affected_pools = {str(row[0]).lower() for row in conn.execute(
             "SELECT DISTINCT pool_id FROM lp_accounting_positions "
             "WHERE last_block>? AND pool_id IS NOT NULL", (ancestor,),
@@ -843,6 +1312,87 @@ class AccountBook:
         conn.execute(
             "INSERT INTO lp_accounting_meta(key,value) VALUES('dirty','1') "
             "ON CONFLICT(key) DO UPDATE SET value=excluded.value"
+        )
+
+    def _rollback_deferred(
+        self, conn: sqlite3.Connection, ancestor: int,
+    ) -> None:
+        keys = {
+            str(row[0]) for row in conn.execute(
+                "SELECT DISTINCT k.position_key "
+                "FROM lp_accounting_event_keys k "
+                "JOIN events e ON e.id=k.event_id "
+                "WHERE e.block_number>?",
+                (ancestor,),
+            ).fetchall()
+        }
+        keys.update(str(row[0]) for row in conn.execute(
+            "SELECT DISTINCT position_key FROM lp_accounting_effects "
+            "WHERE block_number>?",
+            (ancestor,),
+        ).fetchall())
+        keys.update(str(row[0]) for row in conn.execute(
+            "SELECT position_key FROM lp_accounting_positions "
+            "WHERE last_block>?",
+            (ancestor,),
+        ).fetchall())
+        affected_pools: set[str] = set()
+        affected_txs: set[str] = set()
+        for batch in _batches(sorted(keys)):
+            marks = ",".join("?" for _ in batch)
+            affected_pools.update(
+                str(row[0]).lower()
+                for row in conn.execute(
+                    "SELECT pool_id FROM lp_accounting_positions "
+                    f"WHERE position_key IN ({marks}) "
+                    "AND pool_id IS NOT NULL",
+                    batch,
+                ).fetchall()
+            )
+            affected_txs.update(
+                str(row[0])
+                for row in conn.execute(
+                    "SELECT DISTINCT tx_hash FROM lp_accounting_effects "
+                    f"WHERE position_key IN ({marks}) AND tx_hash<>''",
+                    batch,
+                ).fetchall()
+            )
+        next_epoch = self._store_metadata_int(conn, "epoch") + 1
+        self._queue_position_keys(
+            conn,
+            {key: (ancestor + 1, 0, 0) for key in keys},
+            epoch=next_epoch,
+        )
+        conn.execute(
+            "DELETE FROM lp_accounting_event_keys WHERE event_id IN "
+            "(SELECT id FROM events WHERE block_number>?)",
+            (ancestor,),
+        )
+        conn.execute(
+            "DELETE FROM lp_accounting_event_keys "
+            "WHERE event_id NOT IN (SELECT id FROM events)"
+        )
+        for batch in _batches(sorted(keys)):
+            marks = ",".join("?" for _ in batch)
+            for table in (
+                "lp_accounting_effects", "lp_ownership_intervals",
+                "lp_accounting_episodes", "lp_accounting_positions",
+            ):
+                conn.execute(
+                    f"DELETE FROM {table} WHERE position_key IN ({marks})",
+                    batch,
+                )
+        for batch in _batches(sorted(affected_txs)):
+            marks = ",".join("?" for _ in batch)
+            conn.execute(
+                "DELETE FROM lp_accounting_tx_costs "
+                f"WHERE tx_hash IN ({marks})",
+                batch,
+            )
+        if not keys:
+            self._finish_if_idle(conn, epoch=next_epoch)
+        self._invalidate_cache(
+            conn, affected_pools, owners=bool(keys),
         )
 
     def _invalidate_cache(
@@ -976,11 +1526,13 @@ class AccountBook:
             "last_timestamp": int(event.get("timestamp") or 0),
         }
 
-    def _derive(self, conn: sqlite3.Connection, key: str,
-                events: Sequence[Mapping[str, Any]], state: dict[str, Any] | None,
-                *, refresh_values: bool = True,
-                writes: _ReplayWrites | None = None,
-                ) -> tuple[set[str], set[str]]:
+    def _derive(
+        self, conn: sqlite3.Connection, key: str,
+        events: Sequence[Mapping[str, Any]], state: dict[str, Any] | None,
+        *, refresh_values: bool = True,
+        writes: _ReplayWrites | None = None,
+        flush_writes: bool = True,
+    ) -> tuple[set[str], set[str]]:
         if state is None:
             state = self._new_state(key, events[0])
         pool_cache: dict[str, dict[str, Any]] = {}
@@ -1033,11 +1585,12 @@ class AccountBook:
         active = state.get("active_episode")
         if isinstance(active, Mapping):
             self._save_episode(conn, dict(active), writes)
+        self._save_position(conn, state, writes)
         replay_changes = (
-            writes.flush(conn) if writes is not None else (set(), set())
+            writes.flush(conn)
+            if writes is not None and flush_writes else (set(), set())
         )
-        self._save_position(conn, state)
-        if refresh_values:
+        if refresh_values and (writes is None or flush_writes):
             self._refresh_position_value(conn, key)
             active = state.get("active_episode")
             if isinstance(active, Mapping):
@@ -1900,7 +2453,10 @@ class AccountBook:
         else:
             writes.add("episodes", str(episode["id"]), sql, row)
 
-    def _save_position(self, conn: sqlite3.Connection, state: Mapping[str, Any]) -> None:
+    def _save_position(
+        self, conn: sqlite3.Connection, state: Mapping[str, Any],
+        writes: _ReplayWrites | None = None,
+    ) -> None:
         active = state.get("active_episode")
         active_id = active.get("id") if isinstance(active, Mapping) else None
         if active_id:
@@ -1912,33 +2468,37 @@ class AccountBook:
         settled = bool(state.get("settled") and status == "closed")
         first_order = state["first_order"]
         last_order = state["last_order"]
-        conn.execute(
-            "INSERT OR REPLACE INTO lp_accounting_positions(" 
+        sql = (
+            "INSERT OR REPLACE INTO lp_accounting_positions("
             "position_key,token_id,pool_id,protocol,owner,custody,identity_basis,tick_lower,"
             "tick_upper,liquidity,liquidity_known,pending_principal0,pending_principal1,"
             "pending_known,tokens_owed0,tokens_owed1,owed_known,active_episode_id,status,"
             "history_complete,first_block,first_timestamp,last_block,last_tx_index,last_log_index,"
             "last_timestamp,principal0,principal1,principal_usd,uncollected_fees_usd,equity_usd,"
-            "valuation_block,valuation_timestamp,valuation_basis,state_json) VALUES(" +
-            ",".join("?" for _ in range(35)) + ")",
-            (
-                state["position_key"], state.get("token_id"), state.get("pool_id"),
-                state.get("protocol"), _address(state.get("owner")),
-                _address(state.get("custody")), state.get("identity_basis"),
-                state.get("tick_lower"), state.get("tick_upper"), state.get("liquidity"),
-                int(bool(state.get("liquidity_known"))), state.get("pending0"),
-                state.get("pending1"), int(bool(state.get("pending_known"))),
-                state.get("owed0"), state.get("owed1"), int(bool(state.get("owed_known"))),
-                active_id, status, int(bool(state.get("history_complete"))),
-                int(first_order[0]), int(state["first_timestamp"]), int(last_order[0]),
-                int(last_order[1]), int(last_order[2]), int(state["last_timestamp"]),
-                "0" if settled else None, "0" if settled else None,
-                0.0 if settled else None, 0.0 if settled else None,
-                0.0 if settled else None, None, None,
-                "settled_zero" if settled else "unvalued",
-                json.dumps(state, separators=(",", ":"), sort_keys=True),
-            ),
+            "valuation_block,valuation_timestamp,valuation_basis,state_json) VALUES("
+            + ",".join("?" for _ in range(35)) + ")"
         )
+        row = (
+            state["position_key"], state.get("token_id"), state.get("pool_id"),
+            state.get("protocol"), _address(state.get("owner")),
+            _address(state.get("custody")), state.get("identity_basis"),
+            state.get("tick_lower"), state.get("tick_upper"), state.get("liquidity"),
+            int(bool(state.get("liquidity_known"))), state.get("pending0"),
+            state.get("pending1"), int(bool(state.get("pending_known"))),
+            state.get("owed0"), state.get("owed1"), int(bool(state.get("owed_known"))),
+            active_id, status, int(bool(state.get("history_complete"))),
+            int(first_order[0]), int(state["first_timestamp"]), int(last_order[0]),
+            int(last_order[1]), int(last_order[2]), int(state["last_timestamp"]),
+            "0" if settled else None, "0" if settled else None,
+            0.0 if settled else None, 0.0 if settled else None,
+            0.0 if settled else None, None, None,
+            "settled_zero" if settled else "unvalued",
+            json.dumps(state, separators=(",", ":"), sort_keys=True),
+        )
+        if writes is None:
+            conn.execute(sql, row)
+        else:
+            writes.add("positions", str(state["position_key"]), sql, row)
 
     @staticmethod
     def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
@@ -2359,6 +2919,8 @@ class AccountBook:
     def _reader(self):
         connection = self.store.read()
         owns_snapshot = not connection.in_transaction
+        if owns_snapshot:
+            connection.execute("BEGIN")
         try:
             yield connection
         finally:
@@ -2450,6 +3012,28 @@ class AccountBook:
             status = dict(self.store.status())
         except Exception:
             status = {}
+        accounting: dict[str, str] = {}
+        if self.deferred:
+            try:
+                accounting = {
+                    str(row[0]): str(row[1])
+                    for row in self.store.read().execute(
+                        "SELECT key,value FROM lp_accounting_meta "
+                        "WHERE key IN ('applied_revision','applied_epoch','dirty',"
+                        "'bootstrap_phase')"
+                    ).fetchall()
+                }
+            except sqlite3.OperationalError:
+                accounting = {}
+        pending = int(status.get("pending_accounting", 0) or 0)
+        complete = (
+            not self.deferred
+            or (
+                pending == 0
+                and accounting.get("dirty", "1") == "0"
+                and accounting.get("bootstrap_phase", "complete") == "complete"
+            )
+        )
         coverage = status.get("coverage")
         starts = [
             lane["from_block"] for lane in coverage.values()
@@ -2459,13 +3043,23 @@ class AccountBook:
         return {
             "history_from": status.get("history_from"),
             "history_from_block": history_from_block,
-            "history_to": status.get("history_to"),
+            "history_to": status.get("history_to") if complete else None,
             "history_target": status.get("history_target"),
             "backfill": status.get("backfill"),
             "state": status.get("state"),
             "indexed_head": status.get("indexed_head"),
             "revision": status.get("revision"),
             "epoch": status.get("epoch"),
+            "accounting_pending": pending,
+            "accounting_complete": complete,
+            "accounting_applied_revision": (
+                int(accounting["applied_revision"])
+                if accounting.get("applied_revision", "").isdigit() else None
+            ),
+            "accounting_applied_epoch": (
+                int(accounting["applied_epoch"])
+                if accounting.get("applied_epoch", "").isdigit() else None
+            ),
         }
 
     @staticmethod
@@ -2607,6 +3201,10 @@ class AccountBook:
             copied["coverage"] = dict(row["coverage"])
         if isinstance(row.get("activity"), Mapping):
             copied["activity"] = dict(row["activity"])
+        if isinstance(row.get("financial_through_order"), Mapping):
+            copied["financial_through_order"] = dict(
+                row["financial_through_order"]
+            )
         return copied
 
     @staticmethod
@@ -2807,7 +3405,32 @@ class AccountBook:
                     conn, (row.get("owner") for row in beneficial),
                     gas_clauses, args,
                 )
+                financial_state = self._scoped_owner_financial_state(
+                    conn, params,
+                    now - cutoff_seconds
+                    if cutoff_seconds is not None else None,
+                )
             rows = beneficial
+            (
+                through_order, through_as_of, pending_owners,
+                pending_custodies, mapping_complete,
+            ) = financial_state
+            for row in (*beneficial, *custody_rows):
+                owner = _address(row.get("owner"))
+                custody = _address(row.get("custody"))
+                pending = (
+                    not mapping_complete
+                    or owner is not None and owner in pending_owners
+                    or custody is not None and custody in pending_custodies
+                )
+                row["financial_pending"] = pending
+                row["financial_through_order"] = (
+                    None if pending or through_order is None
+                    else dict(through_order)
+                )
+                row["financial_through_as_of"] = (
+                    None if pending else through_as_of
+                )
             for row in rows:
                 timestamp = row.pop("_retention_timestamp", None)
                 if cutoff_seconds is not None and timestamp is not None:
@@ -2916,7 +3539,37 @@ class AccountBook:
             "tx_hash": row.get("tx_hash"),
             "event_count": 1,
             "qualification": "durable_canonical_index",
+            "_order": (
+                int(row.get("block_number") or 0),
+                int(row.get("tx_index") or 0),
+                int(row.get("log_index") or 0),
+            ),
         }
+
+    @staticmethod
+    def _attach_owner_activity(
+            row: dict[str, Any], activity: Mapping[str, Any] | None,
+    ) -> None:
+        if activity is None:
+            row["activity"] = None
+            return
+        view = dict(activity)
+        activity_order = view.pop("_order", None)
+        row["activity"] = view
+        through = row.get("financial_through_order")
+        if (
+            isinstance(activity_order, (list, tuple))
+            and (
+                not isinstance(through, Mapping)
+                or tuple(int(item) for item in activity_order) > tuple(
+                    int(through.get(name) or 0)
+                    for name in ("block_number", "tx_index", "log_index")
+                )
+            )
+        ):
+            row["financial_pending"] = True
+            row["financial_through_order"] = None
+            row["financial_through_as_of"] = None
 
     def _historical_owner_activity(
             self, conn: sqlite3.Connection, owner_row: Mapping[str, Any],
@@ -3001,6 +3654,120 @@ class AccountBook:
         )
         return self._activity_view(latest)
 
+    def _scoped_owner_financial_state(
+            self, conn: sqlite3.Connection, params: Mapping[str, Any],
+            cutoff_timestamp: int | None,
+    ) -> tuple[
+        dict[str, int] | None, int | None, set[str], set[str], bool,
+    ]:
+        """Describe the immutable ledger snapshot backing owner aggregates."""
+        cutoff = cutoff_timestamp
+        protocol = str(params.get("protocol") or "").lower()
+        pool_id = str(params.get("pool") or params.get("pool_id") or "").lower()
+        event_clauses: list[str] = []
+        event_args: list[Any] = []
+        episode_clauses: list[str] = []
+        episode_args: list[Any] = []
+        if cutoff is not None:
+            event_clauses.append("e.timestamp>=?")
+            event_args.append(cutoff)
+            episode_clauses.append("ep.last_timestamp>=?")
+            episode_args.append(cutoff)
+        if protocol:
+            event_clauses.append(
+                "(e.protocol=? OR (e.protocol='nft' AND "
+                "json_extract(e.data,'$.manager_protocol')=?))"
+            )
+            event_args.extend((protocol, protocol))
+            episode_clauses.append("ep.protocol=?")
+            episode_args.append(protocol)
+        if pool_id:
+            event_clauses.append("e.pool_id=?")
+            event_args.append(pool_id)
+            episode_clauses.append("ep.pool_id=?")
+            episode_args.append(pool_id)
+        event_where = (
+            " WHERE " + " AND ".join(event_clauses)
+            if event_clauses else ""
+        )
+        through = conn.execute(
+            "SELECT e.block_number,e.tx_index,e.log_index,e.timestamp "
+            "FROM events e" + event_where
+            + " ORDER BY e.block_number DESC,e.tx_index DESC,"
+            "e.log_index DESC LIMIT 1",
+            event_args,
+        ).fetchone()
+        through_order = (
+            {
+                "block_number": int(through["block_number"]),
+                "tx_index": int(through["tx_index"]),
+                "log_index": int(through["log_index"]),
+            }
+            if through is not None else None
+        )
+        through_as_of = (
+            int(through["timestamp"]) if through is not None else None
+        )
+        bootstrap_complete = (
+            self._accounting_meta(conn, "bootstrap_phase", "complete")
+            == "complete"
+        )
+        pending_exists = conn.execute(
+            "SELECT 1 FROM lp_accounting_pending LIMIT 1"
+        ).fetchone() is not None
+        dirty = self._accounting_meta(conn, "dirty", "1") != "0"
+        if not bootstrap_complete or dirty and not pending_exists:
+            return through_order, through_as_of, set(), set(), False
+        if not pending_exists:
+            return through_order, through_as_of, set(), set(), True
+        if event_clauses:
+            event_scope = " AND " + " AND ".join(event_clauses)
+            episode_scope = " AND " + " AND ".join(episode_clauses)
+            scoped_keys = (
+                "SELECT q.position_key FROM lp_accounting_pending q WHERE "
+                "EXISTS(SELECT 1 FROM lp_accounting_event_keys k "
+                "INDEXED BY lp_accounting_event_keys_position "
+                "JOIN events e ON e.id=k.event_id "
+                "WHERE k.position_key=q.position_key" + event_scope + ") OR "
+                "EXISTS(SELECT 1 FROM lp_accounting_episodes ep "
+                "WHERE ep.position_key=q.position_key" + episode_scope + ")"
+            )
+            scoped_args = [*event_args, *episode_args]
+        else:
+            scoped_keys = (
+                "SELECT q.position_key FROM lp_accounting_pending q"
+            )
+            scoped_args = []
+        pending_rows = conn.execute(
+            "WITH scoped_keys AS (" + scoped_keys + ") "
+            "SELECT ep.owner,ep.custody,NULL AS data "
+            "FROM scoped_keys s JOIN lp_accounting_episodes ep "
+            "ON ep.position_key=s.position_key "
+            "UNION "
+            "SELECT e.owner,e.custody,CASE WHEN e.kind='transfer' THEN e.data END "
+            "FROM scoped_keys s JOIN lp_accounting_event_keys k "
+            "INDEXED BY lp_accounting_event_keys_position "
+            "ON k.position_key=s.position_key "
+            "JOIN events e ON e.id=k.event_id",
+            scoped_args,
+        )
+        owners: set[str] = set()
+        custodies: set[str] = set()
+        for row in pending_rows:
+            owner = _address(row["owner"])
+            custody = _address(row["custody"])
+            if owner is not None:
+                owners.add(owner)
+            if custody is not None:
+                custodies.add(custody)
+            if row["data"] is not None:
+                source, target = self._transfer_parties(dict(row), _json(row["data"]))
+                if source is not None and source != _ZERO_ADDRESS:
+                    owners.add(source)
+                if target is not None and target != _ZERO_ADDRESS:
+                    owners.add(target)
+        return through_order, through_as_of, owners, custodies, True
+
     def decorate_owner_activity(
             self, rows: Sequence[Mapping[str, Any]],
             params: Mapping[str, Any] | None = None,
@@ -3029,18 +3796,24 @@ class AccountBook:
             if cached is ...:
                 missing.append((index, key))
             else:
-                row["activity"] = dict(cached) if isinstance(cached, Mapping) else None
+                self._attach_owner_activity(
+                    row, cached if isinstance(cached, Mapping) else None,
+                )
         if missing:
             with self._reader() as conn:
                 for index, key in missing:
-                    activity = self._historical_owner_activity(conn, output[index], params)
-                    output[index]["activity"] = (
-                        dict(activity) if isinstance(activity, Mapping) else None
+                    activity = self._historical_owner_activity(
+                        conn, output[index], params,
+                    )
+                    self._attach_owner_activity(
+                        output[index],
+                        activity if isinstance(activity, Mapping) else None,
                     )
                     with self._cache_lock:
                         if generation == self._owners_generation:
                             self._owner_activity_cache[key] = (
-                                dict(activity) if isinstance(activity, Mapping) else None
+                                dict(activity)
+                                if isinstance(activity, Mapping) else None
                             )
                             self._owner_activity_cache.move_to_end(key)
                             while len(self._owner_activity_cache) > 2048:

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -339,7 +339,7 @@ _EFFECT_WRITE_SQL = (
 
 def _dict_rows(cursor: sqlite3.Cursor) -> list[dict[str, Any]]:
     names = [item[0] for item in cursor.description or ()]
-    return [dict(zip(names, row)) for row in cursor.fetchall()]
+    return [dict(zip(names, row)) for row in cursor]
 
 
 class _ReplayWrites:
@@ -601,8 +601,11 @@ def _batches(values: Sequence[Any], size: int = 500) -> Iterable[Sequence[Any]]:
 
 
 def _one(cursor: sqlite3.Cursor) -> dict[str, Any] | None:
-    rows = _dict_rows(cursor)
-    return rows[0] if rows else None
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    names = [item[0] for item in cursor.description or ()]
+    return dict(zip(names, row))
 
 
 def _json(value: Any) -> dict[str, Any]:
@@ -3883,21 +3886,21 @@ class AccountBook:
             if identity is not None:
                 owner_clause = " AND ep.owner=?"
                 args.append(identity)
-            rows = _dict_rows(conn.execute(
+            rows = conn.execute(
                 "SELECT DISTINCT ep.owner,e.tx_hash,c.owner AS cost_owner,c.gas_usd "
                 "FROM lp_accounting_effects e "
                 "JOIN lp_accounting_episodes ep ON ep.id=e.episode_id "
                 "LEFT JOIN lp_accounting_tx_costs c ON c.tx_hash=e.tx_hash "
                 f"WHERE e.episode_id IN ({marks}){owner_clause}", args,
-            ))
+            )
             for row in rows:
-                owner = _address(row.get("owner"))
-                tx_hash = str(row.get("tx_hash") or "")
+                owner = _address(row[0])
+                tx_hash = str(row[1] or "")
                 if owner is None or not tx_hash:
                     continue
-                exact_owner = _address(row.get("cost_owner")) == owner
+                exact_owner = _address(row[2]) == owner
                 costs[(owner, tx_hash)] = (
-                    _finite_float(row.get("gas_usd")) if exact_owner else None
+                    _finite_float(row[3]) if exact_owner else None
                 )
         result: dict[str, list[float | None]] = defaultdict(list)
         for (owner, _), value in costs.items():
@@ -3908,15 +3911,46 @@ class AccountBook:
     def _owner_gas_values(
             conn: sqlite3.Connection, identities: Iterable[Any],
             owner_clauses: Sequence[str], args: Sequence[Any],
+            complete_identities: Iterable[Any] = (),
     ) -> dict[str, float | None]:
         selected = sorted({
             str(identity) for identity in identities if identity is not None
         })
         if not selected:
             return {}
+        complete = {
+            str(identity) for identity in complete_identities
+            if identity is not None
+        }
         predicate = " AND ".join(owner_clauses)
         result: dict[str, float | None] = {}
-        for batch in _batches(selected, 400):
+        # A non-NULL episode gas aggregate proves every selected transaction
+        # has an exact episode attribution. Sum those costs in the same owner
+        # index order as before, but resolve scope through c.episode_id instead
+        # of probing the effects table once per transaction.
+        known = [owner for owner in selected if owner in complete]
+        for batch in _batches(known, 400):
+            values = ",".join("(?)" for _ in batch)
+            rows = conn.execute(
+                "WITH selected(owner) AS (VALUES " + values + ") "
+                "SELECT selected.owner,(SELECT SUM(c.gas_usd) "
+                "FROM lp_accounting_tx_costs c "
+                "INDEXED BY lp_accounting_tx_costs_owner "
+                "WHERE c.owner=selected.owner AND EXISTS ("
+                "SELECT 1 FROM lp_accounting_episodes ep "
+                "LEFT JOIN pools p ON p.id=ep.pool_id "
+                "WHERE ep.id=c.episode_id AND ep.owner=selected.owner AND "
+                + predicate + ")) AS gas_usd FROM selected",
+                [*batch, *args],
+            )
+            for row in rows:
+                result[str(row["owner"])] = row["gas_usd"]
+        # Episode NULLs can still be owner-qualified when one transaction
+        # spans several episodes belonging to that owner. Retain the existing
+        # per-owner missing-cost short circuit for exactly those uncertain
+        # owners; only owners which pass it pay for the de-duplicated sum.
+        uncertain = [owner for owner in selected if owner not in complete]
+        for batch in _batches(uncertain, 400):
             values = ",".join("(?)" for _ in batch)
             rows = conn.execute(
                 "WITH selected(owner) AS (VALUES " + values + ") "
@@ -3941,7 +3975,7 @@ class AccountBook:
                 "WHERE fx.tx_hash=c.tx_hash AND ep.owner=selected.owner AND "
                 + predicate + ")) END AS gas_usd FROM selected",
                 [*batch, *args, *args],
-            ).fetchall()
+            )
             for row in rows:
                 result[str(row["owner"])] = row["gas_usd"]
         return result
@@ -4258,9 +4292,7 @@ class AccountBook:
             else:
                 rows = []
         if cached is None:
-            clauses: list[str] = [
-                "(e.owner IS NOT NULL OR e.custody IS NOT NULL)"
-            ]
+            clauses: list[str] = []
             args: list[Any] = []
             if cutoff_seconds is not None:
                 clauses.append("e.last_timestamp>=?")
@@ -4294,7 +4326,6 @@ class AccountBook:
                     "LOWER(fxq.tx_hash) LIKE ? ESCAPE '\\'))"
                 )
                 args.extend([term] * 13)
-            where = " WHERE " + " AND ".join(clauses) if clauses else ""
             aggregate = (
                 "COUNT(DISTINCT e.position_key) AS positions,"
                 "COUNT(DISTINCT CASE WHEN e.closed_at IS NULL THEN e.position_key END) "
@@ -4302,8 +4333,6 @@ class AccountBook:
                 "SUM(e.status='complete') AS closed_episodes,"
                 "CASE WHEN COUNT(e.gross_pnl_usd)=COUNT(*) "
                 "THEN SUM(e.gross_pnl_usd) END AS gross_pnl_usd,"
-                "CASE WHEN COUNT(e.net_pnl_usd)=COUNT(*) "
-                "THEN SUM(e.net_pnl_usd) END AS net_pnl_usd,"
                 "CASE WHEN COUNT(e.gas_usd)=COUNT(*) "
                 "THEN SUM(e.gas_usd) END AS gas_usd,"
                 "CASE WHEN MIN(e.history_complete AND e.fees_complete "
@@ -4325,8 +4354,26 @@ class AccountBook:
                 "100.0*SUM(e.status='complete' AND e.gross_pnl_usd>0)"
                 "/SUM(e.status='complete') END AS win_rate,"
                 "SUM(e.gross_pnl_usd IS NOT NULL) AS complete_episodes,"
-                "COUNT(*) AS episodes,MAX(e.last_timestamp) AS _activity_at,"
-                "MIN(e.last_timestamp) AS _retention_timestamp "
+                "COUNT(*) AS episodes,MAX(e.last_timestamp) AS _activity_at"
+                + (
+                    ",MIN(e.last_timestamp) AS _retention_timestamp"
+                    if cutoff_seconds is not None else ""
+                )
+            )
+            custody_aggregate = (
+                "COUNT(DISTINCT e.position_key) AS positions,"
+                "COUNT(DISTINCT CASE WHEN e.closed_at IS NULL "
+                "THEN e.position_key END) AS open_positions,"
+                "SUM(e.status='complete') AS closed_episodes,"
+                "CASE WHEN MIN(e.history_complete AND e.pricing_complete)=1 "
+                "AND COUNT(e.deposit_usd)=COUNT(*) "
+                "AND COUNT(e.proceeds_usd)=COUNT(*) "
+                "THEN SUM(e.deposit_usd+e.proceeds_usd) END AS volume_usd,"
+                "COUNT(*) AS episodes,MAX(e.last_timestamp) AS _activity_at"
+                + (
+                    ",MIN(e.last_timestamp) AS _retention_timestamp"
+                    if cutoff_seconds is not None else ""
+                )
             )
             source = " FROM lp_accounting_episodes e "
             if cutoff_seconds is not None and not pool_id:
@@ -4350,12 +4397,16 @@ class AccountBook:
                     "financial_scope": "lifetime_of_selected_episodes",
                     "fee_value_unit": "USDG_quote",
                 })
+                beneficial_clauses = [*clauses, "e.owner IS NOT NULL"]
+                beneficial_where = (
+                    " WHERE " + " AND ".join(beneficial_clauses)
+                )
                 beneficial = (
                     _dict_rows(conn.execute(
                         "SELECT e.owner,NULL AS custody,"
                         "'verified_owner' AS identity_basis,"
-                        + aggregate + source + where
-                        + " AND e.owner IS NOT NULL GROUP BY e.owner",
+                        + aggregate + source + beneficial_where
+                        + " GROUP BY e.owner",
                         args,
                     ))
                     if identity_scope != "custody" else []
@@ -4369,7 +4420,7 @@ class AccountBook:
                         "CASE WHEN SUM(e.owner IS NOT NULL)>0 "
                         "THEN 'custody_aggregate' ELSE 'custody_only' END "
                         "AS identity_basis,"
-                        + aggregate + source + custody_where
+                        + custody_aggregate + source + custody_where
                         + " GROUP BY e.custody",
                         args,
                     ))
@@ -4380,6 +4431,10 @@ class AccountBook:
                 gas_by_owner = self._owner_gas_values(
                     conn, (row.get("owner") for row in beneficial),
                     gas_clauses, args,
+                    (
+                        row.get("owner") for row in beneficial
+                        if row.get("gas_usd") is not None
+                    ),
                 )
                 financial_state = self._scoped_owner_financial_state(
                     conn, params,
@@ -4391,22 +4446,23 @@ class AccountBook:
                 through_order, through_as_of, pending_owners,
                 pending_custodies, mapping_complete,
             ) = financial_state
-            for row in (*beneficial, *custody_rows):
-                owner = _address(row.get("owner"))
-                custody = _address(row.get("custody"))
-                pending = (
-                    not mapping_complete
-                    or owner is not None and owner in pending_owners
-                    or custody is not None and custody in pending_custodies
-                )
-                row["financial_pending"] = pending
-                row["financial_through_order"] = (
-                    None if pending or through_order is None
-                    else dict(through_order)
-                )
-                row["financial_through_as_of"] = (
-                    None if pending else through_as_of
-                )
+            for group in (beneficial, custody_rows):
+                for row in group:
+                    owner = _address(row.get("owner"))
+                    custody = _address(row.get("custody"))
+                    pending = (
+                        not mapping_complete
+                        or owner is not None and owner in pending_owners
+                        or custody is not None and custody in pending_custodies
+                    )
+                    row["financial_pending"] = pending
+                    row["financial_through_order"] = (
+                        None if pending or through_order is None
+                        else dict(through_order)
+                    )
+                    row["financial_through_as_of"] = (
+                        None if pending else through_as_of
+                    )
             for row in rows:
                 timestamp = row.pop("_retention_timestamp", None)
                 if cutoff_seconds is not None and timestamp is not None:
@@ -4548,87 +4604,180 @@ class AccountBook:
             row["financial_through_as_of"] = None
 
     def _historical_owner_activity(
-            self, conn: sqlite3.Connection, owner_row: Mapping[str, Any],
+            self, conn: sqlite3.Connection,
+            owner_rows: Sequence[Mapping[str, Any]],
             params: Mapping[str, Any],
-    ) -> dict[str, Any] | None:
-        identity = _address(owner_row.get("owner") or owner_row.get("custody"))
-        if identity is None:
-            return None
-        owner_match = owner_row.get("owner") is not None
-        clauses = [
-            "e.kind IN ('add','remove','collect','checkpoint','donate','fee','transfer')"
+    ) -> list[dict[str, Any] | None]:
+        identities = [
+            (
+                row.get("owner") is not None,
+                _address(row.get("owner") or row.get("custody")),
+            )
+            for row in owner_rows
         ]
-        args: list[Any] = []
-        cutoff = _cutoff(params)
-        if cutoff is not None:
-            clauses.append("e.timestamp>=CAST(strftime('%s','now') AS INTEGER)-?")
-            args.append(cutoff)
-        protocol = str(params.get("protocol") or "").lower()
-        if protocol:
-            clauses.append(
-                "(e.protocol=? OR (e.protocol='nft' AND "
-                "json_extract(e.data,'$.manager_protocol')=?))"
-            )
-            args.extend((protocol, protocol))
-        pool_id = str(params.get("pool") or params.get("pool_id") or "").lower()
-        if pool_id:
-            clauses.append("e.pool_id=?")
-            args.append(pool_id)
         query = str(params.get("q") or "").strip().lower()[:128]
-        if query and query not in identity:
-            escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
-            term = f"%{escaped}%"
-            clauses.append(
-                "(LOWER(COALESCE(e.pool_id,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(e.protocol,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(p.symbol0,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(p.symbol1,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(p.token0,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(p.token1,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(p.symbol0,'')||'/'||"
-                "COALESCE(p.symbol1,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(p.symbol0,'')||' / '||"
-                "COALESCE(p.symbol1,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(e.tx_hash,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(e.position_key,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(e.token_id,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(e.owner,'')) LIKE ? ESCAPE '\\' OR "
-                "LOWER(COALESCE(e.custody,'')) LIKE ? ESCAPE '\\')"
-            )
-            args.extend([term] * 13)
+        escaped = (
+            query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
+        term = f"%{escaped}%"
+        cutoff_seconds = _cutoff(params)
+        cutoff_timestamp = (
+            int(time.time()) - cutoff_seconds
+            if cutoff_seconds is not None else None
+        )
+        protocol = str(params.get("protocol") or "").lower()
+        pool_id = str(
+            params.get("pool") or params.get("pool_id") or ""
+        ).lower()
+        latest: dict[tuple[bool, str], dict[str, Any]] = {}
         columns = (
             "e.block_number,e.timestamp,e.pool_id,e.kind,e.tx_hash,e.tx_index,"
             "e.log_index,p.symbol0,p.symbol1,p.token0,p.token1"
         )
-        identity_column = "e.owner" if owner_match else "e.custody"
-        direct = _one(conn.execute(
-            "SELECT " + columns + " FROM events e "
-            "LEFT JOIN pools p ON p.id=e.pool_id WHERE "
-            + identity_column + "=? AND " + " AND ".join(clauses)
-            + " ORDER BY e.block_number DESC,e.tx_index DESC,e.log_index DESC LIMIT 1",
-            [identity, *args],
-        ))
-        ended = None
-        if owner_match:
-            ended = _one(conn.execute(
-                "SELECT " + columns + " FROM lp_ownership_intervals i "
-                "JOIN lp_accounting_event_keys k ON k.position_key=i.position_key "
-                "JOIN events e ON e.id=k.event_id AND e.block_number=i.end_block "
-                "AND e.tx_index=i.end_tx_index AND e.log_index=i.end_log_index "
-                "LEFT JOIN pools p ON p.id=e.pool_id WHERE i.owner=? "
-                "AND i.end_block IS NOT NULL AND " + " AND ".join(clauses)
-                + " ORDER BY e.block_number DESC,e.tx_index DESC,e.log_index DESC LIMIT 1",
-                [identity, *args],
-            ))
-        latest = max(
-            (row for row in (direct, ended) if row is not None),
-            key=lambda row: (
-                int(row.get("block_number") or 0), int(row.get("tx_index") or 0),
-                int(row.get("log_index") or 0),
-            ),
-            default=None,
-        )
-        return self._activity_view(latest)
+
+        def scope(include_query: bool) -> tuple[list[str], list[Any]]:
+            clauses = [
+                "a.kind IN "
+                "('add','remove','collect','checkpoint','donate','fee','transfer')"
+            ]
+            scope_args: list[Any] = []
+            if cutoff_timestamp is not None:
+                clauses.append("a.timestamp>=?")
+                scope_args.append(cutoff_timestamp)
+            if protocol:
+                clauses.append(
+                    "(a.protocol=? OR (a.protocol='nft' AND "
+                    "json_extract(a.data,'$.manager_protocol')=?))"
+                )
+                scope_args.extend((protocol, protocol))
+            if pool_id:
+                clauses.append("a.pool_id=?")
+                scope_args.append(pool_id)
+            if include_query:
+                clauses.append(
+                    "(LOWER(COALESCE(a.pool_id,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(a.protocol,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(ap.symbol0,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(ap.symbol1,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(ap.token0,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(ap.token1,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(ap.symbol0,'')||'/'||"
+                    "COALESCE(ap.symbol1,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(ap.symbol0,'')||' / '||"
+                    "COALESCE(ap.symbol1,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(a.tx_hash,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(a.position_key,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(a.token_id,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(a.owner,'')) LIKE ? ESCAPE '\\' OR "
+                    "LOWER(COALESCE(a.custody,'')) LIKE ? ESCAPE '\\')"
+                )
+                scope_args.extend([term] * 13)
+            return clauses, scope_args
+
+        def retain(
+                owner_match: bool, rows: Iterable[sqlite3.Row],
+        ) -> None:
+            for source in rows:
+                row = dict(source)
+                identity = str(row.pop("_identity"))
+                key = (owner_match, identity)
+                prior = latest.get(key)
+                order = (
+                    int(row.get("block_number") or 0),
+                    int(row.get("tx_index") or 0),
+                    int(row.get("log_index") or 0),
+                )
+                if prior is None or order > (
+                    int(prior.get("block_number") or 0),
+                    int(prior.get("tx_index") or 0),
+                    int(prior.get("log_index") or 0),
+                ):
+                    latest[key] = row
+
+        def direct(
+                owner_match: bool, selected: Sequence[str],
+                include_query: bool,
+        ) -> None:
+            clauses, scope_args = scope(include_query)
+            identity_column = "a.owner" if owner_match else "a.custody"
+            index_name = (
+                "events_owner_order_idx"
+                if owner_match else "events_custody_order_idx"
+            )
+            for batch in _batches(selected, 400):
+                values = ",".join("(?)" for _ in batch)
+                pool_join = (
+                    "LEFT JOIN pools ap ON ap.id=a.pool_id "
+                    if include_query else ""
+                )
+                retain(owner_match, conn.execute(
+                    "WITH selected(identity) AS (VALUES " + values + ") "
+                    "SELECT s.identity AS _identity," + columns
+                    + " FROM selected s JOIN events e ON e.id=("
+                    "SELECT a.id FROM events a INDEXED BY " + index_name + " "
+                    + pool_join + "WHERE " + identity_column + "=s.identity AND "
+                    + " AND ".join(clauses)
+                    + " ORDER BY a.block_number DESC,a.tx_index DESC,"
+                    "a.log_index DESC LIMIT 1) "
+                    "LEFT JOIN pools p ON p.id=e.pool_id",
+                    [*batch, *scope_args],
+                ))
+
+        def ended(selected: Sequence[str], include_query: bool) -> None:
+            clauses, scope_args = scope(include_query)
+            for batch in _batches(selected, 400):
+                values = ",".join("(?)" for _ in batch)
+                pool_join = (
+                    "LEFT JOIN pools ap ON ap.id=a.pool_id "
+                    if include_query else ""
+                )
+                retain(True, conn.execute(
+                    "WITH selected(identity) AS (VALUES " + values + ") "
+                    "SELECT s.identity AS _identity," + columns
+                    + " FROM selected s JOIN events e ON e.id=("
+                    "SELECT a.id FROM lp_ownership_intervals i "
+                    "INDEXED BY lp_ownership_intervals_owner "
+                    "JOIN lp_accounting_event_keys k "
+                    "ON k.position_key=i.position_key "
+                    "JOIN events a ON a.id=k.event_id "
+                    + pool_join + "WHERE i.owner=s.identity "
+                    "AND i.end_block IS NOT NULL "
+                    "AND a.block_number=i.end_block "
+                    "AND a.tx_index=i.end_tx_index "
+                    "AND a.log_index=i.end_log_index AND "
+                    + " AND ".join(clauses)
+                    + " ORDER BY i.end_block DESC,i.end_tx_index DESC,"
+                    "i.end_log_index DESC LIMIT 1) "
+                    "LEFT JOIN pools p ON p.id=e.pool_id",
+                    [*batch, *scope_args],
+                ))
+
+        for owner_match in (True, False):
+            matches = sorted({
+                identity for match, identity in identities
+                if match is owner_match and identity is not None
+                and (not query or query in identity)
+            })
+            searches = sorted({
+                identity for match, identity in identities
+                if match is owner_match and identity is not None
+                and query and query not in identity
+            })
+            if matches:
+                direct(owner_match, matches, False)
+                if owner_match:
+                    ended(matches, False)
+            if searches:
+                direct(owner_match, searches, True)
+                if owner_match:
+                    ended(searches, True)
+        return [
+            self._activity_view(
+                latest.get((owner_match, identity))
+                if identity is not None else None
+            )
+            for owner_match, identity in identities
+        ]
 
     def _scoped_owner_financial_state(
             self, conn: sqlite3.Connection, params: Mapping[str, Any],
@@ -4792,23 +4941,23 @@ class AccountBook:
                 )
         if missing:
             with self._reader() as conn:
-                for index, key in missing:
-                    activity = self._historical_owner_activity(
-                        conn, output[index], params,
-                    )
-                    self._attach_owner_activity(
-                        output[index],
-                        activity if isinstance(activity, Mapping) else None,
-                    )
-                    with self._cache_lock:
-                        if generation == self._owners_generation:
-                            self._owner_activity_cache[key] = (
-                                dict(activity)
-                                if isinstance(activity, Mapping) else None
-                            )
-                            self._owner_activity_cache.move_to_end(key)
-                            while len(self._owner_activity_cache) > 2048:
-                                self._owner_activity_cache.popitem(last=False)
+                activities = self._historical_owner_activity(
+                    conn, [output[index] for index, _ in missing], params,
+                )
+            for (index, _), activity in zip(missing, activities):
+                self._attach_owner_activity(
+                    output[index],
+                    activity if isinstance(activity, Mapping) else None,
+                )
+            with self._cache_lock:
+                if generation == self._owners_generation:
+                    for (_, key), activity in zip(missing, activities):
+                        self._owner_activity_cache[key] = (
+                            activity if isinstance(activity, Mapping) else None
+                        )
+                        self._owner_activity_cache.move_to_end(key)
+                    while len(self._owner_activity_cache) > 2048:
+                        self._owner_activity_cache.popitem(last=False)
         return output
 
     def owners(self, params: Mapping[str, Any] | None = None) -> dict[str, Any]:

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -194,6 +194,11 @@ CREATE INDEX IF NOT EXISTS lp_accounting_episodes_pool
     ON lp_accounting_episodes(pool_id, closed_at, opened_at);
 CREATE INDEX IF NOT EXISTS lp_accounting_episodes_last_timestamp
     ON lp_accounting_episodes(last_timestamp);
+CREATE INDEX IF NOT EXISTS lp_accounting_episodes_closed_order
+    ON lp_accounting_episodes(
+        closed_at DESC, opened_block DESC,
+        opened_tx_index DESC, opened_log_index DESC
+    ) WHERE closed_at IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS lp_accounting_effects (
     event_id INTEGER PRIMARY KEY,
@@ -1200,7 +1205,7 @@ class AccountBook:
                 ).fetchone() is None:
                     self._invalidate_cache(conn, (), owners=True)
 
-    def _recover_pending_identities(self) -> bool:
+    def recover_pending_identities(self) -> bool:
         prepared = self._prepare_pending_identity_hints()
         if not prepared:
             return False
@@ -1310,8 +1315,6 @@ class AccountBook:
         bounded = max(1, min(int(limit), 128))
         with self._projection_lock:
             worked = self._resume_bootstrap(bounded)
-            if self._recover_pending_identities():
-                worked = True
             pending = self._pending_rows(bounded)
             if pending:
                 worked = True
@@ -3383,11 +3386,11 @@ class AccountBook:
             "coverage": self._row_coverage(row),
         }
 
-    def _episode_rows(self, conn: sqlite3.Connection,
-                      params: Mapping[str, Any] | None = None,
-                      *, closed_only: bool = False,
-                      identity: str | None = None) -> list[dict[str, Any]]:
-        params = params or {}
+    @staticmethod
+    def _episode_scope_filters(
+            params: Mapping[str, Any], *, closed_only: bool = False,
+            identity: str | None = None, include_query: bool = False,
+    ) -> tuple[list[str], list[Any], bool]:
         clauses: list[str] = []
         args: list[Any] = []
         if closed_only:
@@ -3396,7 +3399,9 @@ class AccountBook:
         if protocol in ("v2", "v3", "v4"):
             clauses.append("e.protocol=?")
             args.append(protocol)
-        pool_id = str(params.get("pool") or params.get("pool_id") or "").lower()
+        pool_id = str(
+            params.get("pool") or params.get("pool_id") or ""
+        ).lower()
         if pool_id:
             clauses.append("e.pool_id=?")
             args.append(pool_id)
@@ -3405,8 +3410,43 @@ class AccountBook:
             args.extend((identity, identity))
         cutoff = _cutoff(params)
         if cutoff is not None:
-            clauses.append("e.last_timestamp>=CAST(strftime('%s','now') AS INTEGER)-?")
-            args.append(cutoff)
+            clauses.append("e.last_timestamp>=?")
+            args.append(int(time.time()) - cutoff)
+        query = str(params.get("q") or "").strip().lower()
+        query_pool = bool(include_query and query)
+        if query_pool:
+            clauses.append(
+                "rhpools_episode_query("
+                "?,e.owner,e.custody,p.symbol0,p.symbol1,"
+                "p.token0,p.token1,e.pool_id)"
+            )
+            args.append(query)
+        return clauses, args, query_pool
+
+    @staticmethod
+    def _episode_query(
+            query: object, owner: object, custody: object,
+            symbol0: object, symbol1: object,
+            token0: object, token1: object, pool_id: object,
+    ) -> int:
+        pair = _pair({
+            "symbol0": symbol0, "symbol1": symbol1,
+            "token0": token0, "token1": token1,
+        })
+        searchable = " ".join((
+            str(owner or ""), str(custody or ""), pair.lower(),
+            str(pool_id or ""),
+        ))
+        return int(str(query) in searchable)
+
+    def _episode_rows(self, conn: sqlite3.Connection,
+                      params: Mapping[str, Any] | None = None,
+                      *, closed_only: bool = False,
+                      identity: str | None = None) -> list[dict[str, Any]]:
+        params = params or {}
+        clauses, args, _ = self._episode_scope_filters(
+            params, closed_only=closed_only, identity=identity,
+        )
         sql = (
             "SELECT e.*,s.active_episode_id,p.symbol0,p.symbol1,p.token0,p.token1 "
             "FROM lp_accounting_episodes e LEFT JOIN lp_accounting_positions s "
@@ -4122,25 +4162,69 @@ class AccountBook:
     def closed(self, params: Mapping[str, Any] | None = None) -> dict[str, Any]:
         params = params or {}
         limit, offset = _limit_offset(params)
-        with self._reader() as conn:
-            rows = self._episode_rows(conn, params, closed_only=True)
-        query = str(params.get("q") or "").strip().lower()
-        views = []
-        for row in rows:
-            pair = _pair(row)
-            if query and query not in " ".join((str(row.get("owner") or ""),
-                                                str(row.get("custody") or ""), pair.lower(),
-                                                str(row.get("pool_id") or ""))):
-                continue
-            views.append(self._episode_view(row, pair))
+        clauses, args, query_pool = self._episode_scope_filters(
+            params, closed_only=True, include_query=True,
+        )
+        source = " FROM lp_accounting_episodes e"
+        if query_pool:
+            source += " LEFT JOIN pools p ON p.id=e.pool_id"
+        where = " WHERE " + " AND ".join(clauses)
+        recent_order = (
+            "e.closed_at DESC,e.opened_block DESC,"
+            "e.opened_tx_index DESC,e.opened_log_index DESC"
+        )
         sort_key = str(params.get("sort") or "recent").lower()
-        field = {"net": "net_pnl_usd", "gross": "gross_pnl_usd", "fees": "fees_usd",
-                 "return": "return_pct", "duration": "duration_s"}.get(sort_key, "closed_at")
-        views.sort(key=lambda row: (row.get(field) is not None,
-                                   row.get(field) if row.get(field) is not None else -math.inf),
-                   reverse=True)
-        total = len(views)
-        selected = views[offset:offset + limit]
+        sort_value = {
+            "net": "e.net_pnl_usd",
+            "gross": "e.gross_pnl_usd",
+            "fees": (
+                "CASE WHEN e.fees_complete AND e.pricing_complete "
+                "AND e.history_complete THEN e.fees_usd END"
+            ),
+            "return": "e.return_pct",
+            "duration": "MAX(0,e.closed_at-e.opened_at)",
+        }.get(sort_key)
+        order = recent_order
+        if sort_value is not None:
+            order = "sort_value IS NULL,sort_value DESC," + recent_order
+        with self._reader() as conn:
+            if query_pool:
+                conn.create_function(
+                    "rhpools_episode_query", 8, self._episode_query,
+                    deterministic=True,
+                )
+            total = int(conn.execute(
+                "SELECT COUNT(*)" + source + where, args,
+            ).fetchone()[0])
+            select = "SELECT e.id"
+            if sort_value is not None:
+                select += "," + sort_value + " AS sort_value"
+            episode_ids = [
+                str(row[0])
+                for row in conn.execute(
+                    select + source + where + " ORDER BY " + order
+                    + " LIMIT ? OFFSET ?",
+                    (*args, limit, offset),
+                ).fetchall()
+            ]
+            rows_by_id: dict[str, dict[str, Any]] = {}
+            for batch in _batches(episode_ids):
+                marks = ",".join("?" for _ in batch)
+                rows_by_id.update({
+                    str(row["id"]): row
+                    for row in _dict_rows(conn.execute(
+                        "SELECT e.*,p.symbol0,p.symbol1,p.token0,p.token1 "
+                        "FROM lp_accounting_episodes e "
+                        "LEFT JOIN pools p ON p.id=e.pool_id "
+                        f"WHERE e.id IN ({marks})",
+                        batch,
+                    ))
+                })
+            selected = [
+                self._episode_view(rows_by_id[episode_id],
+                                   _pair(rows_by_id[episode_id]))
+                for episode_id in episode_ids
+            ]
         coverage = self._status_coverage()
         coverage.update({"rows": len(selected), "qualified_rows": sum(
             bool(row["coverage"]["qualified"]) for row in selected)})

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -287,6 +287,7 @@ CREATE TABLE IF NOT EXISTS lp_accounting_pending (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     position_key TEXT NOT NULL UNIQUE,
     generation INTEGER NOT NULL,
+    append_only INTEGER NOT NULL DEFAULT 0,
     requested_revision INTEGER NOT NULL,
     requested_epoch INTEGER NOT NULL,
     priority_block INTEGER NOT NULL,
@@ -343,7 +344,7 @@ def _dict_rows(cursor: sqlite3.Cursor) -> list[dict[str, Any]]:
 
 
 class _ReplayWrites:
-    """Coalesce and pre-diff a full position replay outside the writer."""
+    """Coalesce and pre-diff a full replay or a proven append."""
 
     _GROUPS = {
         "ownership": (
@@ -368,8 +369,9 @@ class _ReplayWrites:
         ),
     }
 
-    def __init__(self, position_key: str) -> None:
+    def __init__(self, position_key: str, *, append_only: bool = False) -> None:
         self.position_key = position_key
+        self._append_only = bool(append_only)
         self._statements: dict[str, str] = {}
         self._rows: dict[str, dict[Any, tuple[Any, ...]]] = {
             group: {} for group in self._GROUPS
@@ -384,6 +386,8 @@ class _ReplayWrites:
         self, conn: sqlite3.Connection, state: dict[str, Any],
     ) -> None:
         """Keep persisted episode IDs when backfill adds earlier boundaries."""
+        if self._append_only:
+            return
         ordinal = int(state.get("episode_ordinal") or 0)
         prior = conn.execute(
             "SELECT json_extract(state_json,'$.episode_ordinal') "
@@ -435,14 +439,41 @@ class _ReplayWrites:
         for group in ("ownership", "episodes", "positions"):
             table, row_key, _delete_sql = self._GROUPS[group]
             desired = self._rows[group]
-            existing: dict[Any, tuple[Any, ...]] = {
-                row_key(row): tuple(row)
-                for row in conn.execute(
-                    f"SELECT * FROM {table} WHERE position_key=?",
-                    (self.position_key,),
-                ).fetchall()
-            }
-            stale = sorted(existing.keys() - desired.keys())
+            if self._append_only and group == "ownership":
+                existing = {}
+                ordinals = sorted(int(key[1]) for key in desired)
+                for batch in _batches(ordinals):
+                    marks = ",".join("?" for _ in batch)
+                    existing.update({
+                        row_key(row): tuple(row)
+                        for row in conn.execute(
+                            f"SELECT * FROM {table} WHERE position_key=? "
+                            f"AND ordinal IN ({marks})",
+                            (self.position_key, *batch),
+                        ).fetchall()
+                    })
+            elif self._append_only and group == "episodes":
+                existing = {}
+                for batch in _batches(sorted(desired)):
+                    marks = ",".join("?" for _ in batch)
+                    existing.update({
+                        row_key(row): tuple(row)
+                        for row in conn.execute(
+                            f"SELECT * FROM {table} WHERE id IN ({marks})",
+                            batch,
+                        ).fetchall()
+                    })
+            else:
+                existing = {
+                    row_key(row): tuple(row)
+                    for row in conn.execute(
+                        f"SELECT * FROM {table} WHERE position_key=?",
+                        (self.position_key,),
+                    ).fetchall()
+                }
+            stale = [] if self._append_only else sorted(
+                existing.keys() - desired.keys()
+            )
             deletes[group] = [
                 key if isinstance(key, tuple) else (key,) for key in stale
             ]
@@ -476,57 +507,84 @@ class _ReplayWrites:
         changed_effects: list[int] = []
         stale_effects: list[int] = []
         columns = ",".join(_EFFECT_COLUMNS)
-        # Stream the position range instead of retaining a second full history
-        # of Python rows and probing every effect again by primary key.
-        for row in conn.execute(
-            f"SELECT {columns} FROM lp_accounting_effects WHERE position_key=?",
-            (self.position_key,),
-        ):
-            event_id = int(row[0])
-            desired = desired_effects.get(event_id)
-            if desired is None:
-                stale_effects.append(event_id)
-                if row[5]:
-                    self._affected_txs.add(str(row[5]))
-                if row[2]:
-                    self._changed_episodes.add(str(row[2]))
-                continue
-            remaining_ids.discard(event_id)
-            if tuple(row) != desired:
+        if self._append_only:
+            for batch in _batches(sorted(desired_effects)):
+                marks = ",".join("?" for _ in batch)
+                existing = {
+                    int(row[0]): tuple(row) for row in conn.execute(
+                        f"SELECT {columns} FROM lp_accounting_effects "
+                        f"WHERE event_id IN ({marks})", batch,
+                    )
+                }
+                for event_id, prior in existing.items():
+                    desired = desired_effects[event_id]
+                    remaining_ids.discard(event_id)
+                    if prior == desired:
+                        continue
+                    changed_effects.append(event_id)
+                    if prior[5]:
+                        self._affected_txs.add(str(prior[5]))
+                    if prior[2] and prior[2] != desired[2]:
+                        self._changed_episodes.add(str(prior[2]))
+                    if desired[5]:
+                        self._affected_txs.add(str(desired[5]))
+            for event_id in sorted(remaining_ids):
                 changed_effects.append(event_id)
-                if row[5]:
-                    self._affected_txs.add(str(row[5]))
-                if row[2] and row[2] != desired[2]:
-                    self._changed_episodes.add(str(row[2]))
-                if desired[5]:
-                    self._affected_txs.add(str(desired[5]))
-        # A newly mapped event may still belong to another position. Preserve
-        # that prior transaction's attribution when moving the effect.
-        for batch in _batches(sorted(remaining_ids)):
-            marks = ",".join("?" for _ in batch)
-            existing = {
-                int(row[0]): tuple(row) for row in conn.execute(
-                    f"SELECT {columns} FROM lp_accounting_effects "
-                    f"WHERE event_id IN ({marks})", batch,
-                )
-            }
-            for event_id in batch:
                 desired = desired_effects[event_id]
-                prior = existing.get(event_id)
-                if prior == desired:
-                    continue
-                changed_effects.append(event_id)
-                if prior is not None and prior[5]:
-                    self._affected_txs.add(str(prior[5]))
-                if prior is not None and prior[2] and prior[2] != desired[2]:
-                    self._changed_episodes.add(str(prior[2]))
                 if desired[5]:
                     self._affected_txs.add(str(desired[5]))
+        else:
+            # Stream the position range instead of retaining a second full
+            # history of Python rows and probing every effect by primary key.
+            for row in conn.execute(
+                f"SELECT {columns} FROM lp_accounting_effects WHERE position_key=?",
+                (self.position_key,),
+            ):
+                event_id = int(row[0])
+                desired = desired_effects.get(event_id)
+                if desired is None:
+                    stale_effects.append(event_id)
+                    if row[5]:
+                        self._affected_txs.add(str(row[5]))
+                    if row[2]:
+                        self._changed_episodes.add(str(row[2]))
+                    continue
+                remaining_ids.discard(event_id)
+                if tuple(row) != desired:
+                    changed_effects.append(event_id)
+                    if row[5]:
+                        self._affected_txs.add(str(row[5]))
+                    if row[2] and row[2] != desired[2]:
+                        self._changed_episodes.add(str(row[2]))
+                    if desired[5]:
+                        self._affected_txs.add(str(desired[5]))
+            # A newly mapped event may still belong to another position.
+            # Preserve that prior transaction's attribution when moving it.
+            for batch in _batches(sorted(remaining_ids)):
+                marks = ",".join("?" for _ in batch)
+                existing = {
+                    int(row[0]): tuple(row) for row in conn.execute(
+                        f"SELECT {columns} FROM lp_accounting_effects "
+                        f"WHERE event_id IN ({marks})", batch,
+                    )
+                }
+                for event_id in batch:
+                    desired = desired_effects[event_id]
+                    prior = existing.get(event_id)
+                    if prior == desired:
+                        continue
+                    changed_effects.append(event_id)
+                    if prior is not None and prior[5]:
+                        self._affected_txs.add(str(prior[5]))
+                    if prior is not None and prior[2] and prior[2] != desired[2]:
+                        self._changed_episodes.add(str(prior[2]))
+                    if desired[5]:
+                        self._affected_txs.add(str(desired[5]))
         deletes["effects"] = [(event_id,) for event_id in sorted(stale_effects)]
         changed["effects"] = [
             desired_effects[event_id] for event_id in sorted(changed_effects)
         ]
-        if desired_effects:
+        if desired_effects and not self._append_only:
             # Receipt or price enrichment can change gas without changing any
             # LP effect. Retain those dependencies instead of waiting for a
             # later liquidity action to refresh transaction attribution.
@@ -1034,6 +1092,7 @@ class AccountBook:
         revision: int | None = None,
         epoch: int | None = None,
         hinted: bool = False,
+        append_only: Mapping[str, bool] | None = None,
     ) -> None:
         if not priorities:
             self._finish_if_idle(conn)
@@ -1046,9 +1105,11 @@ class AccountBook:
             self._store_metadata_int(conn, "epoch")
             if epoch is None else int(epoch)
         )
+        append_proofs = append_only or {}
         rows = [
             (
-                key, 0, requested_revision, requested_epoch,
+                key, 0, int(append_proofs.get(key, False)),
+                requested_revision, requested_epoch,
                 int(order[0]), int(order[1]), int(order[2]),
                 int(hinted), 0,
             )
@@ -1057,15 +1118,19 @@ class AccountBook:
         before = conn.total_changes
         conn.executemany(
             "INSERT OR IGNORE INTO lp_accounting_pending("
-            "position_key,generation,requested_revision,requested_epoch,"
+            "position_key,generation,append_only,"
+            "requested_revision,requested_epoch,"
             "priority_block,priority_tx_index,priority_log_index,"
             "identities_ready,identity_cursor"
-            ") VALUES(?,?,?,?,?,?,?,?,?)",
+            ") VALUES(?,?,?,?,?,?,?,?,?,?)",
             rows,
         )
         inserted = conn.total_changes - before
+        # Any uncertain requeue invalidates the proof until the guarded
+        # publication fulfills and deletes this pending row.
         conn.executemany(
             "UPDATE lp_accounting_pending SET generation=generation+1,"
+            "append_only=append_only AND ?,"
             "requested_revision=MAX(requested_revision,?),requested_epoch=?,"
             "priority_block=MAX(priority_block,?),"
             "priority_tx_index=MAX(priority_tx_index,?),"
@@ -1075,6 +1140,7 @@ class AccountBook:
             "WHERE position_key=?",
             (
                 (
+                    int(append_proofs.get(key, False)),
                     requested_revision, requested_epoch,
                     int(order[0]), int(order[1]), int(order[2]),
                     int(hinted), int(hinted), key,
@@ -1464,13 +1530,35 @@ class AccountBook:
     def _prepare_pending(self, position_key: str) -> _PreparedProjection | None:
         with self._reader() as conn:
             pending = conn.execute(
-                "SELECT generation FROM lp_accounting_pending "
+                "SELECT generation,append_only FROM lp_accounting_pending "
                 "WHERE position_key=?",
                 (position_key,),
             ).fetchone()
             if pending is None:
                 return None
             epoch = self._store_metadata_int(conn, "epoch")
+            # Missing effects identify unprojected events. _append_position
+            # still verifies the persisted state schema and block boundary.
+            if bool(pending["append_only"]):
+                event_ids = [
+                    int(row[0]) for row in conn.execute(
+                        "SELECT k.event_id FROM lp_accounting_event_keys k "
+                        "LEFT JOIN lp_accounting_effects x "
+                        "ON x.event_id=k.event_id "
+                        "WHERE k.position_key=? AND x.event_id IS NULL "
+                        "ORDER BY k.event_id",
+                        (position_key,),
+                    )
+                ]
+                writes = _ReplayWrites(position_key, append_only=True)
+                if self._append_position(
+                    conn, position_key, event_ids,
+                    refresh_values=False, writes=writes, flush_writes=False,
+                ):
+                    writes.prepare(conn)
+                    return _PreparedProjection(
+                        position_key, int(pending["generation"]), epoch, writes,
+                    )
             events = self._event_rows(conn, position_key)
             writes = _ReplayWrites(position_key)
             if events:
@@ -1881,6 +1969,7 @@ class AccountBook:
             if event.get("id") is not None
         ]
         old_mapping: dict[int, str] = {}
+        projected_ids: set[int] = set()
         affected_txs: set[str] = set()
         for batch in _batches(ids):
             marks = ",".join("?" for _ in batch)
@@ -1893,6 +1982,14 @@ class AccountBook:
                     batch,
                 ).fetchall()
             })
+            if self.deferred:
+                projected_ids.update(
+                    int(row[0]) for row in conn.execute(
+                        "SELECT event_id FROM lp_accounting_effects "
+                        f"WHERE event_id IN ({marks})",
+                        batch,
+                    )
+                )
             if not self.deferred:
                 affected_txs.update(str(row[0]) for row in conn.execute(
                     "SELECT DISTINCT tx_hash FROM lp_accounting_effects "
@@ -1944,6 +2041,7 @@ class AccountBook:
         inventory_pools.update(pool for pool in legacy_positions.values() if pool)
         if self.deferred:
             priorities: dict[str, tuple[int, int, int]] = {}
+            append_proofs: dict[str, bool] = {}
             identity_hints: dict[
                 tuple[str, str, str, str, str], int
             ] = {}
@@ -1952,16 +2050,25 @@ class AccountBook:
                     continue
                 event_id = int(event["id"])
                 order = _order(event)[:3]
+                new_key = self._event_position_key(event)
                 event_keys = {
                     key for key in (
                         old_mapping.get(event_id),
-                        self._event_position_key(event),
+                        new_key,
                     )
                     if key
                 }
                 for key in event_keys:
                     priorities[key] = max(
                         priorities.get(key, order), order,
+                    )
+                    # An existing mapping or effect means same-order source
+                    # facts may have changed, so only a full replay is safe.
+                    append_proofs[key] = (
+                        append_proofs.get(key, True)
+                        and event_id not in old_mapping
+                        and event_id not in projected_ids
+                        and key == new_key
                     )
                     self._add_event_identity_hints(
                         identity_hints, key, event,
@@ -1979,7 +2086,12 @@ class AccountBook:
                         batch,
                     ).fetchall()
                 )
-            self._queue_position_keys(conn, priorities, hinted=True)
+            for key in legacy_positions:
+                if key in append_proofs:
+                    append_proofs[key] = False
+            self._queue_position_keys(
+                conn, priorities, hinted=True, append_only=append_proofs,
+            )
             if unqueued_legacy := legacy_positions.keys() - priorities.keys():
                 latest = max(_order(event)[:3] for event in events)
                 self._queue_position_keys(
@@ -2295,6 +2407,8 @@ class AccountBook:
         self, conn: sqlite3.Connection, key: str, event_ids: Sequence[int], *,
         refresh_values: bool = True,
         position: Mapping[str, Any] | None | object = _MISSING,
+        writes: _ReplayWrites | None = None,
+        flush_writes: bool = True,
     ) -> bool:
         if not event_ids:
             return False
@@ -2304,14 +2418,19 @@ class AccountBook:
             ))
         if not isinstance(position, Mapping):
             return False
-        marks = ",".join("?" for _ in event_ids)
-        if conn.execute(
-            f"SELECT 1 FROM lp_accounting_effects WHERE event_id IN ({marks}) LIMIT 1",
-            list(event_ids),).fetchone() is not None:
-            return False
-        events = self._event_rows(conn, key, event_ids)
+        events: list[dict[str, Any]] = []
+        for batch in _batches(event_ids):
+            marks = ",".join("?" for _ in batch)
+            if conn.execute(
+                "SELECT 1 FROM lp_accounting_effects "
+                f"WHERE event_id IN ({marks}) LIMIT 1",
+                batch,
+            ).fetchone() is not None:
+                return False
+            events.extend(self._event_rows(conn, key, batch))
         if len(events) != len(event_ids):
             return False
+        events.sort(key=_order)
         last = (int(position["last_block"]), int(position["last_tx_index"]),
                 int(position["last_log_index"]), -1)
         # Pinned before/after snapshots are block-boundary reads.  A second
@@ -2323,7 +2442,10 @@ class AccountBook:
         state = _json(position.get("state_json"))
         if not state or state.get("version") != _SCHEMA_VERSION:
             return False
-        self._derive(conn, key, events, state, refresh_values=refresh_values)
+        self._derive(
+            conn, key, events, state, refresh_values=refresh_values,
+            writes=writes, flush_writes=flush_writes,
+        )
         return True
 
     def _rebuild_position(
@@ -3949,6 +4071,8 @@ class AccountBook:
         # spans several episodes belonging to that owner. Retain the existing
         # per-owner missing-cost short circuit for exactly those uncertain
         # owners; only owners which pass it pay for the de-duplicated sum.
+        # Exact transactions within an uncertain owner's total still have
+        # direct episode attribution; only shared costs need an effects probe.
         uncertain = [owner for owner in selected if owner not in complete]
         for batch in _batches(uncertain, 400):
             values = ",".join("(?)" for _ in batch)
@@ -3967,14 +4091,19 @@ class AccountBook:
                 " AND c.gas_usd IS NULL) THEN NULL ELSE ("
                 "SELECT SUM(c.gas_usd) FROM lp_accounting_tx_costs c "
                 "INDEXED BY lp_accounting_tx_costs_owner "
-                "WHERE c.owner=selected.owner AND EXISTS ("
+                "WHERE c.owner=selected.owner AND CASE "
+                "WHEN c.episode_id IS NOT NULL THEN EXISTS ("
+                "SELECT 1 FROM lp_accounting_episodes ep "
+                "LEFT JOIN pools p ON p.id=ep.pool_id "
+                "WHERE ep.id=c.episode_id AND ep.owner=selected.owner AND "
+                + predicate + ") ELSE EXISTS ("
                 "SELECT 1 FROM lp_accounting_effects fx "
                 "INDEXED BY lp_accounting_effects_tx "
                 "JOIN lp_accounting_episodes ep ON ep.id=fx.episode_id "
                 "LEFT JOIN pools p ON p.id=ep.pool_id "
                 "WHERE fx.tx_hash=c.tx_hash AND ep.owner=selected.owner AND "
-                + predicate + ")) END AS gas_usd FROM selected",
-                [*batch, *args, *args],
+                + predicate + ") END) END AS gas_usd FROM selected",
+                [*batch, *args, *args, *args],
             )
             for row in rows:
                 result[str(row["owner"])] = row["gas_usd"]

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -3690,13 +3690,20 @@ class AccountBook:
             " WHERE " + " AND ".join(event_clauses)
             if event_clauses else ""
         )
-        through = conn.execute(
-            "SELECT e.block_number,e.tx_index,e.log_index,e.timestamp "
-            "FROM events e" + event_where
-            + " ORDER BY e.block_number DESC,e.tx_index DESC,"
-            "e.log_index DESC LIMIT 1",
-            event_args,
-        ).fetchone()
+        through = None
+        # A window lookup must not sort the entire recent ledger to find its
+        # newest event. Check empty scopes before walking the ordered index.
+        if not event_clauses or conn.execute(
+            "SELECT 1 FROM events e" + event_where + " LIMIT 1", event_args,
+        ).fetchone() is not None:
+            order_index = "" if pool_id else " INDEXED BY events_block_idx"
+            through = conn.execute(
+                "SELECT e.block_number,e.tx_index,e.log_index,e.timestamp "
+                "FROM events e" + order_index + event_where
+                + " ORDER BY e.block_number DESC,e.tx_index DESC,"
+                "e.log_index DESC LIMIT 1",
+                event_args,
+            ).fetchone()
         through_order = (
             {
                 "block_number": int(through["block_number"]),

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -35,7 +35,10 @@ _POOL_RESULT_CACHE_ENTRIES = 512
 _IDENTITY_BOOTSTRAP_EVENTS = 4096
 _IDENTITY_BOOTSTRAP_KEYS = 256
 _IDENTITY_BOOTSTRAP_PAGE = 256
+_PENDING_PREPARATION_SECONDS = 0.2
 _PENDING_PUBLICATION_SECONDS = 0.2
+_POSITION_INTEREST_LIMIT = 2048
+_POSITION_INTEREST_SECONDS = 180.0
 
 
 class _PoolInventory(NamedTuple):
@@ -128,6 +131,9 @@ CREATE INDEX IF NOT EXISTS lp_accounting_positions_active_inventory
         pool_id,owner,custody,protocol,liquidity,liquidity_known,
         tick_lower,tick_upper,principal_usd,history_complete
     ) WHERE active_episode_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS lp_accounting_positions_owner_active_key
+    ON lp_accounting_positions(owner,position_key)
+    WHERE active_episode_id IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS lp_accounting_episodes (
     id TEXT PRIMARY KEY,
@@ -199,6 +205,8 @@ CREATE INDEX IF NOT EXISTS lp_accounting_episodes_closed_order
         closed_at DESC, opened_block DESC,
         opened_tx_index DESC, opened_log_index DESC
     ) WHERE closed_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS lp_accounting_episodes_owner_position
+    ON lp_accounting_episodes(owner,position_key);
 
 CREATE TABLE IF NOT EXISTS lp_accounting_effects (
     event_id INTEGER PRIMARY KEY,
@@ -233,6 +241,27 @@ CREATE INDEX IF NOT EXISTS lp_accounting_effects_episode
     ON lp_accounting_effects(episode_id, tx_hash);
 CREATE INDEX IF NOT EXISTS lp_accounting_effects_tx
     ON lp_accounting_effects(tx_hash, episode_id);
+CREATE TABLE IF NOT EXISTS lp_accounting_claims (
+    position_key TEXT PRIMARY KEY,
+    epoch INTEGER NOT NULL,
+    block_number INTEGER NOT NULL,
+    block_hash TEXT NOT NULL,
+    timestamp INTEGER NOT NULL,
+    position_last_block INTEGER NOT NULL,
+    position_last_tx_index INTEGER NOT NULL,
+    position_last_log_index INTEGER NOT NULL,
+    liquidity TEXT NOT NULL,
+    sqrt_price_x96 TEXT NOT NULL,
+    tick INTEGER NOT NULL,
+    price0_usd REAL,
+    price1_usd REAL,
+    claim0 TEXT NOT NULL,
+    claim1 TEXT NOT NULL,
+    position_state_json TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS lp_accounting_claims_block
+    ON lp_accounting_claims(block_number);
+
 
 CREATE TABLE IF NOT EXISTS lp_accounting_tx_costs (
     tx_hash TEXT PRIMARY KEY,
@@ -270,13 +299,12 @@ CREATE TABLE IF NOT EXISTS lp_accounting_meta (
 """
 
 _EVENT_COLUMNS = (
-    "id", "block_number", "block_hash", "tx_hash", "tx_index", "log_index",
-    "timestamp", "pool_id", "protocol", "kind", "owner", "custody",
-    "position_key", "token_id", "tick_lower", "tick_upper", "liquidity_delta",
-    "liquidity", "sqrt_price_x96", "tick", "fee_ppm", "amount0", "amount1",
+    "id", "block_number", "tx_hash", "tx_index", "log_index", "timestamp",
+    "pool_id", "protocol", "kind", "owner", "custody", "token_id",
+    "tick_lower", "tick_upper", "liquidity_delta", "amount0", "amount1",
     "fee_amount0", "fee_amount1", "cashflow0", "cashflow1", "price0_usd",
-    "price1_usd", "volume_usd", "fees_usd", "deposit_usd", "withdrawal_usd",
-    "pricing_basis", "accounting_basis", "identity_basis", "data", "revision",
+    "price1_usd", "fees_usd", "deposit_usd", "withdrawal_usd",
+    "accounting_basis", "identity_basis", "data",
 )
 _EVENT_SELECT = ",".join(f"e.{name}" for name in _EVENT_COLUMNS)
 _EFFECT_COLUMNS = (
@@ -471,6 +499,13 @@ class _PreparedProjection(NamedTuple):
     epoch: int
     writes: _ReplayWrites
 
+class _PublishedProjection(NamedTuple):
+    position_key: str
+    pool_ids: set[str]
+    tx_hashes: set[str]
+    episode_ids: set[str]
+
+
 class _PreparedIdentityHints(NamedTuple):
     position_key: str
     cursor: int
@@ -641,6 +676,8 @@ class AccountBook:
         self._installed = False
         self._projection_lock = threading.Lock()
         self._cache_lock = threading.RLock()
+        self._priority_lock = threading.Lock()
+        self._priority_positions: OrderedDict[str, float] = OrderedDict()
         self._pool_cache: OrderedDict[tuple[Any, ...], dict[str, Any]] = OrderedDict()
         self._pool_inventory_cache: OrderedDict[
             str, tuple[int, _PoolInventory]
@@ -700,6 +737,16 @@ class AccountBook:
             if self._installed:
                 return self
             self.store.connection.executescript(_SCHEMA)
+            claim_columns = {
+                row[1] for row in self.store.connection.execute(
+                    "PRAGMA table_info(lp_accounting_claims)"
+                )
+            }
+            if "position_state_json" not in claim_columns:
+                self.store.connection.execute(
+                    "ALTER TABLE lp_accounting_claims ADD COLUMN "
+                    "position_state_json TEXT NOT NULL DEFAULT ''"
+                )
             with self.store.transaction() as conn:
                 self.store._install_accounting_pending_identities(conn)
                 prior = {
@@ -1212,28 +1259,99 @@ class AccountBook:
         self._publish_pending_identity_hints(prepared)
         return True
 
+    def prioritize_positions(self, position_keys: Iterable[str]) -> None:
+        """Temporarily reserve replay capacity for requested wallet positions."""
+        keys: OrderedDict[str, None] = OrderedDict()
+        for value in position_keys:
+            position_key = str(value).strip().lower()
+            if not position_key:
+                continue
+            keys[position_key] = None
+            keys.move_to_end(position_key)
+            if len(keys) > _POSITION_INTEREST_LIMIT:
+                keys.popitem(last=False)
+        if not keys:
+            return
+        now = time.monotonic()
+        deadline = now + _POSITION_INTEREST_SECONDS
+        with self._priority_lock:
+            while self._priority_positions:
+                _key, expires_at = next(iter(self._priority_positions.items()))
+                if expires_at > now:
+                    break
+                self._priority_positions.popitem(last=False)
+            for position_key in keys:
+                self._priority_positions[position_key] = deadline
+                self._priority_positions.move_to_end(position_key)
+            while len(self._priority_positions) > _POSITION_INTEREST_LIMIT:
+                self._priority_positions.popitem(last=False)
+
     def _pending_rows(self, limit: int) -> list[dict[str, Any]]:
         historical = max(1, limit // 4)
-        recent = max(0, limit - historical)
+        requested_capacity = min(
+            max(0, limit - historical), max(1, limit // 4),
+        )
+        now = time.monotonic()
+        with self._priority_lock:
+            while self._priority_positions:
+                _key, expires_at = next(iter(self._priority_positions.items()))
+                if expires_at > now:
+                    break
+                self._priority_positions.popitem(last=False)
+            interests = dict(self._priority_positions)
+
         conn = self.store.read()
-        selected: list[dict[str, Any]] = []
-        if recent:
-            selected.extend(_dict_rows(conn.execute(
+        interested_pending: dict[str, dict[str, Any]] = {}
+        for batch in _batches(list(interests)):
+            marks = ",".join("?" for _ in batch)
+            interested_pending.update({
+                str(row["position_key"]): row
+                for row in _dict_rows(conn.execute(
+                    "SELECT * FROM lp_accounting_pending "
+                    f"WHERE position_key IN ({marks})",
+                    batch,
+                ))
+            })
+        absent = interests.keys() - interested_pending.keys()
+        if absent:
+            with self._priority_lock:
+                for position_key in absent:
+                    if self._priority_positions.get(position_key) == interests[position_key]:
+                        self._priority_positions.pop(position_key, None)
+
+        selected = [
+            interested_pending[position_key]
+            for position_key in reversed(interests)
+            if position_key in interested_pending
+        ][:requested_capacity]
+        seen = {str(row["position_key"]) for row in selected}
+        recent_capacity = max(0, limit - historical - len(selected))
+        if recent_capacity:
+            recent = _dict_rows(conn.execute(
                 "SELECT * FROM lp_accounting_pending "
                 "ORDER BY priority_block DESC,priority_tx_index DESC,"
                 "priority_log_index DESC,id DESC LIMIT ?",
-                (recent,),
-            )))
-        seen = {str(row["position_key"]) for row in selected}
+                (recent_capacity + len(seen),),
+            ))
+            for row in recent:
+                position_key = str(row["position_key"])
+                if position_key not in seen:
+                    selected.append(row)
+                    seen.add(position_key)
+                    if len(selected) >= limit - historical:
+                        break
         oldest = _dict_rows(conn.execute(
             "SELECT * FROM lp_accounting_pending ORDER BY id LIMIT ?",
             (historical + len(seen),),
         ))
-        selected.extend(
-            row for row in oldest
-            if str(row["position_key"]) not in seen
-        )
-        return selected[:limit]
+        for row in oldest:
+            position_key = str(row["position_key"])
+            if position_key not in seen:
+                selected.append(row)
+                seen.add(position_key)
+                if len(selected) >= limit:
+                    break
+        return selected
 
     def _prepare_pending(self, position_key: str) -> _PreparedProjection | None:
         with self._reader() as conn:
@@ -1261,16 +1379,16 @@ class AccountBook:
     def _publish_pending(
             self, conn: sqlite3.Connection,
             prepared: _PreparedProjection,
-    ) -> bool:
+    ) -> _PublishedProjection | None:
         if self._store_metadata_int(conn, "epoch") != prepared.epoch:
-            return False
+            return None
         pending = conn.execute(
             "SELECT generation FROM lp_accounting_pending "
             "WHERE position_key=?",
             (prepared.position_key,),
         ).fetchone()
         if pending is None:
-            return False
+            return None
         # Projection publication is serialized. Same-epoch event changes
         # therefore cannot race a newer accounting publish: commit this
         # coherent older snapshot, and let the generation-guarded delete
@@ -1292,11 +1410,6 @@ class AccountBook:
                 (prepared.position_key,),
             ).fetchall()
         )
-        self._refresh_position_values(conn, [prepared.position_key])
-        self._rebuild_tx_costs(conn, affected_txs)
-        self._refresh_episode_costs(
-            conn, affected_txs, episode_ids=changed_episodes,
-        )
         removed = conn.execute(
             "DELETE FROM lp_accounting_pending "
             "WHERE position_key=? AND generation=?",
@@ -1304,9 +1417,10 @@ class AccountBook:
         ).rowcount
         if removed:
             self.store._bump(conn, "pending_accounting", -removed)
-        self._finish_if_idle(conn)
-        self._invalidate_cache(conn, affected_pools)
-        return True
+        return _PublishedProjection(
+            prepared.position_key, affected_pools,
+            affected_txs, changed_episodes,
+        )
 
     def project_pending(self, limit: int = 128) -> bool:
         """Prepare bounded queued histories off-writer, then publish atomically."""
@@ -1318,29 +1432,267 @@ class AccountBook:
             pending = self._pending_rows(bounded)
             if pending:
                 worked = True
-            prepared_batch = []
-            for row in pending:
-                prepared = self._prepare_pending(str(row["position_key"]))
-                if prepared is not None:
-                    prepared_batch.append(prepared)
-            published = 0
-            while published < len(prepared_batch):
+            cursor = 0
+            while cursor < len(pending):
+                prepared_batch: list[_PreparedProjection] = []
+                started_at = time.monotonic()
+                while (
+                    cursor < len(pending)
+                    and (
+                        not prepared_batch
+                        or time.monotonic() - started_at
+                        < _PENDING_PREPARATION_SECONDS
+                    )
+                ):
+                    row = pending[cursor]
+                    cursor += 1
+                    prepared = self._prepare_pending(
+                        str(row["position_key"]),
+                    )
+                    if prepared is not None:
+                        prepared_batch.append(prepared)
+                if not prepared_batch:
+                    continue
                 with self.store.transaction() as conn:
-                    acquired_at = time.monotonic()
-                    first = published
-                    while (
-                        published < len(prepared_batch)
-                        and (
-                            published == first
-                            or time.monotonic() - acquired_at
-                            < _PENDING_PUBLICATION_SECONDS
+                    position_keys: set[str] = set()
+                    affected_pools: set[str] = set()
+                    affected_txs: set[str] = set()
+                    changed_episodes: set[str] = set()
+                    for prepared in prepared_batch:
+                        changes = self._publish_pending(conn, prepared)
+                        if changes is None:
+                            continue
+                        position_keys.add(changes.position_key)
+                        affected_pools.update(changes.pool_ids)
+                        affected_txs.update(changes.tx_hashes)
+                        changed_episodes.update(changes.episode_ids)
+                    if position_keys:
+                        self._refresh_position_values(
+                            conn, sorted(position_keys),
                         )
-                    ):
-                        self._publish_pending(
-                            conn, prepared_batch[published],
+                        self._rebuild_tx_costs(conn, affected_txs)
+                        self._refresh_episode_costs(
+                            conn, affected_txs,
+                            episode_ids=changed_episodes,
                         )
-                        published += 1
+                        self._finish_if_idle(conn)
+                        self._invalidate_cache(conn, affected_pools)
             return worked
+
+    def publish_claims(self, rows: Sequence[Mapping[str, Any]]) -> bool:
+        """Publish canonical pinned claims and their dependent valuations."""
+        candidates: dict[str, tuple[Any, ...]] = {}
+        for source in rows:
+            position_key = str(source.get("position_key") or "").strip().lower()
+            epoch = _raw_int(source.get("epoch"))
+            block_number = _raw_int(source.get("block_number"))
+            timestamp = _raw_int(source.get("timestamp"))
+            position_last_block = _raw_int(source.get("position_last_block"))
+            position_last_tx_index = _raw_int(source.get("position_last_tx_index"))
+            position_last_log_index = _raw_int(source.get("position_last_log_index"))
+            position_pending0 = _raw_int(
+                source.get("position_pending_principal0"),
+            )
+            position_pending1 = _raw_int(
+                source.get("position_pending_principal1"),
+            )
+            position_pending_known = _raw_int(
+                source.get("position_pending_known"),
+            )
+            liquidity = _raw_int(source.get("liquidity"))
+            sqrt_price_x96 = _raw_int(source.get("sqrt_price_x96"))
+            tick = _raw_int(source.get("tick"))
+            claim0 = _raw_int(source.get("claim0"))
+            claim1 = _raw_int(source.get("claim1"))
+            block_hash = str(source.get("block_hash") or "").strip().lower()
+            price0 = _finite_float(source.get("price0_usd"))
+            price1 = _finite_float(source.get("price1_usd"))
+            if (
+                not position_key
+                or not block_hash
+                or None in (
+                    epoch, block_number, timestamp,
+                    position_last_block, position_last_tx_index,
+                    position_last_log_index, liquidity,
+                    sqrt_price_x96, tick, claim0, claim1,
+                )
+                or position_pending_known not in (0, 1)
+                or (
+                    position_pending_known == 1
+                    and (position_pending0 is None or position_pending1 is None)
+                )
+                or (
+                    source.get("position_pending_principal0") is not None
+                    and position_pending0 is None
+                )
+                or (
+                    source.get("position_pending_principal1") is not None
+                    and position_pending1 is None
+                )
+                or (position_pending0 is not None and position_pending0 < 0)
+                or (position_pending1 is not None and position_pending1 < 0)
+                or block_number < 0
+                or timestamp < 0
+                or position_last_block < 0
+                or position_last_tx_index < 0
+                or position_last_log_index < 0
+                or liquidity < 0
+                or sqrt_price_x96 <= 0
+                or claim0 < 0
+                or claim1 < 0
+                or (
+                    source.get("price0_usd") is not None
+                    and price0 is None
+                )
+                or (
+                    source.get("price1_usd") is not None
+                    and price1 is None
+                )
+            ):
+                continue
+            candidate = (
+                position_key, epoch, block_number, block_hash, timestamp,
+                position_last_block, position_last_tx_index,
+                position_last_log_index, str(liquidity),
+                str(sqrt_price_x96), tick, price0, price1,
+                str(claim0), str(claim1), position_pending_known,
+                (
+                    None if position_pending0 is None
+                    else str(position_pending0)
+                ),
+                (
+                    None if position_pending1 is None
+                    else str(position_pending1)
+                ),
+                str(source.get("position_state_json") or ""),
+            )
+            prior = candidates.get(position_key)
+            if prior is None or (block_number, timestamp) >= (
+                int(prior[2]), int(prior[4]),
+            ):
+                candidates[position_key] = candidate
+        if not candidates:
+            return False
+
+        with self._projection_lock:
+            with self.store.transaction() as conn:
+                current_epoch = self._store_metadata_int(conn, "epoch")
+                positions: dict[str, dict[str, Any]] = {}
+                existing_claims: dict[str, dict[str, Any]] = {}
+                for batch in _batches(sorted(candidates)):
+                    marks = ",".join("?" for _ in batch)
+                    positions.update({
+                        str(row["position_key"]): row
+                        for row in _dict_rows(conn.execute(
+                            "SELECT p.position_key,p.pool_id,p.protocol,"
+                            "p.active_episode_id,p.last_block,p.last_tx_index,"
+                            "p.last_log_index,p.liquidity,p.liquidity_known,"
+                            "p.pending_principal0,p.pending_principal1,p.pending_known,p.state_json,"
+                            "q.position_key AS pending_position "
+                            "FROM lp_accounting_positions p "
+                            "LEFT JOIN lp_accounting_pending q "
+                            "ON q.position_key=p.position_key "
+                            f"WHERE p.position_key IN ({marks})",
+                            batch,
+                        ))
+                    })
+                    existing_claims.update({
+                        str(row["position_key"]): row
+                        for row in _dict_rows(conn.execute(
+                            "SELECT * FROM lp_accounting_claims "
+                            f"WHERE position_key IN ({marks})",
+                            batch,
+                        ))
+                    })
+                block_numbers = sorted({
+                    int(candidate[2]) for candidate in candidates.values()
+                })
+                blocks: dict[int, dict[str, Any]] = {}
+                for batch in _batches(block_numbers):
+                    marks = ",".join("?" for _ in batch)
+                    blocks.update({
+                        int(row["number"]): row
+                        for row in _dict_rows(conn.execute(
+                            "SELECT number,hash,timestamp FROM blocks "
+                            f"WHERE number IN ({marks})",
+                            batch,
+                        ))
+                    })
+
+                accepted: list[tuple[Any, ...]] = []
+                affected_pools: set[str] = set()
+                claim_columns = (
+                    "position_key", "epoch", "block_number", "block_hash",
+                    "timestamp", "position_last_block",
+                    "position_last_tx_index", "position_last_log_index",
+                    "liquidity", "sqrt_price_x96", "tick",
+                    "price0_usd", "price1_usd", "claim0", "claim1",
+                    "position_state_json",
+                )
+                for position_key, candidate in candidates.items():
+                    position = positions.get(position_key)
+                    block = blocks.get(int(candidate[2]))
+                    if (
+                        int(candidate[1]) != current_epoch
+                        or position is None
+                        or position.get("pending_position") is not None
+                        or position.get("active_episode_id") is None
+                        or str(position.get("protocol") or "") not in ("v3", "v4")
+                        or not position.get("liquidity_known")
+                        or _raw_int(position.get("liquidity")) != int(candidate[8])
+                        or _raw_int(position.get("last_block")) != int(candidate[5])
+                        or _raw_int(position.get("last_tx_index")) != int(candidate[6])
+                        or _raw_int(position.get("last_log_index")) != int(candidate[7])
+                        or _raw_int(position.get("pending_known")) != int(candidate[15])
+                        or (
+                            _raw_int(position.get("pending_principal0"))
+                            != _raw_int(candidate[16])
+                        )
+                        or (
+                            _raw_int(position.get("pending_principal1"))
+                            != _raw_int(candidate[17])
+                        )
+                        or position.get("state_json") != candidate[18]
+                        or int(candidate[2]) < int(candidate[5])
+                        or block is None
+                        or str(block.get("hash") or "").lower() != candidate[3]
+                        or _raw_int(block.get("timestamp")) != int(candidate[4])
+                    ):
+                        continue
+                    existing = existing_claims.get(position_key)
+                    if existing is not None:
+                        if (
+                            _raw_int(existing.get("epoch")) == current_epoch
+                            and _raw_int(existing.get("block_number")) is not None
+                            and _raw_int(existing.get("block_number")) > int(candidate[2])
+                        ):
+                            continue
+                        if tuple(
+                            existing.get(column) for column in claim_columns
+                        ) == candidate[:15] + candidate[18:]:
+                            continue
+                    accepted.append(candidate[:15] + candidate[18:])
+                    pool_id = position.get("pool_id")
+                    if pool_id:
+                        affected_pools.add(str(pool_id).lower())
+                if not accepted:
+                    return False
+                conn.executemany(
+                    "INSERT INTO lp_accounting_claims("
+                    + ",".join(claim_columns)
+                    + ") VALUES(" + ",".join("?" for _ in claim_columns) + ") "
+                    "ON CONFLICT(position_key) DO UPDATE SET "
+                    + ",".join(
+                        f"{column}=excluded.{column}"
+                        for column in claim_columns[1:]
+                    ),
+                    accepted,
+                )
+                accepted_keys = [str(row[0]) for row in accepted]
+                self._refresh_position_values(conn, accepted_keys)
+                self._refresh_active_episode_values(conn, accepted_keys)
+                self._invalidate_cache(conn, affected_pools)
+                return True
 
     def _apply(
         self, conn: sqlite3.Connection,
@@ -1521,6 +1873,48 @@ class AccountBook:
             conn, inventory_pools, owners=bool(old_keys or new_keys),
         )
 
+    def _invalidate_claims_after_rollback(
+            self, conn: sqlite3.Connection, ancestor: int, next_epoch: int,
+    ) -> tuple[set[str], set[str]]:
+        rows = _dict_rows(conn.execute(
+            "SELECT c.position_key,p.pool_id "
+            "FROM lp_accounting_claims c "
+            "LEFT JOIN lp_accounting_positions p "
+            "ON p.position_key=c.position_key "
+            "WHERE c.block_number>? OR c.epoch<>?",
+            (ancestor, next_epoch),
+        ))
+        position_keys = {str(row["position_key"]) for row in rows}
+        pool_ids = {
+            str(row["pool_id"]).lower()
+            for row in rows if row.get("pool_id") is not None
+        }
+        if not position_keys:
+            return position_keys, pool_ids
+        conn.execute(
+            "DELETE FROM lp_accounting_claims "
+            "WHERE block_number>? OR epoch<>?",
+            (ancestor, next_epoch),
+        )
+        for batch in _batches(sorted(position_keys)):
+            # PriceProjection rolls back later. Its current mark may still be
+            # orphaned, so do not revalue against it inside this callback.
+            marks = ",".join("?" for _ in batch)
+            conn.execute(
+                "UPDATE lp_accounting_positions SET principal0=NULL,principal1=NULL,"
+                "principal_usd=NULL,uncollected_fees_usd=NULL,equity_usd=NULL,"
+                "valuation_block=NULL,valuation_timestamp=NULL,valuation_basis='unknown' "
+                f"WHERE position_key IN ({marks})", batch,
+            )
+            conn.execute(
+                "UPDATE lp_accounting_episodes SET current_equity_usd=NULL,"
+                "lp_value_usd=NULL,hold_value_usd=NULL,lp_vs_hold_usd=NULL,"
+                "gross_pnl_usd=NULL,net_pnl_usd=NULL,return_pct=NULL "
+                "WHERE id IN (SELECT active_episode_id FROM lp_accounting_positions "
+                f"WHERE position_key IN ({marks}))", batch,
+            )
+        return position_keys, pool_ids
+
     def _rollback(self, conn: sqlite3.Connection, ancestor_number: int) -> None:
         ancestor = int(ancestor_number)
         if self.deferred:
@@ -1566,8 +1960,14 @@ class AccountBook:
         )
         self._rebuild_tx_costs(conn, txs)
         self._refresh_episode_costs(conn, txs)
-        self._invalidate_cache(conn, affected_pools, owners=bool(keys))
-
+        next_epoch = self._store_metadata_int(conn, "epoch") + 1
+        claim_keys, claim_pools = self._invalidate_claims_after_rollback(
+            conn, ancestor, next_epoch,
+        )
+        affected_pools.update(claim_pools)
+        self._invalidate_cache(
+            conn, affected_pools, owners=bool(keys or claim_keys),
+        )
         conn.execute(
             "INSERT INTO lp_accounting_meta(key,value) VALUES('dirty','1') "
             "ON CONFLICT(key) DO UPDATE SET value=excluded.value"
@@ -1650,8 +2050,12 @@ class AccountBook:
             )
         if not keys:
             self._finish_if_idle(conn, epoch=next_epoch)
+        claim_keys, claim_pools = self._invalidate_claims_after_rollback(
+            conn, ancestor, next_epoch,
+        )
+        affected_pools.update(claim_pools)
         self._invalidate_cache(
-            conn, affected_pools, owners=bool(keys),
+            conn, affected_pools, owners=bool(keys or claim_keys),
         )
 
     def _invalidate_cache(
@@ -1787,24 +2191,24 @@ class AccountBook:
 
     def _derive(
         self, conn: sqlite3.Connection, key: str,
-        events: Sequence[Mapping[str, Any]], state: dict[str, Any] | None,
+        events: Sequence[dict[str, Any]], state: dict[str, Any] | None,
         *, refresh_values: bool = True,
         writes: _ReplayWrites | None = None,
         flush_writes: bool = True,
     ) -> tuple[set[str], set[str]]:
-        if state is None:
-            state = self._new_state(key, events[0])
         pool_cache: dict[str, dict[str, Any]] = {}
         state_events: dict[int, list[int]] = defaultdict(list)
         prepared_events: list[dict[str, Any]] = []
         for index, source_event in enumerate(events):
-            event = dict(source_event)
+            event = source_event
             data = _json(event.get("data"))
             event["data"] = data
             prepared_events.append(event)
             if (_event_position_state(data, "before") is not None
                     or _event_position_state(data, "after") is not None):
                 state_events[int(event.get("block_number") or 0)].append(index)
+        if state is None:
+            state = self._new_state(key, prepared_events[0])
         # V3 manager transactions emit the pool event before the ERC-721 mint
         # and the final Collect before the ERC-721 burn.  Those verified
         # transfers prove the missing boundary state even though their logs
@@ -2771,7 +3175,7 @@ class AccountBook:
         if not self._table_exists(conn, "lp_pool_state"):
             return {}
         clauses = ["p.active_episode_id IS NOT NULL"]
-        args: list[Any] = []
+        args: list[Any] = [self._store_metadata_int(conn, "epoch")]
         if position_key is not None:
             clauses.append("p.position_key=?")
             args.append(position_key)
@@ -2786,11 +3190,28 @@ class AccountBook:
             "SELECT p.position_key,p.protocol,p.liquidity,p.liquidity_known,"
             "p.tick_lower,p.tick_upper,p.pending_principal0,p.pending_principal1,"
             "p.pending_known,p.tokens_owed0,p.tokens_owed1,p.owed_known,"
-            "s.block_number AS mark_block,s.timestamp AS mark_timestamp,"
-            "s.sqrt_price_x96 AS mark_sqrt,s.tick AS mark_tick,"
-            "s.price0_usd AS mark_price0,s.price1_usd AS mark_price1,"
+            "CASE WHEN c.position_key IS NOT NULL THEN c.block_number "
+            "ELSE s.block_number END AS mark_block,"
+            "CASE WHEN c.position_key IS NOT NULL THEN c.timestamp "
+            "ELSE s.timestamp END AS mark_timestamp,"
+            "CASE WHEN c.position_key IS NOT NULL THEN c.sqrt_price_x96 "
+            "ELSE s.sqrt_price_x96 END AS mark_sqrt,"
+            "CASE WHEN c.position_key IS NOT NULL THEN c.tick "
+            "ELSE s.tick END AS mark_tick,"
+            "CASE WHEN c.position_key IS NOT NULL THEN c.price0_usd "
+            "ELSE s.price0_usd END AS mark_price0,"
+            "CASE WHEN c.position_key IS NOT NULL THEN c.price1_usd "
+            "ELSE s.price1_usd END AS mark_price1,"
+            "c.position_key AS claim_position_key,c.claim0,c.claim1,"
             "m.decimals0,m.decimals1 "
-            "FROM lp_accounting_positions p JOIN lp_pool_state s ON s.pool_id=p.pool_id "
+            "FROM lp_accounting_positions p "
+            "LEFT JOIN lp_pool_state s ON s.pool_id=p.pool_id "
+            "LEFT JOIN lp_accounting_claims c ON c.position_key=p.position_key "
+            "AND c.epoch=? AND c.position_last_block=p.last_block "
+            "AND c.position_last_tx_index=p.last_tx_index "
+            "AND c.position_last_log_index=p.last_log_index "
+            "AND c.liquidity=p.liquidity "
+            "AND c.position_state_json=p.state_json "
             "LEFT JOIN pools m ON m.id=p.pool_id WHERE " + " AND ".join(clauses), args))
         values: dict[str, dict[str, Any]] = {}
         for row in rows:
@@ -2832,20 +3253,52 @@ class AccountBook:
             _raw_int(row.get("decimals0")), _raw_int(row.get("decimals1")),
         )
         result["principal_usd"] = principal
-        result["valuation_basis"] = "pool_current_v3_integer_principal"
+        claim_proven = row.get("claim_position_key") is not None
+        result["valuation_basis"] = (
+            f"pinned_current_claim_{protocol}_integer_principal"
+            if claim_proven else "pool_current_v3_integer_principal"
+        )
         fees: float | None = None
         claim_principal: float | None = None
         pending0 = _raw_int(row.get("pending_principal0"))
         pending1 = _raw_int(row.get("pending_principal1"))
-        if row.get("pending_known") and pending0 is not None and pending1 is not None:
+        pending_known = bool(row.get("pending_known"))
+        if pending_known and pending0 is not None and pending1 is not None:
             claim_principal = _token_value(
                 pending0, pending1, row.get("mark_price0"), row.get("mark_price1"),
                 _raw_int(row.get("decimals0")), _raw_int(row.get("decimals1")),
             )
-        # tokensOwed excludes lazy fee growth while liquidity is active.  It
+        if claim_proven:
+            claim0 = _raw_int(row.get("claim0"))
+            claim1 = _raw_int(row.get("claim1"))
+            if (
+                protocol == "v3"
+                and pending_known
+                and None not in (claim0, claim1, pending0, pending1)
+                and claim0 >= pending0
+                and claim1 >= pending1
+            ):
+                fees = _token_value(
+                    claim0 - pending0, claim1 - pending1,
+                    row.get("mark_price0"), row.get("mark_price1"),
+                    _raw_int(row.get("decimals0")), _raw_int(row.get("decimals1")),
+                )
+            elif (
+                protocol == "v4"
+                and pending_known
+                and pending0 == 0
+                and pending1 == 0
+                and claim0 is not None
+                and claim1 is not None
+            ):
+                fees = _token_value(
+                    claim0, claim1,
+                    row.get("mark_price0"), row.get("mark_price1"),
+                    _raw_int(row.get("decimals0")), _raw_int(row.get("decimals1")),
+                )
+        # tokensOwed excludes lazy fee growth while liquidity is active. It
         # proves the full outstanding claim only after liquidity reaches zero.
-        fee_state_current = liquidity == 0
-        if fee_state_current and row.get("owed_known") and row.get("pending_known"):
+        elif liquidity == 0 and row.get("owed_known") and pending_known:
             owed0, owed1 = _raw_int(row.get("tokens_owed0")), _raw_int(row.get("tokens_owed1"))
             if None not in (owed0, owed1, pending0, pending1):
                 fees = _token_value(
@@ -2950,6 +3403,31 @@ class AccountBook:
             "WHERE id=?",
             (current_equity, lp_value, hold, lp_vs_hold, gross, net, return_pct, episode_id),
         )
+
+    def _refresh_active_episode_values(
+            self, conn: sqlite3.Connection,
+            position_keys: Iterable[str],
+    ) -> None:
+        selected = sorted({str(key) for key in position_keys})
+        for batch in _batches(selected):
+            marks = ",".join("?" for _ in batch)
+            episodes = _dict_rows(conn.execute(
+                "SELECT e.*,p.active_episode_id,m.decimals0,m.decimals1 "
+                "FROM lp_accounting_positions p "
+                "JOIN lp_accounting_episodes e ON e.id=p.active_episode_id "
+                "LEFT JOIN pools m ON m.id=e.pool_id "
+                f"WHERE p.position_key IN ({marks})",
+                batch,
+            ))
+            current_values = self._current_values(
+                conn, position_keys=batch,
+            )
+            for episode in episodes:
+                self._refresh_episode_value(
+                    conn, str(episode["id"]),
+                    current_values=current_values, episode=episode,
+                )
+
 
     def _rebuild_tx_costs(self, conn: sqlite3.Connection,
                           tx_hashes: set[str] | None) -> None:

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -288,6 +288,7 @@ CREATE TABLE IF NOT EXISTS lp_accounting_pending (
     position_key TEXT NOT NULL UNIQUE,
     generation INTEGER NOT NULL,
     append_only INTEGER NOT NULL DEFAULT 0,
+    cost_only INTEGER NOT NULL DEFAULT 0,
     requested_revision INTEGER NOT NULL,
     requested_epoch INTEGER NOT NULL,
     priority_block INTEGER NOT NULL,
@@ -298,6 +299,13 @@ CREATE INDEX IF NOT EXISTS lp_accounting_pending_recent
     ON lp_accounting_pending(
         priority_block DESC,priority_tx_index DESC,priority_log_index DESC,id DESC
     );
+CREATE TABLE IF NOT EXISTS lp_accounting_pending_costs (
+    position_key TEXT NOT NULL
+        REFERENCES lp_accounting_pending(position_key) ON DELETE CASCADE,
+    tx_hash TEXT NOT NULL,
+    PRIMARY KEY(position_key,tx_hash)
+) WITHOUT ROWID;
+
 
 CREATE TABLE IF NOT EXISTS lp_accounting_meta (
     key TEXT PRIMARY KEY,
@@ -380,6 +388,7 @@ class _ReplayWrites:
         self._prepared_rows: dict[str, list[tuple[Any, ...]]] | None = None
         self._affected_txs: set[str] = set()
         self._changed_episodes: set[str] = set()
+        self._gas_changed_episodes: set[str] = set()
         self.episode_ids: dict[tuple[int, int, int], tuple[str, int]] = {}
 
     def restore_episode_identity(
@@ -491,7 +500,14 @@ class _ReplayWrites:
                     key for key, row in desired.items()
                     if existing.get(key) != row
                 ]
-            changed[group] = [desired[key] for key in changed_keys]
+            changed[group] = [
+                (
+                    desired[key][:44] + existing[key][44:52] + desired[key][52:]
+                    if group == "episodes" and key in existing
+                    else desired[key]
+                )
+                for key in changed_keys
+            ]
             if group == "episodes":
                 self._changed_episodes.update(
                     str(key) for key in changed_keys
@@ -503,6 +519,12 @@ class _ReplayWrites:
                 )
 
         desired_effects = self._rows["effects"]
+        desired_pairs = {
+            (str(row[2]), str(row[5]))
+            for row in desired_effects.values()
+            if row[2] is not None
+        }
+        existing_pairs: set[tuple[str, str]] = set()
         remaining_ids = set(desired_effects)
         changed_effects: list[int] = []
         stale_effects: list[int] = []
@@ -516,6 +538,11 @@ class _ReplayWrites:
                         f"WHERE event_id IN ({marks})", batch,
                     )
                 }
+                existing_pairs.update(
+                    (str(row[2]), str(row[5]))
+                    for row in existing.values()
+                    if row[2] is not None
+                )
                 for event_id, prior in existing.items():
                     desired = desired_effects[event_id]
                     remaining_ids.discard(event_id)
@@ -533,6 +560,16 @@ class _ReplayWrites:
                 desired = desired_effects[event_id]
                 if desired[5]:
                     self._affected_txs.add(str(desired[5]))
+            # A new event can share a transaction with an earlier effect in
+            # the same episode. Gas is per transaction, so only a genuinely
+            # new episode/transaction membership changes its total.
+            for episode_id, tx_hash in desired_pairs:
+                if conn.execute(
+                    "SELECT 1 FROM lp_accounting_effects "
+                    "WHERE episode_id=? AND tx_hash=? LIMIT 1",
+                    (episode_id, tx_hash),
+                ).fetchone() is not None:
+                    existing_pairs.add((episode_id, tx_hash))
         else:
             # Stream the position range instead of retaining a second full
             # history of Python rows and probing every effect by primary key.
@@ -542,6 +579,8 @@ class _ReplayWrites:
             ):
                 event_id = int(row[0])
                 desired = desired_effects.get(event_id)
+                if row[2] is not None:
+                    existing_pairs.add((str(row[2]), str(row[5])))
                 if desired is None:
                     stale_effects.append(event_id)
                     if row[5]:
@@ -574,10 +613,13 @@ class _ReplayWrites:
                     if prior == desired:
                         continue
                     changed_effects.append(event_id)
-                    if prior is not None and prior[5]:
-                        self._affected_txs.add(str(prior[5]))
-                    if prior is not None and prior[2] and prior[2] != desired[2]:
-                        self._changed_episodes.add(str(prior[2]))
+                    if prior is not None:
+                        if prior[2] is not None:
+                            existing_pairs.add((str(prior[2]), str(prior[5])))
+                        if prior[5]:
+                            self._affected_txs.add(str(prior[5]))
+                        if prior[2] and prior[2] != desired[2]:
+                            self._changed_episodes.add(str(prior[2]))
                     if desired[5]:
                         self._affected_txs.add(str(desired[5]))
         deletes["effects"] = [(event_id,) for event_id in sorted(stale_effects)]
@@ -597,6 +639,10 @@ class _ReplayWrites:
                 "(c.payer IS NOT t.payer OR c.gas_usd IS NOT t.gas_usd))",
                 (self.position_key,),
             ))
+        self._gas_changed_episodes.update(
+            episode_id
+            for episode_id, _tx_hash in existing_pairs ^ desired_pairs
+        )
         for batch in _batches(sorted(owner_changed_episodes)):
             marks = ",".join("?" for _ in batch)
             self._affected_txs.update(str(row[0]) for row in conn.execute(
@@ -608,6 +654,10 @@ class _ReplayWrites:
         self._prepared_rows = changed
         self._rows.clear()
         self.episode_ids.clear()
+
+    @property
+    def gas_changed_episode_ids(self) -> set[str]:
+        return set(self._gas_changed_episodes)
 
     def flush(
         self, conn: sqlite3.Connection,
@@ -635,13 +685,16 @@ class _PreparedProjection(NamedTuple):
     position_key: str
     generation: int
     epoch: int
-    writes: _ReplayWrites
+    writes: _ReplayWrites | None
+    tx_hashes: tuple[str, ...]
 
 class _PublishedProjection(NamedTuple):
     position_key: str
     pool_ids: set[str]
     tx_hashes: set[str]
     episode_ids: set[str]
+    gas_episode_ids: set[str]
+    refresh_position: bool
 
 
 class _PreparedIdentityHints(NamedTuple):
@@ -1084,6 +1137,17 @@ class AccountBook:
             hints,
         )
 
+    @staticmethod
+    def _merge_pending_costs(
+        conn: sqlite3.Connection,
+        rows: Iterable[tuple[str, str]],
+    ) -> None:
+        conn.executemany(
+            "INSERT OR IGNORE INTO lp_accounting_pending_costs("
+            "position_key,tx_hash) VALUES(?,?)",
+            rows,
+        )
+
     def _queue_position_keys(
         self,
         conn: sqlite3.Connection,
@@ -1093,6 +1157,7 @@ class AccountBook:
         epoch: int | None = None,
         hinted: bool = False,
         append_only: Mapping[str, bool] | None = None,
+        cost_only: Mapping[str, bool] | None = None,
     ) -> None:
         if not priorities:
             self._finish_if_idle(conn)
@@ -1106,9 +1171,11 @@ class AccountBook:
             if epoch is None else int(epoch)
         )
         append_proofs = append_only or {}
+        cost_proofs = cost_only or {}
         rows = [
             (
                 key, 0, int(append_proofs.get(key, False)),
+                int(cost_proofs.get(key, False)),
                 requested_revision, requested_epoch,
                 int(order[0]), int(order[1]), int(order[2]),
                 int(hinted), 0,
@@ -1118,11 +1185,11 @@ class AccountBook:
         before = conn.total_changes
         conn.executemany(
             "INSERT OR IGNORE INTO lp_accounting_pending("
-            "position_key,generation,append_only,"
+            "position_key,generation,append_only,cost_only,"
             "requested_revision,requested_epoch,"
             "priority_block,priority_tx_index,priority_log_index,"
             "identities_ready,identity_cursor"
-            ") VALUES(?,?,?,?,?,?,?,?,?,?)",
+            ") VALUES(?,?,?,?,?,?,?,?,?,?,?)",
             rows,
         )
         inserted = conn.total_changes - before
@@ -1130,7 +1197,7 @@ class AccountBook:
         # publication fulfills and deletes this pending row.
         conn.executemany(
             "UPDATE lp_accounting_pending SET generation=generation+1,"
-            "append_only=append_only AND ?,"
+            "append_only=append_only AND ?,cost_only=cost_only AND ?,"
             "requested_revision=MAX(requested_revision,?),requested_epoch=?,"
             "priority_block=MAX(priority_block,?),"
             "priority_tx_index=MAX(priority_tx_index,?),"
@@ -1141,6 +1208,7 @@ class AccountBook:
             (
                 (
                     int(append_proofs.get(key, False)),
+                    int(cost_proofs.get(key, False)),
                     requested_revision, requested_epoch,
                     int(order[0]), int(order[1]), int(order[2]),
                     int(hinted), int(hinted), key,
@@ -1530,13 +1598,25 @@ class AccountBook:
     def _prepare_pending(self, position_key: str) -> _PreparedProjection | None:
         with self._reader() as conn:
             pending = conn.execute(
-                "SELECT generation,append_only FROM lp_accounting_pending "
-                "WHERE position_key=?",
+                "SELECT generation,append_only,cost_only "
+                "FROM lp_accounting_pending WHERE position_key=?",
                 (position_key,),
             ).fetchone()
             if pending is None:
                 return None
             epoch = self._store_metadata_int(conn, "epoch")
+            tx_hashes = tuple(
+                str(row[0]) for row in conn.execute(
+                    "SELECT tx_hash FROM lp_accounting_pending_costs "
+                    "WHERE position_key=? ORDER BY tx_hash",
+                    (position_key,),
+                )
+            )
+            if bool(pending["cost_only"]):
+                return _PreparedProjection(
+                    position_key, int(pending["generation"]), epoch,
+                    None, tx_hashes,
+                )
             # Missing effects identify unprojected events. _append_position
             # still verifies the persisted state schema and block boundary.
             if bool(pending["append_only"]):
@@ -1557,7 +1637,8 @@ class AccountBook:
                 ):
                     writes.prepare(conn)
                     return _PreparedProjection(
-                        position_key, int(pending["generation"]), epoch, writes,
+                        position_key, int(pending["generation"]), epoch,
+                        writes, tx_hashes,
                     )
             events = self._event_rows(conn, position_key)
             writes = _ReplayWrites(position_key)
@@ -1568,7 +1649,8 @@ class AccountBook:
                 )
             writes.prepare(conn)
             return _PreparedProjection(
-                position_key, int(pending["generation"]), epoch, writes,
+                position_key, int(pending["generation"]), epoch,
+                writes, tx_hashes,
             )
 
 
@@ -1597,15 +1679,22 @@ class AccountBook:
                 (prepared.position_key,),
             ).fetchall()
         }
-        affected_txs, changed_episodes = prepared.writes.flush(conn)
-        affected_pools.update(
-            str(row[0]).lower()
-            for row in conn.execute(
-                "SELECT pool_id FROM lp_accounting_positions "
-                "WHERE position_key=? AND pool_id IS NOT NULL",
-                (prepared.position_key,),
-            ).fetchall()
-        )
+        if prepared.writes is None:
+            affected_txs: set[str] = set()
+            changed_episodes: set[str] = set()
+            gas_changed_episodes: set[str] = set()
+        else:
+            affected_txs, changed_episodes = prepared.writes.flush(conn)
+            gas_changed_episodes = prepared.writes.gas_changed_episode_ids
+            affected_pools.update(
+                str(row[0]).lower()
+                for row in conn.execute(
+                    "SELECT pool_id FROM lp_accounting_positions "
+                    "WHERE position_key=? AND pool_id IS NOT NULL",
+                    (prepared.position_key,),
+                ).fetchall()
+            )
+        affected_txs.update(prepared.tx_hashes)
         removed = conn.execute(
             "DELETE FROM lp_accounting_pending "
             "WHERE position_key=? AND generation=?",
@@ -1615,7 +1704,8 @@ class AccountBook:
             self.store._bump(conn, "pending_accounting", -removed)
         return _PublishedProjection(
             prepared.position_key, affected_pools,
-            affected_txs, changed_episodes,
+            affected_txs, changed_episodes, gas_changed_episodes,
+            prepared.writes is not None,
         )
 
     def project_pending(self, limit: int = 128) -> bool:
@@ -1647,33 +1737,58 @@ class AccountBook:
                     )
                     if prepared is not None:
                         prepared_batch.append(prepared)
-                if not prepared_batch:
-                    continue
-                with self.store.transaction() as conn:
-                    position_keys: set[str] = set()
-                    affected_pools: set[str] = set()
-                    affected_txs: set[str] = set()
-                    changed_episodes: set[str] = set()
-                    for prepared in prepared_batch:
-                        changes = self._publish_pending(conn, prepared)
-                        if changes is None:
-                            continue
-                        position_keys.add(changes.position_key)
-                        affected_pools.update(changes.pool_ids)
-                        affected_txs.update(changes.tx_hashes)
-                        changed_episodes.update(changes.episode_ids)
-                    if position_keys:
-                        values = self._refresh_position_values(
-                            conn, sorted(position_keys),
-                        )
-                        self._refresh_active_episode_values(conn, values)
-                        self._rebuild_tx_costs(conn, affected_txs)
-                        self._refresh_episode_costs(
-                            conn, affected_txs,
-                            episode_ids=changed_episodes,
-                        )
-                        self._finish_if_idle(conn)
-                        self._invalidate_cache(conn, affected_pools)
+                published = 0
+                while published < len(prepared_batch):
+                    with self.store.transaction() as conn:
+                        acquired_at = time.monotonic()
+                        batch_start = published
+                        position_keys: set[str] = set()
+                        affected_pools: set[str] = set()
+                        published_any = False
+                        affected_txs: set[str] = set()
+                        changed_episodes: set[str] = set()
+                        gas_changed_episodes: set[str] = set()
+                        while (
+                            published < len(prepared_batch)
+                            and (
+                                published == batch_start
+                                or time.monotonic() - acquired_at
+                                < _PENDING_PUBLICATION_SECONDS
+                            )
+                        ):
+                            prepared = prepared_batch[published]
+                            published += 1
+                            changes = self._publish_pending(conn, prepared)
+                            if changes is None:
+                                continue
+                            published_any = True
+                            if changes.refresh_position:
+                                position_keys.add(changes.position_key)
+                            affected_pools.update(changes.pool_ids)
+                            affected_txs.update(changes.tx_hashes)
+                            changed_episodes.update(changes.episode_ids)
+                            gas_changed_episodes.update(changes.gas_episode_ids)
+                        if published_any:
+                            if position_keys:
+                                values = self._refresh_position_values(
+                                    conn, sorted(position_keys),
+                                )
+                                self._refresh_active_episode_values(conn, values)
+                            changed_cost_txs = self._rebuild_tx_costs(
+                                conn, affected_txs,
+                            )
+                            refreshed_cost_episodes = self._refresh_episode_costs(
+                                conn, changed_cost_txs,
+                                episode_ids=gas_changed_episodes,
+                            )
+                            self._refresh_episode_values(
+                                conn,
+                                changed_episodes - (
+                                    refreshed_cost_episodes or set()
+                                ),
+                            )
+                            self._finish_if_idle(conn)
+                            self._invalidate_cache(conn, affected_pools)
             return worked
 
     def publish_claims(self, rows: Sequence[Mapping[str, Any]]) -> bool:
@@ -2042,6 +2157,8 @@ class AccountBook:
         if self.deferred:
             priorities: dict[str, tuple[int, int, int]] = {}
             append_proofs: dict[str, bool] = {}
+            cost_proofs: dict[str, bool] = {}
+            cost_rows: set[tuple[str, str]] = set()
             identity_hints: dict[
                 tuple[str, str, str, str, str], int
             ] = {}
@@ -2051,6 +2168,7 @@ class AccountBook:
                 event_id = int(event["id"])
                 order = _order(event)[:3]
                 new_key = self._event_position_key(event)
+                transaction_only = bool(event.get("_transaction_only"))
                 event_keys = {
                     key for key in (
                         old_mapping.get(event_id),
@@ -2070,6 +2188,16 @@ class AccountBook:
                         and event_id not in projected_ids
                         and key == new_key
                     )
+                    cost_proof = bool(
+                        transaction_only
+                        and old_mapping.get(event_id) == new_key == key
+                        and event_id in projected_ids
+                    )
+                    cost_proofs[key] = (
+                        cost_proofs.get(key, True) and cost_proof
+                    )
+                    if cost_proof and event.get("tx_hash"):
+                        cost_rows.add((key, str(event["tx_hash"]).lower()))
                     self._add_event_identity_hints(
                         identity_hints, key, event,
                     )
@@ -2089,14 +2217,18 @@ class AccountBook:
             for key in legacy_positions:
                 if key in append_proofs:
                     append_proofs[key] = False
+                if key in cost_proofs:
+                    cost_proofs[key] = False
             self._queue_position_keys(
-                conn, priorities, hinted=True, append_only=append_proofs,
+                conn, priorities, hinted=True,
+                append_only=append_proofs, cost_only=cost_proofs,
             )
             if unqueued_legacy := legacy_positions.keys() - priorities.keys():
                 latest = max(_order(event)[:3] for event in events)
                 self._queue_position_keys(
                     conn, {key: latest for key in unqueued_legacy},
                 )
+            self._merge_pending_costs(conn, sorted(cost_rows))
             self._merge_pending_identity_hints(
                 conn,
                 (
@@ -3756,12 +3888,14 @@ class AccountBook:
                 )
 
 
-    def _rebuild_tx_costs(self, conn: sqlite3.Connection,
-                          tx_hashes: set[str] | None) -> None:
+    def _rebuild_tx_costs(
+        self, conn: sqlite3.Connection, tx_hashes: set[str] | None,
+    ) -> set[str] | None:
         if tx_hashes is not None:
+            changed: set[str] = set()
             for batch in _batches(sorted(tx_hashes)):
-                self._rebuild_tx_cost_batch(conn, batch)
-            return
+                changed.update(self._rebuild_tx_cost_batch(conn, batch))
+            return changed
 
         conn.execute("DELETE FROM lp_accounting_tx_costs")
         after = ""
@@ -3775,16 +3909,28 @@ class AccountBook:
                 ).fetchall()
             ]
             if not values:
-                return
+                return None
             self._rebuild_tx_cost_batch(conn, values)
             after = values[-1]
 
     def _rebuild_tx_cost_batch(
         self, conn: sqlite3.Connection, values: Sequence[str],
-    ) -> None:
+    ) -> set[str]:
         if not values:
-            return
+            return set()
         marks = ",".join("?" for _ in values)
+        cost_columns = (
+            "tx_hash,payer,owner,position_key,episode_id,gas_usd,"
+            "attribution,block_number"
+        )
+        prior_costs = {
+            str(row[0]): tuple(row)
+            for row in conn.execute(
+                f"SELECT {cost_columns} FROM lp_accounting_tx_costs "
+                f"WHERE tx_hash IN ({marks})",
+                values,
+            )
+        }
         effects_by_tx: dict[str, list[dict[str, Any]]] = defaultdict(list)
         for row in _dict_rows(conn.execute(
             "SELECT DISTINCT tx_hash,episode_id,position_key,owner,block_number "
@@ -3825,7 +3971,11 @@ class AccountBook:
                     f"WHERE id IN ({episode_marks})", batch,
                 ).fetchall()
             })
-        empty = [tx_hash for tx_hash in values if tx_hash not in effects_by_tx]
+        empty = [
+            tx_hash
+            for tx_hash in values
+            if tx_hash not in effects_by_tx and tx_hash in prior_costs
+        ]
         if empty:
             empty_marks = ",".join("?" for _ in empty)
             conn.execute(
@@ -3879,17 +4029,20 @@ class AccountBook:
                 tx_hash, payer, owner, position_key, episode_id, gas, attribution,
                 int((transaction or effects[0]).get("block_number") or 0),
             ))
+        changed_rows = [
+            row for row in rows if prior_costs.get(str(row[0])) != row
+        ]
         conn.executemany(
             "INSERT OR REPLACE INTO lp_accounting_tx_costs("
             "tx_hash,payer,owner,position_key,episode_id,gas_usd,attribution,block_number) "
             "VALUES(?,?,?,?,?,?,?,?)",
-            rows,
+            changed_rows,
         )
-
+        return set(empty) | {str(row[0]) for row in changed_rows}
     def _refresh_episode_costs(
         self, conn: sqlite3.Connection, tx_hashes: set[str] | None, *,
         episode_ids: Iterable[str] = (),
-    ) -> None:
+    ) -> set[str] | None:
         if tx_hashes is None:
             after = ""
             while True:
@@ -3902,7 +4055,7 @@ class AccountBook:
                     ).fetchall()
                 ]
                 if not batch:
-                    return
+                    return None
                 self._refresh_episode_cost_batch(conn, batch)
                 after = batch[-1]
         affected_episodes = {str(episode_id) for episode_id in episode_ids}
@@ -3914,6 +4067,7 @@ class AccountBook:
             ).fetchall())
         for batch in _batches(sorted(affected_episodes)):
             self._refresh_episode_cost_batch(conn, batch)
+        return affected_episodes
 
     def _refresh_episode_cost_batch(
         self, conn: sqlite3.Connection, batch: Sequence[str],
@@ -3924,20 +4078,23 @@ class AccountBook:
         gas_by_episode: dict[str, float | None] = {
             str(episode_id): None for episode_id in batch
         }
-        # One episode can contain tens of thousands of effects.  Group its
-        # transaction hashes while streaming the covering effects index, then
-        # return one aggregate row per episode.  The former DISTINCT join
-        # materialized every historical transaction (and five wide columns)
-        # into a temp B-tree and then into Python on every update.
+        # Most historical episodes are intentionally cost-incomplete while
+        # receipt enrichment catches up. Reject those on the first missing or
+        # inexact transaction instead of grouping every historical effect just
+        # to derive NULL. Complete episodes still sum each transaction once.
         for row in conn.execute(
-            "SELECT ep.id,(SELECT CASE WHEN COUNT(*)>0 AND "
-            "MIN(CASE WHEN c.attribution='exact' AND c.episode_id=ep.id "
-            "AND c.gas_usd IS NOT NULL THEN 1 ELSE 0 END)=1 "
-            "THEN SUM(c.gas_usd) END FROM ("
-            "SELECT x.tx_hash FROM lp_accounting_effects x "
-            "WHERE x.episode_id=ep.id GROUP BY x.tx_hash"
-            ") tx LEFT JOIN lp_accounting_tx_costs c ON c.tx_hash=tx.tx_hash"
-            ") AS gas_usd FROM lp_accounting_episodes ep "
+            "SELECT ep.id,CASE WHEN EXISTS("
+            "SELECT 1 FROM lp_accounting_effects x "
+            "WHERE x.episode_id=ep.id) AND NOT EXISTS("
+            "SELECT 1 FROM lp_accounting_effects x "
+            "LEFT JOIN lp_accounting_tx_costs c ON c.tx_hash=x.tx_hash "
+            "WHERE x.episode_id=ep.id AND (c.attribution IS NOT 'exact' "
+            "OR c.episode_id IS NOT ep.id OR c.gas_usd IS NULL)) THEN ("
+            "SELECT SUM(c.gas_usd) FROM (SELECT x.tx_hash "
+            "FROM lp_accounting_effects x WHERE x.episode_id=ep.id "
+            "GROUP BY x.tx_hash) tx JOIN lp_accounting_tx_costs c "
+            "ON c.tx_hash=tx.tx_hash) END AS gas_usd "
+            "FROM lp_accounting_episodes ep "
             f"WHERE ep.id IN ({marks})",
             batch,
         ).fetchall():
@@ -3951,6 +4108,21 @@ class AccountBook:
                 for episode_id in batch
             ),
         )
+        self._refresh_episode_values(conn, batch)
+
+    def _refresh_episode_values(
+        self, conn: sqlite3.Connection, episode_ids: Iterable[str],
+    ) -> None:
+        selected = sorted({str(episode_id) for episode_id in episode_ids})
+        for batch in _batches(selected):
+            self._refresh_episode_value_batch(conn, batch)
+
+    def _refresh_episode_value_batch(
+        self, conn: sqlite3.Connection, batch: Sequence[str],
+    ) -> None:
+        if not batch:
+            return
+        marks = ",".join("?" for _ in batch)
         episodes = {
             str(row["id"]): row
             for row in _dict_rows(conn.execute(

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -2168,7 +2168,13 @@ class AccountBook:
                 event_id = int(event["id"])
                 order = _order(event)[:3]
                 new_key = self._event_position_key(event)
-                transaction_only = bool(event.get("_transaction_only"))
+                transaction_source = event.get("_transaction_source")
+                transaction_only = (
+                    isinstance(transaction_source, Mapping)
+                    and transaction_source == self.store._event_row(
+                        event, int(event["revision"]),
+                    )
+                )
                 event_keys = {
                     key for key in (
                         old_mapping.get(event_id),

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -32,6 +32,10 @@ _MISSING = object()
 _POOL_INVENTORY_CACHE_POOLS = 128
 _POOL_INVENTORY_CACHE_POSITIONS = 100_000
 _POOL_RESULT_CACHE_ENTRIES = 512
+_IDENTITY_BOOTSTRAP_EVENTS = 4096
+_IDENTITY_BOOTSTRAP_KEYS = 256
+_IDENTITY_BOOTSTRAP_PAGE = 256
+_PENDING_PUBLICATION_SECONDS = 0.2
 
 
 class _PoolInventory(NamedTuple):
@@ -462,6 +466,14 @@ class _PreparedProjection(NamedTuple):
     epoch: int
     writes: _ReplayWrites
 
+class _PreparedIdentityHints(NamedTuple):
+    position_key: str
+    cursor: int
+    next_cursor: int
+    complete: bool
+    epoch: int
+    hints: tuple[tuple[str, str, str, str, str, int], ...]
+
 
 def _batches(values: Sequence[Any], size: int = 500) -> Iterable[Sequence[Any]]:
     for start in range(0, len(values), size):
@@ -684,6 +696,7 @@ class AccountBook:
                 return self
             self.store.connection.executescript(_SCHEMA)
             with self.store.transaction() as conn:
+                self.store._install_accounting_pending_identities(conn)
                 prior = {
                     str(row[0]): str(row[1])
                     for row in conn.execute(
@@ -791,6 +804,81 @@ class AccountBook:
             ).strip().lower()
         return key
 
+    @staticmethod
+    def _hint_scope(event: Mapping[str, Any]) -> tuple[str, str, int]:
+        data = _json(event.get("data"))
+        raw_protocol = str(event.get("protocol") or "").strip().lower()
+        protocol = raw_protocol
+        if raw_protocol == "nft":
+            manager_protocol = str(
+                data.get("manager_protocol") or ""
+            ).strip().lower()
+            protocol = (
+                manager_protocol
+                if manager_protocol in {"v2", "v3", "v4"} else "nft"
+            )
+        pool_id = str(event.get("pool_id") or "").strip().lower()
+        return protocol, pool_id, int(event.get("timestamp") or 0)
+
+    @staticmethod
+    def _add_identity_hint(
+            hints: dict[tuple[str, str, str, str, str], int],
+            position_key: str, kind: str, identity: str,
+            protocol: str, pool_id: str, timestamp: int,
+    ) -> None:
+        key = (position_key, kind, identity, protocol, pool_id)
+        hints[key] = max(hints.get(key, timestamp), timestamp)
+
+    def _add_event_identity_hints(
+            self, hints: dict[tuple[str, str, str, str, str], int],
+            position_key: str, event: Mapping[str, Any],
+    ) -> None:
+        protocol, pool_id, timestamp = self._hint_scope(event)
+        self._add_identity_hint(
+            hints, position_key, "scope", "", protocol, pool_id, timestamp,
+        )
+        owner = _address(event.get("owner"))
+        custody = _address(event.get("custody"))
+        if owner is not None and owner != _ZERO_ADDRESS:
+            self._add_identity_hint(
+                hints, position_key, "owner", owner,
+                protocol, pool_id, timestamp,
+            )
+        if custody is not None and custody != _ZERO_ADDRESS:
+            self._add_identity_hint(
+                hints, position_key, "custody", custody,
+                protocol, pool_id, timestamp,
+            )
+        if (
+            str(event.get("protocol") or "").strip().lower() == "nft"
+            and str(event.get("kind") or "").strip().lower() == "transfer"
+        ):
+            source, target = self._transfer_parties(
+                event, _json(event.get("data")),
+            )
+            for actor in (source, target):
+                if actor is not None and actor != _ZERO_ADDRESS:
+                    self._add_identity_hint(
+                        hints, position_key, "owner", actor,
+                        protocol, pool_id, timestamp,
+                    )
+
+
+    @staticmethod
+    def _merge_pending_identity_hints(
+            conn: sqlite3.Connection,
+            hints: Iterable[tuple[str, str, str, str, str, int]],
+    ) -> None:
+        conn.executemany(
+            "INSERT INTO lp_accounting_pending_identities("
+            "position_key,kind,identity,protocol,pool_id,timestamp"
+            ") VALUES(?,?,?,?,?,?) ON CONFLICT("
+            "position_key,kind,identity,protocol,pool_id"
+            ") DO UPDATE SET timestamp=MAX("
+            "lp_accounting_pending_identities.timestamp,excluded.timestamp)",
+            hints,
+        )
+
     def _queue_position_keys(
         self,
         conn: sqlite3.Connection,
@@ -798,6 +886,7 @@ class AccountBook:
         *,
         revision: int | None = None,
         epoch: int | None = None,
+        hinted: bool = False,
     ) -> None:
         if not priorities:
             self._finish_if_idle(conn)
@@ -814,6 +903,7 @@ class AccountBook:
             (
                 key, 0, requested_revision, requested_epoch,
                 int(order[0]), int(order[1]), int(order[2]),
+                int(hinted), 0,
             )
             for key, order in sorted(priorities.items())
         ]
@@ -821,8 +911,9 @@ class AccountBook:
         conn.executemany(
             "INSERT OR IGNORE INTO lp_accounting_pending("
             "position_key,generation,requested_revision,requested_epoch,"
-            "priority_block,priority_tx_index,priority_log_index"
-            ") VALUES(?,?,?,?,?,?,?)",
+            "priority_block,priority_tx_index,priority_log_index,"
+            "identities_ready,identity_cursor"
+            ") VALUES(?,?,?,?,?,?,?,?,?)",
             rows,
         )
         inserted = conn.total_changes - before
@@ -831,15 +922,27 @@ class AccountBook:
             "requested_revision=MAX(requested_revision,?),requested_epoch=?,"
             "priority_block=MAX(priority_block,?),"
             "priority_tx_index=MAX(priority_tx_index,?),"
-            "priority_log_index=MAX(priority_log_index,?) WHERE position_key=?",
+            "priority_log_index=MAX(priority_log_index,?),"
+            "identities_ready=CASE WHEN ? THEN identities_ready ELSE 0 END,"
+            "identity_cursor=CASE WHEN ? THEN identity_cursor ELSE 0 END "
+            "WHERE position_key=?",
             (
                 (
                     requested_revision, requested_epoch,
-                    int(order[0]), int(order[1]), int(order[2]), key,
+                    int(order[0]), int(order[1]), int(order[2]),
+                    int(hinted), int(hinted), key,
                 )
                 for key, order in sorted(priorities.items())
             ),
         )
+        if not hinted:
+            for batch in _batches(sorted(priorities)):
+                marks = ",".join("?" for _ in batch)
+                conn.execute(
+                    "DELETE FROM lp_accounting_pending_identities "
+                    f"WHERE position_key IN ({marks})",
+                    batch,
+                )
         if inserted:
             self.store._bump(conn, "pending_accounting", inserted)
         self._set_accounting_meta(conn, "dirty", 1)
@@ -989,6 +1092,121 @@ class AccountBook:
                 self._finish_if_idle(conn)
             return True
 
+    def _prepare_pending_identity_hints(
+            self,
+    ) -> list[_PreparedIdentityHints]:
+        prepared: list[_PreparedIdentityHints] = []
+        remaining = _IDENTITY_BOOTSTRAP_EVENTS
+        with self._reader() as conn:
+            if self._accounting_meta(
+                conn, "bootstrap_phase", "complete",
+            ) != "complete":
+                return prepared
+            epoch = self._store_metadata_int(conn, "epoch")
+            pending = conn.execute(
+                "SELECT position_key,identity_cursor "
+                "FROM lp_accounting_pending "
+                "INDEXED BY lp_accounting_pending_identity_bootstrap "
+                "WHERE identities_ready=0 ORDER BY id LIMIT ?",
+                (_IDENTITY_BOOTSTRAP_KEYS,),
+            ).fetchall()
+            for row in pending:
+                if remaining <= 0:
+                    break
+                position_key = str(row["position_key"])
+                cursor = int(row["identity_cursor"])
+                page_size = min(_IDENTITY_BOOTSTRAP_PAGE, remaining)
+                events = _dict_rows(conn.execute(
+                    "SELECT e.protocol,e.pool_id,e.timestamp,e.owner,e.custody,"
+                    "e.kind,e.data,k.event_id "
+                    "FROM lp_accounting_event_keys k "
+                    "INDEXED BY lp_accounting_event_keys_position "
+                    "JOIN events e ON e.id=k.event_id "
+                    "WHERE k.position_key=? AND k.event_id>? "
+                    "ORDER BY k.event_id LIMIT ?",
+                    (position_key, cursor, page_size),
+                ))
+                hints: dict[tuple[str, str, str, str, str], int] = {}
+                for event in events:
+                    self._add_event_identity_hints(
+                        hints, position_key, event,
+                    )
+                next_cursor = (
+                    int(events[-1]["event_id"]) if events else cursor
+                )
+                prepared.append(_PreparedIdentityHints(
+                    position_key=position_key,
+                    cursor=cursor,
+                    next_cursor=next_cursor,
+                    complete=len(events) < page_size,
+                    epoch=epoch,
+                    hints=tuple(
+                        (*key, timestamp)
+                        for key, timestamp in hints.items()
+                    ),
+                ))
+                remaining -= len(events)
+        return prepared
+
+    def _publish_pending_identity_hints(
+            self, prepared: Sequence[_PreparedIdentityHints],
+    ) -> None:
+        published = 0
+        while published < len(prepared):
+            with self.store.transaction() as conn:
+                acquired_at = time.monotonic()
+                epoch = self._store_metadata_int(conn, "epoch")
+                changed = False
+                first = published
+                while (
+                    published < len(prepared)
+                    and (
+                        published == first
+                        or time.monotonic() - acquired_at
+                        < _PENDING_PUBLICATION_SECONDS
+                    )
+                ):
+                    item = prepared[published]
+                    published += 1
+                    if epoch != item.epoch:
+                        continue
+                    pending = conn.execute(
+                        "SELECT identity_cursor,identities_ready "
+                        "FROM lp_accounting_pending WHERE position_key=?",
+                        (item.position_key,),
+                    ).fetchone()
+                    if (
+                        pending is None
+                        or int(pending["identities_ready"]) != 0
+                        or int(pending["identity_cursor"]) != item.cursor
+                    ):
+                        continue
+                    self._merge_pending_identity_hints(conn, item.hints)
+                    updated = conn.execute(
+                        "UPDATE lp_accounting_pending SET "
+                        "identity_cursor=?,identities_ready=? "
+                        "WHERE position_key=? AND identities_ready=0 "
+                        "AND identity_cursor=?",
+                        (
+                            item.next_cursor, int(item.complete),
+                            item.position_key, item.cursor,
+                        ),
+                    ).rowcount
+                    changed = bool(updated) or changed
+                if changed and conn.execute(
+                    "SELECT 1 FROM lp_accounting_pending "
+                    "INDEXED BY lp_accounting_pending_identity_bootstrap "
+                    "WHERE identities_ready=0 LIMIT 1"
+                ).fetchone() is None:
+                    self._invalidate_cache(conn, (), owners=True)
+
+    def _recover_pending_identities(self) -> bool:
+        prepared = self._prepare_pending_identity_hints()
+        if not prepared:
+            return False
+        self._publish_pending_identity_hints(prepared)
+        return True
+
     def _pending_rows(self, limit: int) -> list[dict[str, Any]]:
         historical = max(1, limit // 4)
         recent = max(0, limit - historical)
@@ -1035,68 +1253,90 @@ class AccountBook:
             )
 
 
-    def _publish_pending(self, prepared: _PreparedProjection) -> bool:
-        with self.store.transaction() as conn:
-            if self._store_metadata_int(conn, "epoch") != prepared.epoch:
-                return False
-            pending = conn.execute(
-                "SELECT generation FROM lp_accounting_pending "
-                "WHERE position_key=?",
+    def _publish_pending(
+            self, conn: sqlite3.Connection,
+            prepared: _PreparedProjection,
+    ) -> bool:
+        if self._store_metadata_int(conn, "epoch") != prepared.epoch:
+            return False
+        pending = conn.execute(
+            "SELECT generation FROM lp_accounting_pending "
+            "WHERE position_key=?",
+            (prepared.position_key,),
+        ).fetchone()
+        if pending is None:
+            return False
+        # Projection publication is serialized. Same-epoch event changes
+        # therefore cannot race a newer accounting publish: commit this
+        # coherent older snapshot, and let the generation-guarded delete
+        # retain the key for the newer snapshot. Reorgs are rejected above.
+        affected_pools = {
+            str(row[0]).lower()
+            for row in conn.execute(
+                "SELECT pool_id FROM lp_accounting_positions "
+                "WHERE position_key=? AND pool_id IS NOT NULL",
                 (prepared.position_key,),
-            ).fetchone()
-            if pending is None:
-                return False
-            # Projection publication is serialized. Same-epoch event changes
-            # therefore cannot race a newer accounting publish: commit this
-            # coherent older snapshot, and let the generation-guarded delete
-            # retain the key for the newer snapshot. Reorgs are rejected above.
-            affected_pools = {
-                str(row[0]).lower()
-                for row in conn.execute(
-                    "SELECT pool_id FROM lp_accounting_positions "
-                    "WHERE position_key=? AND pool_id IS NOT NULL",
-                    (prepared.position_key,),
-                ).fetchall()
-            }
-            affected_txs, changed_episodes = prepared.writes.flush(conn)
-            affected_pools.update(
-                str(row[0]).lower()
-                for row in conn.execute(
-                    "SELECT pool_id FROM lp_accounting_positions "
-                    "WHERE position_key=? AND pool_id IS NOT NULL",
-                    (prepared.position_key,),
-                ).fetchall()
-            )
-            self._refresh_position_values(conn, [prepared.position_key])
-            self._rebuild_tx_costs(conn, affected_txs)
-            self._refresh_episode_costs(
-                conn, affected_txs, episode_ids=changed_episodes,
-            )
-            removed = conn.execute(
-                "DELETE FROM lp_accounting_pending "
-                "WHERE position_key=? AND generation=?",
-                (prepared.position_key, prepared.generation),
-            ).rowcount
-            if removed:
-                self.store._bump(conn, "pending_accounting", -removed)
-            self._finish_if_idle(conn)
-            self._invalidate_cache(conn, affected_pools)
-            return True
+            ).fetchall()
+        }
+        affected_txs, changed_episodes = prepared.writes.flush(conn)
+        affected_pools.update(
+            str(row[0]).lower()
+            for row in conn.execute(
+                "SELECT pool_id FROM lp_accounting_positions "
+                "WHERE position_key=? AND pool_id IS NOT NULL",
+                (prepared.position_key,),
+            ).fetchall()
+        )
+        self._refresh_position_values(conn, [prepared.position_key])
+        self._rebuild_tx_costs(conn, affected_txs)
+        self._refresh_episode_costs(
+            conn, affected_txs, episode_ids=changed_episodes,
+        )
+        removed = conn.execute(
+            "DELETE FROM lp_accounting_pending "
+            "WHERE position_key=? AND generation=?",
+            (prepared.position_key, prepared.generation),
+        ).rowcount
+        if removed:
+            self.store._bump(conn, "pending_accounting", -removed)
+        self._finish_if_idle(conn)
+        self._invalidate_cache(conn, affected_pools)
+        return True
 
-    def project_pending(self, limit: int = 32) -> bool:
+    def project_pending(self, limit: int = 128) -> bool:
         """Prepare bounded queued histories off-writer, then publish atomically."""
         if not self.deferred:
             return False
         bounded = max(1, min(int(limit), 128))
         with self._projection_lock:
             worked = self._resume_bootstrap(bounded)
+            if self._recover_pending_identities():
+                worked = True
             pending = self._pending_rows(bounded)
             if pending:
                 worked = True
+            prepared_batch = []
             for row in pending:
                 prepared = self._prepare_pending(str(row["position_key"]))
                 if prepared is not None:
-                    self._publish_pending(prepared)
+                    prepared_batch.append(prepared)
+            published = 0
+            while published < len(prepared_batch):
+                with self.store.transaction() as conn:
+                    acquired_at = time.monotonic()
+                    first = published
+                    while (
+                        published < len(prepared_batch)
+                        and (
+                            published == first
+                            or time.monotonic() - acquired_at
+                            < _PENDING_PUBLICATION_SECONDS
+                        )
+                    ):
+                        self._publish_pending(
+                            conn, prepared_batch[published],
+                        )
+                        published += 1
             return worked
 
     def _apply(
@@ -1172,19 +1412,28 @@ class AccountBook:
         keys = sorted(old_keys | new_keys)
         if self.deferred:
             priorities: dict[str, tuple[int, int, int]] = {}
+            identity_hints: dict[
+                tuple[str, str, str, str, str], int
+            ] = {}
             for event in events:
                 if event.get("id") is None:
                     continue
                 event_id = int(event["id"])
                 order = _order(event)[:3]
-                for key in (
-                    old_mapping.get(event_id),
-                    self._event_position_key(event),
-                ):
-                    if key:
-                        priorities[key] = max(
-                            priorities.get(key, order), order,
-                        )
+                event_keys = {
+                    key for key in (
+                        old_mapping.get(event_id),
+                        self._event_position_key(event),
+                    )
+                    if key
+                }
+                for key in event_keys:
+                    priorities[key] = max(
+                        priorities.get(key, order), order,
+                    )
+                    self._add_event_identity_hints(
+                        identity_hints, key, event,
+                    )
                 if event.get("pool_id"):
                     inventory_pools.add(str(event["pool_id"]).lower())
             for batch in _batches(keys):
@@ -1198,7 +1447,14 @@ class AccountBook:
                         batch,
                     ).fetchall()
                 )
-            self._queue_position_keys(conn, priorities)
+            self._queue_position_keys(conn, priorities, hinted=True)
+            self._merge_pending_identity_hints(
+                conn,
+                (
+                    (*key, timestamp)
+                    for key, timestamp in identity_hints.items()
+                ),
+            )
             self._invalidate_cache(
                 conn, inventory_pools, owners=bool(priorities),
             )
@@ -3668,11 +3924,15 @@ class AccountBook:
         event_args: list[Any] = []
         episode_clauses: list[str] = []
         episode_args: list[Any] = []
+        hint_clauses = ["h.kind='scope'"]
+        hint_args: list[Any] = []
         if cutoff is not None:
             event_clauses.append("e.timestamp>=?")
             event_args.append(cutoff)
             episode_clauses.append("ep.last_timestamp>=?")
             episode_args.append(cutoff)
+            hint_clauses.append("h.timestamp>=?")
+            hint_args.append(cutoff)
         if protocol:
             event_clauses.append(
                 "(e.protocol=? OR (e.protocol='nft' AND "
@@ -3681,11 +3941,15 @@ class AccountBook:
             event_args.extend((protocol, protocol))
             episode_clauses.append("ep.protocol=?")
             episode_args.append(protocol)
+            hint_clauses.append("h.protocol=?")
+            hint_args.append(protocol)
         if pool_id:
             event_clauses.append("e.pool_id=?")
             event_args.append(pool_id)
             episode_clauses.append("ep.pool_id=?")
             episode_args.append(pool_id)
+            hint_clauses.append("h.pool_id=?")
+            hint_args.append(pool_id)
         event_where = (
             " WHERE " + " AND ".join(event_clauses)
             if event_clauses else ""
@@ -3727,35 +3991,41 @@ class AccountBook:
             return through_order, through_as_of, set(), set(), False
         if not pending_exists:
             return through_order, through_as_of, set(), set(), True
-        if event_clauses:
-            event_scope = " AND " + " AND ".join(event_clauses)
+        if conn.execute(
+            "SELECT 1 FROM lp_accounting_pending "
+            "INDEXED BY lp_accounting_pending_identity_bootstrap "
+            "WHERE identities_ready=0 LIMIT 1"
+        ).fetchone() is not None:
+            return through_order, through_as_of, set(), set(), False
+        if cutoff is not None or protocol or pool_id:
+            hint_scope = " AND " + " AND ".join(hint_clauses)
             episode_scope = " AND " + " AND ".join(episode_clauses)
             scoped_keys = (
                 "SELECT q.position_key FROM lp_accounting_pending q WHERE "
-                "EXISTS(SELECT 1 FROM lp_accounting_event_keys k "
-                "INDEXED BY lp_accounting_event_keys_position "
-                "JOIN events e ON e.id=k.event_id "
-                "WHERE k.position_key=q.position_key" + event_scope + ") OR "
+                "EXISTS(SELECT 1 "
+                "FROM lp_accounting_pending_identities h "
+                "WHERE h.position_key=q.position_key" + hint_scope + ") OR "
                 "EXISTS(SELECT 1 FROM lp_accounting_episodes ep "
                 "WHERE ep.position_key=q.position_key" + episode_scope + ")"
             )
-            scoped_args = [*event_args, *episode_args]
+            scoped_args = [*hint_args, *episode_args]
         else:
             scoped_keys = (
                 "SELECT q.position_key FROM lp_accounting_pending q"
             )
             scoped_args = []
         pending_rows = conn.execute(
-            "WITH scoped_keys AS (" + scoped_keys + ") "
-            "SELECT ep.owner,ep.custody,NULL AS data "
-            "FROM scoped_keys s JOIN lp_accounting_episodes ep "
+            "WITH scoped_keys AS MATERIALIZED (" + scoped_keys + ") "
+            "SELECT ep.owner,ep.custody "
+            "FROM scoped_keys s CROSS JOIN lp_accounting_episodes ep "
             "ON ep.position_key=s.position_key "
             "UNION "
-            "SELECT e.owner,e.custody,CASE WHEN e.kind='transfer' THEN e.data END "
-            "FROM scoped_keys s JOIN lp_accounting_event_keys k "
-            "INDEXED BY lp_accounting_event_keys_position "
-            "ON k.position_key=s.position_key "
-            "JOIN events e ON e.id=k.event_id",
+            "SELECT CASE WHEN h.kind='owner' THEN h.identity END AS owner,"
+            "CASE WHEN h.kind='custody' THEN h.identity END AS custody "
+            "FROM scoped_keys s "
+            "CROSS JOIN lp_accounting_pending_identities h "
+            "ON h.position_key=s.position_key "
+            "WHERE h.kind IN ('owner','custody')",
             scoped_args,
         )
         owners: set[str] = set()
@@ -3767,12 +4037,6 @@ class AccountBook:
                 owners.add(owner)
             if custody is not None:
                 custodies.add(custody)
-            if row["data"] is not None:
-                source, target = self._transfer_parties(dict(row), _json(row["data"]))
-                if source is not None and source != _ZERO_ADDRESS:
-                    owners.add(source)
-                if target is not None and target != _ZERO_ADDRESS:
-                    owners.add(target)
         return through_order, through_as_of, owners, custodies, True
 
     def decorate_owner_activity(

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -8,13 +8,17 @@ for already-priced USD presentation values.
 
 from __future__ import annotations
 
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict, defaultdict, deque
 from collections.abc import Mapping
+from concurrent.futures import Future, ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from contextlib import contextmanager
 from functools import lru_cache
-from itertools import groupby
+from itertools import groupby, islice
 import json
 import math
+import multiprocessing
+from pathlib import Path
 import sqlite3
 import threading
 import time
@@ -706,6 +710,35 @@ class _PreparedIdentityHints(NamedTuple):
     hints: tuple[tuple[str, str, str, str, str, int], ...]
 
 
+class _PreparationReader:
+    """Worker-local reader; cannot install schema or publish ledger changes."""
+
+    def __init__(self, path: str) -> None:
+        self._connection = sqlite3.connect(
+            Path(path).resolve().as_uri() + "?mode=ro", uri=True,
+            isolation_level=None, timeout=5.0,
+        )
+        self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA query_only=ON")
+
+    def read(self) -> sqlite3.Connection:
+        return self._connection
+
+
+_preparation_book: AccountBook | None = None
+
+
+def _initialize_preparation_worker(path: str) -> None:
+    global _preparation_book
+    _preparation_book = AccountBook(_PreparationReader(path), deferred=True)
+
+
+def _prepare_in_worker(position_key: str) -> _PreparedProjection | None:
+    if _preparation_book is None:
+        raise RuntimeError("accounting preparation worker is not initialized")
+    return _preparation_book._prepare_pending(position_key)
+
+
 def _batches(values: Sequence[Any], size: int = 500) -> Iterable[Sequence[Any]]:
     for start in range(0, len(values), size):
         yield values[start:start + size]
@@ -864,10 +897,15 @@ def _pair(pool: Mapping[str, Any]) -> str:
 class AccountBook:
     """Canonical, reorg-safe LP ownership and episode projection."""
 
-    def __init__(self, store: Any, *, deferred: bool = False):
+    def __init__(
+        self, store: Any, *, deferred: bool = False,
+        preparation_workers: int = 0,
+    ):
         self.store = store
         self.deferred = bool(deferred)
         self._installed = False
+        self._preparation_workers = preparation_workers
+        self._preparation_pool: ProcessPoolExecutor | None = None
         self._projection_lock = threading.Lock()
         self._cache_lock = threading.RLock()
         self._priority_lock = threading.Lock()
@@ -884,6 +922,54 @@ class AccountBook:
         self._owner_activity_cache: OrderedDict[
             tuple[Any, ...], dict[str, Any] | None
         ] = OrderedDict()
+
+    def close(self) -> None:
+        """Join preparation after the accounting coordinator has stopped."""
+        with self._projection_lock:
+            if self._preparation_pool is not None:
+                self._preparation_pool.shutdown(wait=True, cancel_futures=True)
+                self._preparation_pool = None
+
+    def _prepared_pending(
+        self, pending: Sequence[Mapping[str, Any]],
+    ) -> Iterable[_PreparedProjection | None]:
+        if not self._preparation_workers:
+            for row in pending:
+                yield self._prepare_pending(str(row["position_key"]))
+            return
+        if not pending:
+            return
+        if self._preparation_pool is None:
+            # Spawn never inherits the writer connection, locks or web threads.
+            self._preparation_pool = ProcessPoolExecutor(
+                max_workers=self._preparation_workers,
+                mp_context=multiprocessing.get_context("spawn"),
+                initializer=_initialize_preparation_worker,
+                initargs=(str(self.store.path),),
+            )
+        pool = self._preparation_pool
+        source = iter(pending)
+        waiting: deque[Future[_PreparedProjection | None]] = deque()
+        try:
+            for row in islice(source, self._preparation_workers * 2):
+                waiting.append(pool.submit(
+                    _prepare_in_worker, str(row["position_key"]),
+                ))
+            while waiting:
+                prepared = waiting.popleft().result()
+                row = next(source, None)
+                if row is not None:
+                    waiting.append(pool.submit(
+                        _prepare_in_worker, str(row["position_key"]),
+                    ))
+                yield prepared
+        except BrokenProcessPool:
+            pool.shutdown(wait=False, cancel_futures=True)
+            self._preparation_pool = None
+            raise
+        finally:
+            for future in waiting:
+                future.cancel()
 
     @property
     def owners_revision(self) -> int:
@@ -1718,6 +1804,7 @@ class AccountBook:
             pending = self._pending_rows(bounded)
             if pending:
                 worked = True
+            prepared_rows = iter(self._prepared_pending(pending))
             cursor = 0
             while cursor < len(pending):
                 prepared_batch: list[_PreparedProjection] = []
@@ -1730,11 +1817,8 @@ class AccountBook:
                         < _PENDING_PREPARATION_SECONDS
                     )
                 ):
-                    row = pending[cursor]
+                    prepared = next(prepared_rows)
                     cursor += 1
-                    prepared = self._prepare_pending(
-                        str(row["position_key"]),
-                    )
                     if prepared is not None:
                         prepared_batch.append(prepared)
                 published = 0

--- a/src/rhpools/lp_market_accounting.py
+++ b/src/rhpools/lp_market_accounting.py
@@ -1798,6 +1798,34 @@ class AccountBook:
             self._invalidate_cache(conn, affected_pools)
             return True
 
+    def recover_receipt_costs(
+            self, tx_hashes: Iterable[str], *, epoch: int,
+    ) -> None:
+        """Refresh already-published histories whose receipt costs arrived later."""
+        selected = sorted(set(tx_hashes))
+        for offset in range(0, len(selected), 32):
+            batch = selected[offset:offset + 32]
+            marks = ",".join("?" for _ in batch)
+            with self.store.transaction() as conn:
+                if self._store_metadata_int(conn, "epoch") != epoch:
+                    return
+                stale = conn.execute(
+                    "SELECT t.tx_hash,c.episode_id FROM transactions t "
+                    "LEFT JOIN lp_accounting_tx_costs c ON c.tx_hash=t.tx_hash "
+                    f"WHERE t.tx_hash IN ({marks}) AND (c.tx_hash IS NULL "
+                    "OR c.payer IS NOT t.payer OR c.gas_usd IS NOT t.gas_usd)",
+                    batch,
+                ).fetchall()
+                if not stale:
+                    continue
+                affected_txs = {str(row[0]) for row in stale}
+                previous_episodes = {str(row[1]) for row in stale if row[1]}
+                self._rebuild_tx_costs(conn, affected_txs)
+                self._refresh_episode_costs(
+                    conn, affected_txs, episode_ids=previous_episodes,
+                )
+                self._invalidate_cache(conn, ())
+
     @staticmethod
     def _invalidate_legacy_core_values(
             conn: sqlite3.Connection, keys: Iterable[str],

--- a/src/rhpools/lp_market_claims.py
+++ b/src/rhpools/lp_market_claims.py
@@ -95,6 +95,10 @@ def fetch_position_claims(
                 decoder = "v3_nfpm_position"
                 indices["position"] = request(manager, NFT_POSITIONS_SELECTOR + _word(int(token_id)))
             else:
+                prefix = f"v3:{pool['id']}:"
+                if not key.startswith(prefix):
+                    continue
+                key = key[len(prefix):]
                 if len(key) != 66 or not key.startswith("0x"):
                     continue
                 decoder = "v3_core_position"
@@ -110,6 +114,11 @@ def fetch_position_claims(
                 if manager != V4_POSITION_MANAGER:
                     continue
                 key = _v4_position_key(manager, lower, upper, "0x" + _word(int(token_id)))
+            else:
+                prefix = f"v4:{pool['id']}:"
+                if not key.startswith(prefix):
+                    continue
+                key = key[len(prefix):]
             if len(key) != 66 or not key.startswith("0x"):
                 continue
             decoder = "v4_state_view_position"

--- a/src/rhpools/lp_market_claims.py
+++ b/src/rhpools/lp_market_claims.py
@@ -1,0 +1,360 @@
+"""Bounded wallet evidence recovery and block-pinned outstanding LP claims."""
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
+
+from .lp_chain import STATE_VIEW
+from .lp_math import fee_claim, fee_growth_amount
+from .lp_market_protocols import (
+    LIQUIDITY_SELECTOR, NFT_POSITIONS_SELECTOR, POSITIONS_SELECTOR, SLOT0_SELECTOR,
+    STATE_VIEW_LIQUIDITY_SELECTOR, STATE_VIEW_POSITION_SELECTOR, STATE_VIEW_SLOT0_SELECTOR,
+    V3_NFT_MANAGER_ADDRESSES, V4_POSITION_MANAGER,
+    _decode_position_result, _selector, _sint, _uint, _v4_position_key,
+    _word_address, _words, nft_position_key,
+)
+from .lp_market_store import CanonicalConflict
+from .workbench_market import _price_from_sqrt
+
+_FEE_GLOBAL0 = _selector("feeGrowthGlobal0X128()")
+_FEE_GLOBAL1 = _selector("feeGrowthGlobal1X128()")
+_TICKS = _selector("ticks(int24)")
+_FEE_INSIDE = _selector("getFeeGrowthInside(bytes32,int24,int24)")
+_OWNER_OF = _selector("ownerOf(uint256)")
+
+
+def _word(value: int) -> str:
+    return (value % (1 << 256)).to_bytes(32, "big").hex()
+
+
+def fetch_position_claims(
+    store, book, prices, client, positions: Sequence[Mapping[str, Any]], *,
+    admit: Callable[[int], None] | None = None,
+):
+    """Read principal and outstanding claims at one canonical end-of-block pin."""
+    if not positions:
+        return []
+    with book._reader() as conn:
+        cursor = store._metadata(conn, "cursor:live", {})
+        if not cursor:
+            return []
+        number = int(cursor["block_number"])
+        header = conn.execute(
+            "SELECT hash,timestamp FROM blocks WHERE number=?", (number,),
+        ).fetchone()
+        if header is None:
+            return []
+        block_hash, timestamp = str(header["hash"]), int(header["timestamp"])
+        epoch = int(store._metadata(conn, "epoch", 0))
+        pools = {}
+        for position in positions:
+            pool_id = position.get("pool_id")
+            if pool_id and pool_id not in pools:
+                pool = conn.execute("SELECT * FROM pools WHERE id=?", (pool_id,)).fetchone()
+                if pool is not None:
+                    pools[pool_id] = dict(pool)
+    calls = []
+    call_indexes = {}
+
+    def request(target, data):
+        key = (target, data)
+        if key not in call_indexes:
+            call_indexes[key] = len(calls)
+            calls.append(("eth_call", [{"to": target, "data": data}, hex(number)]))
+        return call_indexes[key]
+
+    planned = []
+    for position in positions:
+        pool = pools.get(position.get("pool_id"))
+        if pool is None or not position.get("liquidity_known"):
+            continue
+        if position.get("tick_lower") is None or position.get("tick_upper") is None:
+            continue
+        if int(position["last_block"]) > number:
+            continue
+        protocol = position.get("protocol")
+        lower, upper = int(position["tick_lower"]), int(position["tick_upper"])
+        if lower >= upper:
+            continue
+        key = str(position["position_key"])
+        manager, token_id = position.get("custody"), position.get("token_id")
+        indices = {}
+        if key.startswith("nft:"):
+            if token_id is None or key != nft_position_key(manager, token_id):
+                continue
+            if manager not in V3_NFT_MANAGER_ADDRESSES and manager != V4_POSITION_MANAGER:
+                continue
+            indices["owner"] = request(manager, _OWNER_OF + _word(int(token_id)))
+        if protocol == "v3":
+            if key.startswith("nft:"):
+                if manager not in V3_NFT_MANAGER_ADDRESSES:
+                    continue
+                decoder = "v3_nfpm_position"
+                indices["position"] = request(manager, NFT_POSITIONS_SELECTOR + _word(int(token_id)))
+            else:
+                if len(key) != 66 or not key.startswith("0x"):
+                    continue
+                decoder = "v3_core_position"
+                indices["position"] = request(pool["id"], POSITIONS_SELECTOR + key[2:])
+            indices["slot"] = request(pool["id"], SLOT0_SELECTOR)
+            indices["active_liquidity"] = request(pool["id"], LIQUIDITY_SELECTOR)
+            indices["global0"] = request(pool["id"], _FEE_GLOBAL0)
+            indices["global1"] = request(pool["id"], _FEE_GLOBAL1)
+            indices["lower"] = request(pool["id"], _TICKS + _word(lower))
+            indices["upper"] = request(pool["id"], _TICKS + _word(upper))
+        elif protocol == "v4":
+            if key.startswith("nft:"):
+                if manager != V4_POSITION_MANAGER:
+                    continue
+                key = _v4_position_key(manager, lower, upper, "0x" + _word(int(token_id)))
+            if len(key) != 66 or not key.startswith("0x"):
+                continue
+            decoder = "v4_state_view_position"
+            indices["position"] = request(
+                STATE_VIEW, STATE_VIEW_POSITION_SELECTOR + pool["id"][2:] + key[2:],
+            )
+            indices["slot"] = request(STATE_VIEW, STATE_VIEW_SLOT0_SELECTOR + pool["id"][2:])
+            indices["active_liquidity"] = request(
+                STATE_VIEW, STATE_VIEW_LIQUIDITY_SELECTOR + pool["id"][2:],
+            )
+            indices["inside"] = request(
+                STATE_VIEW, _FEE_INSIDE + pool["id"][2:] + _word(lower) + _word(upper),
+            )
+        else:
+            continue
+        planned.append((position, pool, decoder, indices))
+    if not planned:
+        return []
+    results = []
+    for offset in range(0, len(calls), 100):
+        if admit is not None:
+            admit(min(100, len(calls) - offset))
+        results.extend(client.batch(calls[offset:offset + 100], allow_reverts=True))
+    if len(results) != len(calls):
+        raise ValueError("claim request/result count mismatch")
+    verified = client.call("eth_getBlockByNumber", [hex(number), False])
+    if not isinstance(verified, Mapping) or str(verified.get("hash", "")).lower() != block_hash:
+        raise CanonicalConflict("claim snapshot block is no longer canonical")
+    output = []
+    for position, pool, decoder, indices in planned:
+        # A reverted/burned NFT cannot prevent healthy siblings from refreshing.
+        if any(isinstance(results[index], Mapping) for index in indices.values()):
+            continue
+        state = _decode_position_result(decoder, results[indices["position"]])
+        liquidity = int(state["liquidity"])
+        if liquidity != int(position["liquidity"]):
+            continue
+        if "owner" in indices:
+            owner = _word_address(_words(results[indices["owner"]], "claim owner", 1)[0], "claim owner")
+            if owner != position.get("owner"):
+                continue
+        if decoder == "v3_nfpm_position" and any(
+            state[field] != expected for field, expected in (
+                ("tick_lower", int(position["tick_lower"])),
+                ("tick_upper", int(position["tick_upper"])),
+                ("token0", pool["token0"]), ("token1", pool["token1"]),
+                ("fee_ppm", pool["fee_ppm"]),
+            )
+        ):
+            continue
+        slot = _words(results[indices["slot"]], "claim pool slot")
+        if len(slot) < 2:
+            raise ValueError("claim pool slot is incomplete")
+        sqrt = _uint(slot[0], 160, "claim pool sqrt price")
+        tick = _sint(slot[1], 24, "claim pool tick")
+        if sqrt <= 0:
+            continue
+        last0 = int(state["fee_growth_inside0_last_x128"])
+        last1 = int(state["fee_growth_inside1_last_x128"])
+        if position["protocol"] == "v3":
+            global0 = _words(results[indices["global0"]], "claim fee growth0", 1)[0]
+            global1 = _words(results[indices["global1"]], "claim fee growth1", 1)[0]
+            lower = _words(results[indices["lower"]], "claim lower tick")
+            upper = _words(results[indices["upper"]], "claim upper tick")
+            if len(lower) < 4 or len(upper) < 4:
+                raise ValueError("claim tick fee state is incomplete")
+            claim0, claim1, _lazy0, _lazy1 = fee_claim(
+                liquidity, last0, last1, int(state["tokens_owed0"]), int(state["tokens_owed1"]),
+                global0, global1, lower[2], lower[3], upper[2], upper[3], tick,
+                int(position["tick_lower"]), int(position["tick_upper"]),
+            )
+        else:
+            inside = _words(results[indices["inside"]], "V4 claim fee growth", 2)
+            claim0 = fee_growth_amount(liquidity, inside[0], last0)
+            claim1 = fee_growth_amount(liquidity, inside[1], last1)
+        active_liquidity = _uint(
+            _words(results[indices["active_liquidity"]], "claim pool liquidity", 1)[0],
+            128, "claim pool liquidity",
+        )
+        ratio = (
+            _price_from_sqrt(sqrt, pool["decimals0"], pool["decimals1"])
+            if active_liquidity > 0 else None
+        )
+        mark = {"block_number": number, "tx_index": 2**31 - 1,
+                "log_index": 2**31 - 1, "timestamp": timestamp}
+        with book._reader() as conn:
+            price0, price1, _basis = prices._quote(conn, pool, mark, ratio)
+        output.append({
+            "position_key": position["position_key"], "epoch": epoch,
+            "block_number": number, "block_hash": block_hash, "timestamp": timestamp,
+            "position_last_block": int(position["last_block"]),
+            "position_last_tx_index": int(position["last_tx_index"]),
+            "position_last_log_index": int(position["last_log_index"]),
+            "position_pending_principal0": position["pending_principal0"],
+            "position_pending_principal1": position["pending_principal1"],
+            "position_pending_known": int(position["pending_known"]),
+            "position_state_json": position["state_json"],
+            "liquidity": str(liquidity), "sqrt_price_x96": str(sqrt), "tick": tick,
+            "price0_usd": price0, "price1_usd": price1,
+            "claim0": str(claim0), "claim1": str(claim1),
+        })
+    return output
+
+
+class PositionClaims:
+    """Refresh visible wallets without synchronous RPC or request-side writes."""
+
+    def __init__(self, store, book, prices, rpc: Callable[[], Any]):
+        self.store, self.book, self.prices, self.rpc = store, book, prices, rpc
+        self._lock = threading.Lock()
+        self._stop = threading.Event()
+        self._owners: OrderedDict[str, dict[str, Any]] = OrderedDict()
+        self._event_cursors: OrderedDict[str, int] = OrderedDict()
+        self._thread: threading.Thread | None = None
+        self._rpc_next = 0.0
+        self._status = {"refreshed_positions": 0, "last_success": None, "last_error": None}
+
+    def request(self, owners: Sequence[str], *, priority: bool = False) -> None:
+        now = time.monotonic()
+        with self._lock:
+            for owner in owners:
+                if not isinstance(owner, str) or len(owner) != 42 or not owner.startswith("0x"):
+                    continue
+                owner = owner.lower()
+                if owner not in self._owners:
+                    self._owners[owner] = {"expires": now + 180, "due": 0.0,
+                                           "positions": "", "episodes": ""}
+                else:
+                    self._owners[owner]["expires"] = now + 180
+                if priority:
+                    self._owners.move_to_end(owner, last=False)
+            while len(self._owners) > 512:
+                self._owners.popitem(last=priority)
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, name="lp-market-claims", daemon=True)
+        self._thread.start()
+
+    def close(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join()
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            return {**self._status, "requested_wallets": len(self._owners)}
+
+    def _next(self):
+        now = time.monotonic()
+        with self._lock:
+            for owner, state in tuple(self._owners.items()):
+                if state["expires"] <= now:
+                    del self._owners[owner]
+                elif state["due"] <= now:
+                    state["due"] = now + 5.0
+                    self._owners.move_to_end(owner)
+                    return owner, state
+        return None
+
+    def _admit(self, items: int) -> None:
+        # Current claims borrow at most 8 of the shared 80 state items/second.
+        if self._stop.wait(max(0.0, self._rpc_next - time.monotonic())):
+            raise RuntimeError("claim refresh stopped")
+        self._rpc_next = time.monotonic() + items / 8.0
+
+    def _refresh(self, owner, state):
+        with self.book._reader() as conn:
+            positions = [dict(row) for row in conn.execute(
+                "SELECT p.*,c.timestamp AS claim_timestamp,c.epoch AS claim_epoch "
+                "FROM lp_accounting_positions p "
+                "INDEXED BY lp_accounting_positions_owner_active_key "
+                "LEFT JOIN lp_accounting_claims c ON c.position_key=p.position_key "
+                "AND c.position_state_json=p.state_json "
+                "WHERE p.owner=? AND p.active_episode_id IS NOT NULL AND p.position_key>? "
+                "ORDER BY p.position_key LIMIT 4", (owner, state["positions"]),
+            ).fetchall()]
+            state["positions"] = positions[-1]["position_key"] if len(positions) == 4 else ""
+            historical = [str(row[0]) for row in conn.execute(
+                "SELECT DISTINCT position_key FROM lp_accounting_episodes "
+                "INDEXED BY lp_accounting_episodes_owner_position "
+                "WHERE owner=? AND position_key>? ORDER BY position_key LIMIT 4",
+                (owner, state["episodes"]),
+            ).fetchall()]
+            state["episodes"] = historical[-1] if len(historical) == 4 else ""
+            keys = set(historical) | {row["position_key"] for row in positions}
+            pending = set()
+            tx_hashes = set()
+            for key in keys:
+                if conn.execute(
+                    "SELECT 1 FROM lp_accounting_pending WHERE position_key=?", (key,),
+                ).fetchone() is not None:
+                    pending.add(key)
+                cursor = self._event_cursors.get(key, 0)
+                page = conn.execute(
+                    "SELECT event_id FROM lp_accounting_event_keys "
+                    "WHERE position_key=? AND event_id>? ORDER BY event_id LIMIT 64",
+                    (key, cursor),
+                ).fetchall()
+                self._event_cursors[key] = int(page[-1][0]) if len(page) == 64 else 0
+                self._event_cursors.move_to_end(key)
+                if page:
+                    marks = ",".join("?" for _ in page)
+                    tx_hashes.update(str(row[0]) for row in conn.execute(
+                        "SELECT DISTINCT p.tx_hash FROM events e "
+                        "JOIN pending_enrichment p ON p.tx_hash=e.tx_hash "
+                        f"WHERE e.id IN ({marks})", tuple(int(row[0]) for row in page),
+                    ))
+            epoch = int(self.store._metadata(conn, "epoch", 0))
+        while len(self._event_cursors) > 2048:
+            self._event_cursors.popitem(last=False)
+        self.store.prioritize_enrichment(tx_hashes)
+        self.book.prioritize_positions(keys)
+        positions = [row for row in positions
+                     if row["position_key"] not in pending and row["liquidity_known"]
+                     and (row["claim_epoch"] != epoch or row["claim_timestamp"] is None
+                          or time.time() - row["claim_timestamp"] >= 10)]
+        if not positions or self._stop.is_set():
+            return
+        claims = fetch_position_claims(
+            self.store, self.book, self.prices, self.rpc(), positions, admit=self._admit,
+        )
+        if self._stop.is_set():
+            return
+        if claims and self.book.publish_claims(claims):
+            with self._lock:
+                self._status.update(
+                    last_success=time.time(),
+                    last_error=(
+                        None if len(claims) == len(positions)
+                        else "some positions await matching pinned claim evidence"
+                    ),
+                )
+                self._status["refreshed_positions"] += len(claims)
+
+    def _run(self):
+        try:
+            while not self._stop.is_set():
+                item = self._next()
+                if item is None:
+                    self._stop.wait(0.25)
+                    continue
+                try:
+                    self._refresh(*item)
+                except Exception as exc:
+                    with self._lock:
+                        self._status["last_error"] = str(exc)
+        finally:
+            self.store.close_reader()

--- a/src/rhpools/lp_market_claims.py
+++ b/src/rhpools/lp_market_claims.py
@@ -306,6 +306,7 @@ class PositionClaims:
             keys = set(historical) | {row["position_key"] for row in positions}
             pending = set()
             tx_hashes = set()
+            stale_costs = set()
             for key in keys:
                 if conn.execute(
                     "SELECT 1 FROM lp_accounting_pending WHERE position_key=?", (key,),
@@ -321,16 +322,26 @@ class PositionClaims:
                 self._event_cursors.move_to_end(key)
                 if page:
                     marks = ",".join("?" for _ in page)
-                    tx_hashes.update(str(row[0]) for row in conn.execute(
-                        "SELECT DISTINCT p.tx_hash FROM events e "
-                        "JOIN pending_enrichment p ON p.tx_hash=e.tx_hash "
+                    for row in conn.execute(
+                        "SELECT DISTINCT e.tx_hash,p.tx_hash,t.tx_hash IS NOT NULL AND "
+                        "(c.tx_hash IS NULL OR c.payer IS NOT t.payer "
+                        "OR c.gas_usd IS NOT t.gas_usd) AS stale_cost "
+                        "FROM events e LEFT JOIN pending_enrichment p ON p.tx_hash=e.tx_hash "
+                        "LEFT JOIN transactions t ON t.tx_hash=e.tx_hash "
+                        "LEFT JOIN lp_accounting_tx_costs c ON c.tx_hash=e.tx_hash "
                         f"WHERE e.id IN ({marks})", tuple(int(row[0]) for row in page),
-                    ))
+                    ):
+                        if row[1] is not None:
+                            tx_hashes.add(str(row[0]))
+                        if row[2]:
+                            stale_costs.add(str(row[0]))
             epoch = int(self.store._metadata(conn, "epoch", 0))
         while len(self._event_cursors) > 2048:
             self._event_cursors.popitem(last=False)
         self.store.prioritize_enrichment(tx_hashes)
         self.book.prioritize_positions(keys)
+        if stale_costs and not self._stop.is_set():
+            self.book.recover_receipt_costs(stale_costs, epoch=epoch)
         positions = [row for row in positions
                      if row["position_key"] not in pending and row["liquidity_known"]
                      and (row["claim_epoch"] != epoch or row["claim_timestamp"] is None

--- a/src/rhpools/lp_market_index.py
+++ b/src/rhpools/lp_market_index.py
@@ -64,8 +64,12 @@ HISTORY_MAX_CHUNK = 32_768
 # Background history uses a shorter writer target so financial lanes can run.
 MAX_INTERVAL_STORE_SECONDS = 2.0
 HISTORY_MAX_INTERVAL_STORE_SECONDS = 0.2
-ENRICH_BATCH = 8
+ENRICH_BATCH = 4
 ENRICHMENT_CAPABILITY_RECHECK_S = 300.0
+ENRICH_TRACE_BATCH = 2
+ENRICH_WORKERS = 8
+ENRICH_TRACE_WORKERS = 4
+ENRICH_INFLIGHT_LIMIT = ENRICH_BATCH * ENRICH_WORKERS
 REPROJECT_BATCH = 128
 V4_OWNER_REPAIR_LIMIT = 32
 V4_OWNER_REPAIR_SCAN = 8192
@@ -396,7 +400,10 @@ class MarketIndexer:
         self._publish_after_id = ""
         self._market_epoch = int(self.store.status().get("epoch", 0))
         self._enrichment_local = threading.local()
-        self._enrichment_jobs: dict[str, tuple[Mapping[str, Any], Future, float]] = {}
+        self._enrichment_jobs: dict[
+            tuple[str, ...],
+            tuple[tuple[Mapping[str, Any], ...], Future, float, bool],
+        ] = {}
         self._worker_clients: list[Any] = []
         self._worker_clients_lock = threading.Lock()
         self._feed_condition = threading.Condition()
@@ -423,7 +430,12 @@ class MarketIndexer:
             max_workers=2, thread_name_prefix="lp-current-pool",
         )
         self._enrichment_executor = ThreadPoolExecutor(
-            max_workers=ENRICH_BATCH, thread_name_prefix="lp-market-fetch",
+            max_workers=ENRICH_WORKERS,
+            thread_name_prefix="lp-market-fetch",
+        )
+        self._trace_enrichment_executor = ThreadPoolExecutor(
+            max_workers=ENRICH_TRACE_WORKERS,
+            thread_name_prefix="lp-market-trace",
         )
         self._header_executor = ThreadPoolExecutor(
             max_workers=2, thread_name_prefix="lp-market-headers",
@@ -1929,6 +1941,9 @@ class MarketIndexer:
                     wait=True, cancel_futures=True,
                 )
                 self._enrichment_executor.shutdown(
+                    wait=True, cancel_futures=True,
+                )
+                self._trace_enrichment_executor.shutdown(
                     wait=True, cancel_futures=True,
                 )
                 self._header_executor.shutdown(
@@ -4121,101 +4136,283 @@ class MarketIndexer:
         results = self._batch_on(selected, unique, allow_reverts=True)
         return [results[index] for index in order]
 
+    @staticmethod
+    def _apply_position_state_updates(
+        events: Sequence[dict[str, Any]],
+        state_updates: Sequence[Mapping[str, Any]],
+    ) -> None:
+        by_identity = {
+            (
+                _lower(event.get("block_hash")),
+                _lower(event.get("tx_hash")),
+                int(event.get("log_index", -1)),
+            ): event
+            for event in events
+        }
+        for update in state_updates:
+            identity = update.get("identity")
+            if not isinstance(identity, Mapping):
+                raise ValueError("position state decoder omitted event identity")
+            key = (
+                _lower(identity.get("block_hash")),
+                _lower(identity.get("tx_hash")),
+                int(identity.get("log_index", -1)),
+            )
+            event = by_identity.get(key)
+            if event is None:
+                raise ValueError(
+                    "position state decoder returned an unknown event identity"
+                )
+            data_update = update.get("data")
+            if not isinstance(data_update, Mapping):
+                raise ValueError(
+                    "position state decoder returned malformed event data"
+                )
+            data = event.get("data")
+            merged = dict(data) if isinstance(data, Mapping) else {}
+            merged.update(data_update)
+            event["data"] = merged
+
+    @staticmethod
+    def _requires_v4_trace(receipt: Mapping[str, Any]) -> bool:
+        logs = receipt.get("logs")
+        if not isinstance(logs, Sequence) or isinstance(logs, (str, bytes)):
+            return False
+        for log in logs:
+            if not isinstance(log, Mapping):
+                continue
+            topics = log.get("topics")
+            if (
+                _lower(log.get("address")) == POOL_MANAGER
+                and isinstance(topics, Sequence)
+                and not isinstance(topics, (str, bytes))
+                and bool(topics)
+                and _lower(topics[0]) == V4_MODIFY_LIQUIDITY_TOPIC
+            ):
+                return True
+        return False
+
+    def _enrich_transactions(
+        self, pending_rows: Sequence[Mapping[str, Any]],
+    ) -> list[
+        tuple[
+            Mapping[str, Any],
+            list[dict[str, Any]] | None,
+            dict[str, Any] | None,
+            Exception | None,
+        ]
+    ]:
+        """Fetch one bounded wave while isolating transaction-level evidence."""
+        if self._stop.is_set():
+            raise RpcError("indexer closed before enrichment fetch")
+        rows = tuple(pending_rows)
+        if not rows:
+            return []
+        client = self._worker_rpc()
+        receipts = self._batch_on(client, [
+            ("eth_getTransactionReceipt", [_lower(row["tx_hash"])])
+            for row in rows
+        ])
+        prepared: dict[str, dict[str, Any]] = {}
+        errors: dict[str, Exception] = {}
+        needs_body: list[str] = []
+        for row, receipt in zip(rows, receipts):
+            tx_hash = _lower(row["tx_hash"])
+            try:
+                if not isinstance(receipt, Mapping):
+                    raise RpcError(
+                        f"transaction {tx_hash} receipt unavailable"
+                    )
+                if _lower(receipt.get("transactionHash")) != tx_hash:
+                    raise RpcError(
+                        f"transaction {tx_hash} receipt identity mismatch"
+                    )
+                block_number = _hex_int(
+                    receipt.get("blockNumber"), "receipt block number"
+                )
+                block_hash = _lower(receipt.get("blockHash"))
+                if (
+                    block_number != int(row["block_number"])
+                    or block_hash != _lower(row["block_hash"])
+                ):
+                    raise CanonicalConflict(
+                        f"pending transaction {tx_hash} moved to another block"
+                    )
+                raw_logs = receipt.get("logs")
+                if not isinstance(raw_logs, list):
+                    raise RpcError(f"transaction {tx_hash} receipt omitted logs")
+                if any(not isinstance(log, Mapping) for log in raw_logs):
+                    raise RpcError(
+                        f"transaction {tx_hash} receipt contains malformed logs"
+                    )
+                prepared[tx_hash] = {
+                    "row": row,
+                    "receipt": dict(receipt),
+                    "transaction": {},
+                    "block_number": block_number,
+                    "block_hash": block_hash,
+                    "raw_logs": [dict(log) for log in raw_logs],
+                    "trace": None,
+                }
+                if (
+                    receipt.get("effectiveGasPrice") is None
+                    or receipt.get("from") is None
+                ):
+                    needs_body.append(tx_hash)
+            except Exception as exc:
+                errors[tx_hash] = exc
+
+        if needs_body:
+            bodies = self._batch_on(client, [
+                ("eth_getTransactionByHash", [tx_hash])
+                for tx_hash in needs_body
+            ])
+            for tx_hash, transaction in zip(needs_body, bodies):
+                try:
+                    if (
+                        not isinstance(transaction, Mapping)
+                        or _lower(transaction.get("hash")) != tx_hash
+                    ):
+                        raise RpcError(
+                            f"transaction {tx_hash} fallback body unavailable"
+                        )
+                    prepared[tx_hash]["transaction"] = dict(transaction)
+                except Exception as exc:
+                    errors[tx_hash] = exc
+                    prepared.pop(tx_hash)
+
+        # Trace calls stay independent. One pruned or malformed trace must not
+        # discard successful siblings from the receipt wave.
+        for tx_hash, context in tuple(prepared.items()):
+            if not self._requires_v4_trace(context["receipt"]):
+                continue
+            try:
+                trace = client.call("debug_traceTransaction", [
+                    tx_hash,
+                    {
+                        "tracer": "callTracer",
+                        "tracerConfig": {"withLog": True},
+                        # Missing historical state stays pending; never rebuild
+                        # it on the authoritative live node.
+                        "reexec": 0,
+                        "timeout": "5s",
+                    },
+                ])
+                if not isinstance(trace, Mapping):
+                    raise RpcError(
+                        f"transaction {tx_hash} returned a malformed call trace"
+                    )
+                context["trace"] = dict(trace)
+            except Exception as exc:
+                errors[tx_hash] = exc
+                prepared.pop(tx_hash)
+
+        block_numbers = sorted({
+            int(context["block_number"]) for context in prepared.values()
+        })
+        raw_headers = self._batch_on(client, [
+            ("eth_getBlockByNumber", [hex(number), False])
+            for number in block_numbers
+        ])
+        headers: dict[int, dict[str, Any]] = {}
+        for number, raw_header in zip(block_numbers, raw_headers):
+            try:
+                headers[number] = _header(raw_header, number)
+            except Exception as exc:
+                for tx_hash, context in tuple(prepared.items()):
+                    if int(context["block_number"]) == number:
+                        errors[tx_hash] = exc
+                        prepared.pop(tx_hash)
+        for tx_hash, context in tuple(prepared.items()):
+            header = headers[int(context["block_number"])]
+            if header["hash"] != context["block_hash"]:
+                errors[tx_hash] = CanonicalConflict(
+                    f"pending transaction {tx_hash} is orphaned"
+                )
+                prepared.pop(tx_hash)
+
+        decoded: dict[str, tuple[list[dict[str, Any]], list[dict[str, Any]]]] = {}
+        all_state_requests: list[dict[str, Any]] = []
+        state_slices: dict[str, tuple[int, int]] = {}
+        for tx_hash, context in tuple(prepared.items()):
+            try:
+                block_number = int(context["block_number"])
+                traces = (
+                    {tx_hash: context["trace"]}
+                    if context["trace"] is not None
+                    else None
+                )
+                events = self._decode(
+                    "enrichment",
+                    context["raw_logs"],
+                    {block_number: headers[block_number]},
+                    receipts={tx_hash: context["receipt"]},
+                    traces=traces,
+                    resolve_unknown=False,
+                )
+                if not events:
+                    raise ValueError(
+                        f"enrichment decoder returned no events for {tx_hash}"
+                    )
+                requests_ = list(position_state_requests(events))
+                start = len(all_state_requests)
+                all_state_requests.extend(requests_)
+                state_slices[tx_hash] = (start, len(all_state_requests))
+                decoded[tx_hash] = (events, requests_)
+            except Exception as exc:
+                errors[tx_hash] = exc
+                prepared.pop(tx_hash)
+
+        state_results = (
+            self._rpc_state_batch(
+                self._state_rpc_calls(all_state_requests), client,
+            )
+            if all_state_requests
+            else []
+        )
+        completed: dict[
+            str, tuple[list[dict[str, Any]], dict[str, Any]]
+        ] = {}
+        for tx_hash, context in tuple(prepared.items()):
+            try:
+                events, requests_ = decoded[tx_hash]
+                start, end = state_slices[tx_hash]
+                if requests_:
+                    state_updates = decode_position_state_results(
+                        requests_, state_results[start:end],
+                    )
+                    self._apply_position_state_updates(events, state_updates)
+                gas = decode_gas_record(
+                    context["receipt"], context["transaction"],
+                )
+                if not isinstance(gas, Mapping):
+                    raise ValueError("gas decoder returned a malformed record")
+                gas_record = dict(gas)
+                if gas_record.get("gas_native") is not None:
+                    gas_record["gas_native"] = str(gas_record["gas_native"])
+                completed[tx_hash] = (events, gas_record)
+            except Exception as exc:
+                errors[tx_hash] = exc
+
+        return [
+            (
+                row,
+                completed.get(_lower(row["tx_hash"]), (None, None))[0],
+                completed.get(_lower(row["tx_hash"]), (None, None))[1],
+                errors.get(_lower(row["tx_hash"])),
+            )
+            for row in rows
+        ]
+
     def _enrich_transaction(
         self, pending: Mapping[str, Any],
     ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
-        if self._stop.is_set():
-            raise RpcError("indexer closed before enrichment fetch")
-        client = self._worker_rpc()
-        tx_hash = _lower(pending["tx_hash"])
-        receipt, transaction = self._batch_on(client, [
-            ("eth_getTransactionReceipt", [tx_hash]),
-            ("eth_getTransactionByHash", [tx_hash]),
-        ])
-        if not isinstance(receipt, Mapping) or not isinstance(transaction, Mapping):
-            raise RpcError(f"transaction {tx_hash} receipt/body unavailable")
-        block_number = _hex_int(receipt.get("blockNumber"), "receipt block number")
-        block_hash = _lower(receipt.get("blockHash"))
-        if block_number != int(pending["block_number"]) or block_hash != _lower(pending["block_hash"]):
-            raise CanonicalConflict(f"pending transaction {tx_hash} moved to another block")
-        raw_logs = receipt.get("logs")
-        if not isinstance(raw_logs, list):
-            raise RpcError(f"transaction {tx_hash} receipt omitted logs")
-        if any(not isinstance(log, Mapping) for log in raw_logs):
-            raise RpcError(f"transaction {tx_hash} receipt contains malformed logs")
-        traces = None
-        if any(
-            _lower(log.get("address")) == POOL_MANAGER
-            and _lower((log.get("topics") or [None])[0]) == V4_MODIFY_LIQUIDITY_TOPIC
-            for log in raw_logs
-        ):
-            trace = client.call("debug_traceTransaction", [
-                tx_hash,
-                {
-                    "tracer": "callTracer", "tracerConfig": {"withLog": True},
-                    # Missing historical state stays pending; never rebuild it
-                    # on the authoritative live node.
-                    "reexec": 0, "timeout": "5s",
-                },
-            ])
-            if not isinstance(trace, Mapping):
-                raise RpcError(f"transaction {tx_hash} returned a malformed call trace")
-            traces = {tx_hash: dict(trace)}
-        header = _header(
-            client.call("eth_getBlockByNumber", [hex(block_number), False]),
-            block_number,
-        )
-        if header["hash"] != block_hash:
-            raise CanonicalConflict(f"pending transaction {tx_hash} is orphaned")
-        events = self._decode(
-            "enrichment",
-            [dict(log) for log in raw_logs],
-            {block_number: header},
-            receipts={tx_hash: dict(receipt)},
-            traces=traces,
-            resolve_unknown=False,
-        )
-        if not events:
-            raise ValueError(f"enrichment decoder returned no events for {tx_hash}")
-        requests_ = list(position_state_requests(events))
-        if requests_:
-            state_results = self._rpc_state_batch(
-                self._state_rpc_calls(requests_), client,
-            )
-            state_updates = decode_position_state_results(requests_, state_results)
-            if state_updates is not None:
-                by_identity = {
-                    (
-                        _lower(event.get("block_hash")), _lower(event.get("tx_hash")),
-                        int(event.get("log_index", -1)),
-                    ): event
-                    for event in events
-                }
-                for update in state_updates:
-                    identity = update.get("identity")
-                    if not isinstance(identity, Mapping):
-                        raise ValueError("position state decoder omitted event identity")
-                    key = (
-                        _lower(identity.get("block_hash")), _lower(identity.get("tx_hash")),
-                        int(identity.get("log_index", -1)),
-                    )
-                    event = by_identity.get(key)
-                    if event is None:
-                        raise ValueError("position state decoder returned an unknown event identity")
-                    data_update = update.get("data")
-                    if not isinstance(data_update, Mapping):
-                        raise ValueError("position state decoder returned malformed event data")
-                    data = event.get("data")
-                    merged = dict(data) if isinstance(data, Mapping) else {}
-                    merged.update(data_update)
-                    event["data"] = merged
-        gas = decode_gas_record(dict(receipt), dict(transaction))
-        if not isinstance(gas, Mapping):
-            raise ValueError("gas decoder returned a malformed record")
-        gas_record = dict(gas)
-        if gas_record.get("gas_native") is not None:
-            gas_record["gas_native"] = str(gas_record["gas_native"])
-        return events, gas_record
+        _row, events, transaction, error = self._enrich_transactions([pending])[0]
+        if error is not None:
+            raise error
+        if events is None or transaction is None:
+            raise RuntimeError("enrichment wave omitted its transaction result")
+        return events, transaction
 
     @staticmethod
     def _trace_capability_error(error: BaseException) -> bool:
@@ -4251,57 +4448,137 @@ class MarketIndexer:
             self.store.mark_enrichment_error(str(row["tx_hash"]), str(error), delay=delay)
         return True
 
+    def _pending_v4_trace_hashes(
+        self, rows: Sequence[Mapping[str, Any]],
+    ) -> set[str]:
+        hashes = tuple(dict.fromkeys(str(row["tx_hash"]) for row in rows))
+        if not hashes:
+            return set()
+        marks = ",".join("?" for _ in hashes)
+        return {
+            str(row["tx_hash"])
+            for row in self.store.read().execute(
+                "SELECT DISTINCT tx_hash FROM events "
+                "INDEXED BY events_tx_log_idx "
+                f"WHERE tx_hash IN ({marks}) AND protocol='v4' "
+                "AND kind IN ('add','remove','collect')",
+                hashes,
+            )
+        }
+
+    def _fill_enrichment_jobs(
+        self, reserved: Iterable[str] = (),
+    ) -> None:
+        active = sum(
+            len(rows)
+            for rows, _future, _started, _trace
+            in self._enrichment_jobs.values()
+        )
+        capacity = ENRICH_INFLIGHT_LIMIT - active
+        if capacity <= 0 or self._stop.is_set():
+            return
+        blocked = {
+            str(row["tx_hash"])
+            for rows, _future, _started, _trace in self._enrichment_jobs.values()
+            for row in rows
+        }
+        blocked.update(str(tx_hash) for tx_hash in reserved)
+        selection_limit = min(256, capacity + len(blocked))
+        candidates = []
+        for row in self.store.pending_enrichments(selection_limit):
+            if str(row["tx_hash"]) in blocked:
+                continue
+            candidates.append(row)
+            if len(candidates) == capacity:
+                break
+        trace_hashes = self._pending_v4_trace_hashes(candidates)
+        trace_rows = [
+            row for row in candidates if str(row["tx_hash"]) in trace_hashes
+        ]
+        regular_rows = [
+            row for row in candidates if str(row["tx_hash"]) not in trace_hashes
+        ]
+        batches = [
+            *(
+                (tuple(regular_rows[offset:offset + ENRICH_BATCH]), False)
+                for offset in range(0, len(regular_rows), ENRICH_BATCH)
+            ),
+            *(
+                (tuple(trace_rows[offset:offset + ENRICH_TRACE_BATCH]), True)
+                for offset in range(0, len(trace_rows), ENRICH_TRACE_BATCH)
+            ),
+        ]
+        for rows, trace in batches:
+            key = tuple(str(row["tx_hash"]) for row in rows)
+            executor = (
+                self._trace_enrichment_executor
+                if trace
+                else self._enrichment_executor
+            )
+            self._enrichment_jobs[key] = (
+                rows,
+                executor.submit(self._enrich_transactions, rows),
+                time.monotonic(),
+                trace,
+            )
+
     def _enrich_once(self) -> bool:
-        capacity = ENRICH_BATCH - len(self._enrichment_jobs)
-        if capacity and not self._stop.is_set():
-            for row in self.store.pending_enrichments(ENRICH_BATCH):
-                tx_hash = str(row["tx_hash"])
-                if tx_hash in self._enrichment_jobs:
-                    continue
-                self._enrichment_jobs[tx_hash] = (
-                    row, self._enrichment_executor.submit(self._enrich_transaction, row),
-                    time.monotonic(),
-                )
-                capacity -= 1
-                if not capacity:
-                    break
+        self._fill_enrichment_jobs()
         if not self._enrichment_jobs:
             return False
         wait(
             [job[1] for job in self._enrichment_jobs.values()],
-            timeout=0.05, return_when=FIRST_COMPLETED,
+            timeout=0.05,
+            return_when=FIRST_COMPLETED,
         )
         jobs = [
-            self._enrichment_jobs.pop(tx_hash)
-            for tx_hash, job in tuple(self._enrichment_jobs.items())
+            self._enrichment_jobs.pop(key)
+            for key, job in tuple(self._enrichment_jobs.items())
             if job[1].done()
         ]
         if not jobs:
             return False
         started = min(job[2] for job in jobs)
+        outcomes = []
+        completed_hashes: set[str] = set()
+        for rows, future, _submitted_at, _trace in jobs:
+            completed_hashes.update(str(row["tx_hash"]) for row in rows)
+            try:
+                batch_outcomes = future.result()
+                if (
+                    len(batch_outcomes) != len(rows)
+                    or any(
+                        str(expected["tx_hash"]) != str(outcome[0]["tx_hash"])
+                        for expected, outcome in zip(rows, batch_outcomes)
+                    )
+                ):
+                    raise RuntimeError(
+                        "enrichment wave returned an inconsistent result set"
+                    )
+            except Exception as exc:
+                batch_outcomes = [
+                    (row, None, None, exc)
+                    for row in rows
+                ]
+            outcomes.extend(batch_outcomes)
+
         successful_rows: list[Mapping[str, Any]] = []
         events: list[dict[str, Any]] = []
         transactions: list[dict[str, Any]] = []
+        failures: list[tuple[Mapping[str, Any], Exception]] = []
         orphan: Mapping[str, Any] | None = None
-        batch_error: Exception | None = None
-        for row, future, _submitted_at in jobs:
-            try:
-                row_events, transaction = future.result()
-            except CanonicalConflict:
+        for row, row_events, transaction, error in outcomes:
+            if isinstance(error, CanonicalConflict):
                 orphan = orphan or row
-            except Exception as exc:
-                attempts = int(row.get("attempts", 0)) + 1
-                if not self._mark_enrichment_failure(
-                    row, exc,
-                    delay=(
-                        ENRICHMENT_CAPABILITY_RECHECK_S
-                        if self._trace_capability_error(exc)
-                        else min(300.0, 2.0 ** min(attempts, 8))
+            elif error is not None:
+                failures.append((row, error))
+            elif row_events is None or transaction is None:
+                failures.append((
+                    row,
+                    RuntimeError(
+                        "enrichment wave omitted its transaction result"
                     ),
-                ):
-                    continue
-                batch_error = exc
-                self._set_runtime("enrichment", error=exc)
+                ))
             else:
                 successful_rows.append(row)
                 events.extend(row_events)
@@ -4316,6 +4593,26 @@ class MarketIndexer:
                 supplied_anchor=True,
             )
             return True
+
+        # Refill before taking the writer lock. Fetch workers keep using the
+        # provider while completed evidence waits behind live/history commits.
+        self._fill_enrichment_jobs(completed_hashes)
+        batch_error: Exception | None = None
+        for row, exc in failures:
+            attempts = int(row.get("attempts", 0)) + 1
+            if not self._mark_enrichment_failure(
+                row,
+                exc,
+                delay=(
+                    ENRICHMENT_CAPABILITY_RECHECK_S
+                    if self._trace_capability_error(exc)
+                    else min(300.0, 2.0 ** min(attempts, 8))
+                ),
+            ):
+                continue
+            batch_error = exc
+            self._set_runtime("enrichment", error=exc)
+
         if transactions:
             try:
                 with self.store.transaction() as conn:
@@ -4326,13 +4623,19 @@ class MarketIndexer:
                         return True
                     if len(ready) != len(successful_rows):
                         successful_rows = [
-                            row for row in successful_rows if str(row["tx_hash"]) in ready
+                            row
+                            for row in successful_rows
+                            if str(row["tx_hash"]) in ready
                         ]
                         transactions = [
-                            row for row in transactions if str(row["tx_hash"]) in ready
+                            row
+                            for row in transactions
+                            if str(row["tx_hash"]) in ready
                         ]
                         events = [
-                            event for event in events if str(event["tx_hash"]) in ready
+                            event
+                            for event in events
+                            if str(event["tx_hash"]) in ready
                         ]
                     self.store.enrich(events, transactions=transactions)
             except CanonicalConflict:
@@ -4349,7 +4652,8 @@ class MarketIndexer:
                 for row in successful_rows:
                     attempts = int(row.get("attempts", 0)) + 1
                     self._mark_enrichment_failure(
-                        row, exc,
+                        row,
+                        exc,
                         delay=min(300.0, 2.0 ** min(attempts, 8)),
                     )
                 self._set_runtime("enrichment", error=exc)
@@ -4359,12 +4663,14 @@ class MarketIndexer:
                 )
                 if batch_error is None:
                     self._set_runtime(
-                        "enrichment", latency=time.monotonic() - started,
+                        "enrichment",
+                        latency=time.monotonic() - started,
                         enrichment_batch=len(transactions),
                     )
                 else:
                     self._set_runtime(
-                        "enrichment", error=batch_error,
+                        "enrichment",
+                        error=batch_error,
                         latency=time.monotonic() - started,
                         enrichment_batch=len(transactions),
                     )
@@ -4790,6 +5096,9 @@ class MarketIndexer:
                 self._current_receipt_executor.shutdown(wait=True, cancel_futures=True)
                 self._current_pool_executor.shutdown(wait=True, cancel_futures=True)
                 self._enrichment_executor.shutdown(wait=True, cancel_futures=True)
+                self._trace_enrichment_executor.shutdown(
+                    wait=True, cancel_futures=True,
+                )
                 self._header_executor.shutdown(
                     wait=True, cancel_futures=True,
                 )

--- a/src/rhpools/lp_market_index.py
+++ b/src/rhpools/lp_market_index.py
@@ -21,6 +21,7 @@ import requests
 from eth_utils import keccak
 from requests.adapters import HTTPAdapter
 
+from . import _mc
 from .lp_chain import CHAIN_ID
 from .lp_market_protocols import (
     EVENT_TOPICS,
@@ -66,7 +67,7 @@ MAX_INTERVAL_STORE_SECONDS = 2.0
 HISTORY_MAX_INTERVAL_STORE_SECONDS = 0.2
 ENRICH_BATCH = 8
 ENRICHMENT_CAPABILITY_RECHECK_S = 300.0
-ENRICH_TRACE_BATCH = 2
+ENRICH_TRACE_BATCH = 8
 ENRICH_WORKERS = 8
 ENRICH_TRACE_WORKERS = 4
 ENRICH_REGULAR_INFLIGHT_LIMIT = ENRICH_BATCH * ENRICH_WORKERS
@@ -78,12 +79,15 @@ V4_OWNER_REPAIR_SCAN = 8192
 V3_BIRTH_REPAIR_PREFIXES = tuple(
     sorted(f"nft:{address}:" for address in V3_NFT_MANAGER_ADDRESSES)
 )
-DEFERRED_POOL_IDENTITY_BATCH = 8
+DEFERRED_POOL_IDENTITY_BATCH = 64
+DEFERRED_POOL_IDENTITY_RPC_BATCH = 8
 DEFERRED_POOL_IDENTITY_CANDIDATES_PER_POOL = 4
 DEFERRED_POOL_IDENTITY_SEED_BUSY_S = 1.0
 LEGACY_V4_IDENTITY_BATCH = 4
 DEFERRED_POOL_IDENTITY_PREFIX = "pool_identity_pending:"
-BALANCE_BATCH = 8
+# A bounded snapshot wave shares exact-block state roots through Multicall3.
+# The shared endpoint gate, not a fixed lane quota, limits archive traffic.
+BALANCE_BATCH = 64
 BALANCE_OF_SELECTOR = "0x70a08231"
 SYMBOL_SELECTOR = "0x95d89b41"
 DECIMALS_SELECTOR = "0x313ce567"
@@ -301,11 +305,11 @@ def _timestamp(header: Mapping[str, Any]) -> int:
 
 
 class MarketIndexer:
-    """Canonical LP event index with independent live/history/enrichment lanes.
+    """Canonical LP event index with independent live/history/enrichment/balance lanes.
 
     ``rpc`` is an optional deterministic injected client (or ``lane -> client``
     factory) implementing ``call`` and optionally ``batch``.  Production uses
-    dedicated live/history sessions and a bounded worker-local enrichment pool.
+    dedicated live/history/balance sessions and bounded enrichment worker pools.
     """
 
     def __init__(
@@ -371,6 +375,12 @@ class MarketIndexer:
             self._clients["live_header"] = self._clients["live"]
             self._clients["history_header"] = self._clients["history"]
             self._head_wss_urls = ()
+        if self.v3_balances:
+            self._clients["balance"] = (
+                self._rpc_factory("balance")
+                if self._rpc_factory is not None
+                else self._clients["enrichment"]
+            )
         for lane, client in self._clients.items():
             if not callable(getattr(client, "call", None)):
                 raise TypeError(f"injected {lane} RPC must implement call(method, params)")
@@ -398,7 +408,7 @@ class MarketIndexer:
         self._process_lock_fd: int | None = None
         self._history_verified = False
         self._enrichment_verified = False
-        self._projection_verified = False
+        self._balance_verified = False
         self._publish_after_id = ""
         self._market_epoch = int(self.store.status().get("epoch", 0))
         self._enrichment_local = threading.local()
@@ -1730,6 +1740,32 @@ class MarketIndexer:
                     raise
         return results
 
+
+    def _batch_results_on(
+        self, client: Any, calls: list[tuple[str, Sequence[Any]]],
+    ) -> list[Any]:
+        if not calls:
+            return []
+        batch_results = getattr(client, "batch_results", None)
+        if callable(batch_results):
+            output: list[Any] = []
+            for offset in range(0, len(calls), MAX_BATCH_CALLS):
+                chunk = calls[offset:offset + MAX_BATCH_CALLS]
+                results = list(batch_results(chunk))
+                if len(results) != len(chunk):
+                    raise RpcError("batch RPC returned an incomplete result set")
+                output.extend(results)
+            return output
+        # Injected clients without per-item results cannot safely share a
+        # failure-prone wave: a failed trace must not discard its siblings.
+        output = []
+        for method, params in calls:
+            try:
+                output.append(client.call(method, list(params)))
+            except Exception as exc:
+                output.append(exc)
+        return output
+
     def _rpc_batch(self, lane: str, calls: list[tuple[str, Sequence[Any]]]) -> list[Any]:
         return self._batch_on(self._clients[lane], calls)
 
@@ -1903,6 +1939,12 @@ class MarketIndexer:
                         daemon=True,
                     ),
                 ]
+                if self.v3_balances:
+                    self._threads.append(threading.Thread(
+                        target=self._balance_run,
+                        name="lp-market-balances",
+                        daemon=True,
+                    ))
                 if self._accounting_projector is not None:
                     self._threads.append(threading.Thread(
                         target=self._accounting_run,
@@ -2508,20 +2550,19 @@ class MarketIndexer:
     def _optional_identity_batch(
         self, lane: str, calls: list[tuple[str, Sequence[Any]]],
     ) -> list[Any]:
-        try:
-            return self._rpc_batch(lane, calls)
-        except RpcError:
-            results: list[Any] = []
-            client = self._clients[lane]
-            for method, params in calls:
-                try:
-                    results.append(client.call(method, list(params)))
-                except RpcError as exc:
-                    if "revert" in str(exc).lower():
-                        results.append(None)
-                    else:
-                        raise
-            return results
+        results = self._rpc_state_batch(calls, self._clients[lane])
+        for index, result in enumerate(results):
+            if not isinstance(result, Mapping) or "error" not in result:
+                continue
+            error = result["error"]
+            code = error.get("code") if isinstance(error, Mapping) else None
+            if code == 3 or "execution reverted" in str(error).lower():
+                results[index] = None
+            else:
+                # A missing identity method is a contract outcome. Missing
+                # archive state or transport failure cannot reject an emitter.
+                raise RpcError(str(error), code=code)
+        return results
 
     def _resolve_unknown_pools(
         self, lane: str, logs: list[dict[str, Any]],
@@ -2967,7 +3008,7 @@ class MarketIndexer:
             "ORDER BY pool_id LIMIT ?",
             (
                 self._deferred_identity_seed_after_id,
-                DEFERRED_POOL_IDENTITY_BATCH,
+                DEFERRED_POOL_IDENTITY_RPC_BATCH,
             ),
         ).fetchall()
         if not pool_rows:
@@ -3150,45 +3191,53 @@ class MarketIndexer:
         if not rows:
             return False
         with self._current_receipt_lock:
-            if self._current_pool_pending:
-                return False
+            current_pending = set(self._current_pool_pending)
         self._pool_identity_replay_turn = (self._pool_identity_replay_turn + 1) % 4
         started = time.monotonic()
-        try:
-            identity_block = _hex_int(
-                self._clients["pool"].call("eth_blockNumber", []),
-                "current pool identity block",
-            )
-            identity_header = self._block("pool", identity_block)
-        except Exception as exc:
-            for row in rows:
-                marker = str(row.get("last_error") or "")
-                payload = self._pool_identity_marker(marker)
-                if payload is not None:
-                    self._mark_pool_identity_replay_error(
-                        row, marker, payload, exc,
-                    )
-            self._set_runtime("pool_identity", error=exc)
-            return True
-
-        address_budget = 1
+        identity_block: int | None = None
+        identity_header: dict[str, Any] | None = None
+        address_budget = DEFERRED_POOL_IDENTITY_RPC_BATCH
+        worked = False
         replayed = 0
         rejected = 0
         inserted_count = 0
         batch_error: Exception | None = None
         for row in rows:
-            if address_budget <= 0 or self._stop.is_set():
+            if self._stop.is_set():
                 break
             marker = str(row.get("last_error") or "")
             payload = self._pool_identity_marker(marker)
             if payload is None:
                 continue
-            addresses = set(payload["addresses"][:address_budget])
-            if not addresses:
+            addresses: set[str] = set()
+            needs_state = False
+            for address in payload["addresses"]:
+                known = (
+                    self._verified_pool(address) is not None
+                    or address in self._identity_checked
+                )
+                if known:
+                    addresses.add(address)
+                elif address_budget > 0 and address not in current_pending:
+                    addresses.add(address)
+                    address_budget -= 1
+                    needs_state = True
+            if not payload["addresses"]:
                 self._finish_pool_identity_replay(row, marker, payload, set())
+                worked = True
                 continue
-            address_budget -= len(addresses)
+            if not addresses:
+                continue
+            worked = True
             try:
+                # Known identities and already-rejected emitters need no RPC.
+                # They must not wait behind either a new identity or the live feed.
+                if needs_state and identity_header is None:
+                    identity_block = _hex_int(
+                        self._clients["pool"].call("eth_blockNumber", []),
+                        "current pool identity block",
+                    )
+                    identity_header = self._block("pool", identity_block)
                 stored = self.store.read().execute(
                     "SELECT hash,parent_hash,timestamp FROM blocks WHERE number=?",
                     (int(row["block_number"]),),
@@ -3238,8 +3287,11 @@ class MarketIndexer:
                 if legacy_addresses:
                     self._resolve_unknown_pools(
                         "pool", logs, pools,
-                        identity_block=identity_block,
-                        identity_hash=identity_header["hash"],
+                        identity_block=identity_block if needs_state else None,
+                        identity_hash=(
+                            identity_header["hash"]
+                            if needs_state and identity_header is not None else None
+                        ),
                     )
                 resolved_v4: list[dict[str, Any]] = []
                 for pool_id in sorted(
@@ -3250,6 +3302,7 @@ class MarketIndexer:
                         pools[pool_id] = pool
                         resolved_v4.append(pool)
                         continue
+                    assert identity_block is not None and identity_header is not None
                     pool = self._resolve_current_v4_pool(
                         pool_id, identity_block, identity_header["hash"],
                     )
@@ -3260,11 +3313,13 @@ class MarketIndexer:
                     if pool is not None:
                         pools[pool_id] = pool
                         resolved_v4.append(pool)
-                canonical = self._block("pool", identity_block)
-                if canonical["hash"] != identity_header["hash"]:
-                    raise CanonicalConflict(
-                        "current V4 pool identity anchor changed during resolution"
-                    )
+                if needs_state:
+                    assert identity_block is not None and identity_header is not None
+                    canonical = self._block("pool", identity_block)
+                    if canonical["hash"] != identity_header["hash"]:
+                        raise CanonicalConflict(
+                            "current pool identity anchor changed during resolution"
+                        )
                 events = self._decode(
                     "pool", logs, {int(row["block_number"]): header},
                     resolve_unknown=False,
@@ -3307,7 +3362,7 @@ class MarketIndexer:
             pool_identity_rejected=rejected,
             pool_identity_inserted_events=inserted_count,
         )
-        return True
+        return worked
 
     def _decode_current(
         self, logs: list[dict[str, Any]], headers: dict[int, dict[str, Any]],
@@ -4131,6 +4186,7 @@ class MarketIndexer:
     def _rpc_state_batch(
         self, calls: list[tuple[str, Sequence[Any]]], client: Any | None = None,
     ) -> list[Any]:
+        """Deduplicate caller-independent reads and share each pinned state root."""
         selected = client or self._clients["enrichment"]
         unique: list[tuple[str, Sequence[Any]]] = []
         indexes: dict[tuple[str, str], int] = {}
@@ -4143,7 +4199,74 @@ class MarketIndexer:
                 indexes[key] = index
                 unique.append((method, params))
             order.append(index)
-        results = self._batch_on(selected, unique, allow_reverts=True)
+        groups: dict[str, list[int]] = {}
+        for index, (method, params) in enumerate(unique):
+            if (
+                method == "eth_call" and len(params) == 2
+                and isinstance(params[0], Mapping)
+                and set(params[0]) == {"to", "data"}
+            ):
+                pin = json.dumps(params[1], sort_keys=True, separators=(",", ":"))
+            else:
+                pin = f"direct:{index}"
+            groups.setdefault(pin, []).append(index)
+        specifications: list[tuple[str, Sequence[Any]]] = []
+        members: list[list[int]] = []
+        for group in groups.values():
+            for offset in range(0, len(group), _mc.MAX_PER_BATCH):
+                chunk = group[offset:offset + _mc.MAX_PER_BATCH]
+                members.append(chunk)
+                if len(chunk) == 1:
+                    specifications.append(unique[chunk[0]])
+                else:
+                    packed = [
+                        (str(unique[index][1][0]["to"]), str(unique[index][1][0]["data"]))
+                        for index in chunk
+                    ]
+                    specifications.append(("eth_call", [{
+                        "to": _mc.MULTICALL3, "data": _mc.encode(packed),
+                    }, unique[chunk[0]][1][1]]))
+
+        def fetch(specs: list[tuple[str, Sequence[Any]]]) -> list[Any]:
+            if callable(getattr(selected, "batch_results", None)):
+                return [
+                    {"error": str(value)} if isinstance(value, Exception) else value
+                    for value in self._batch_results_on(selected, specs)
+                ]
+            return self._batch_on(selected, specs, allow_reverts=True)
+
+        try:
+            aggregated = fetch(specifications)
+        except Exception:
+            # Older injected transports can reject Multicall3 before returning
+            # any result. The original pinned calls remain the fallback.
+            direct = fetch(unique)
+            return [direct[index] for index in order]
+        results: list[Any] = [None] * len(unique)
+        fallback: list[int] = []
+        for chunk, raw in zip(members, aggregated):
+            if len(chunk) == 1:
+                results[chunk[0]] = raw
+                continue
+            try:
+                decoded = _mc.decode(raw)
+                if len(decoded) != len(chunk):
+                    raise ValueError("Multicall3 response arity mismatch")
+            except Exception:
+                fallback.extend(chunk)
+                continue
+            for index, (ok, data) in zip(chunk, decoded):
+                results[index] = (
+                    "0x" + data.hex() if ok else {
+                        "error": {
+                            "code": 3, "message": "execution reverted",
+                            "data": "0x" + data.hex(),
+                        },
+                    }
+                )
+        if fallback:
+            for index, value in zip(fallback, fetch([unique[index] for index in fallback])):
+                results[index] = value
         return [results[index] for index in order]
 
     @staticmethod
@@ -4291,28 +4414,32 @@ class MarketIndexer:
                     errors[tx_hash] = exc
                     prepared.pop(tx_hash)
 
-        # Trace calls stay independent. One pruned or malformed trace must not
-        # discard successful siblings from the receipt wave.
-        for tx_hash, context in tuple(prepared.items()):
-            if not self._requires_v4_trace(context["receipt"]):
-                continue
+        trace_hashes = [
+            tx_hash for tx_hash, context in prepared.items()
+            if self._requires_v4_trace(context["receipt"])
+        ]
+        traces = self._batch_results_on(client, [
+            ("debug_traceTransaction", [
+                tx_hash, {
+                    "tracer": "callTracer",
+                    "tracerConfig": {"withLog": True},
+                    # Missing archive state stays pending, never reexecutes
+                    # on the authoritative live node.
+                    "reexec": 0,
+                    "timeout": "5s",
+                },
+            ])
+            for tx_hash in trace_hashes
+        ])
+        for tx_hash, trace in zip(trace_hashes, traces):
             try:
-                trace = client.call("debug_traceTransaction", [
-                    tx_hash,
-                    {
-                        "tracer": "callTracer",
-                        "tracerConfig": {"withLog": True},
-                        # Missing historical state stays pending; never rebuild
-                        # it on the authoritative live node.
-                        "reexec": 0,
-                        "timeout": "5s",
-                    },
-                ])
+                if isinstance(trace, Exception):
+                    raise trace
                 if not isinstance(trace, Mapping):
                     raise RpcError(
                         f"transaction {tx_hash} returned a malformed call trace"
                     )
-                context["trace"] = dict(trace)
+                prepared[tx_hash]["trace"] = dict(trace)
             except Exception as exc:
                 errors[tx_hash] = exc
                 prepared.pop(tx_hash)
@@ -4831,11 +4958,14 @@ class MarketIndexer:
         return True
 
     @staticmethod
-    def _balance_call(token: str, pool_address: str, block: int) -> tuple[str, list[Any]]:
+    def _balance_call(token: str, pool_address: str, block_hash: str) -> tuple[str, list[Any]]:
         if len(token) != 42 or len(pool_address) != 42:
             raise ValueError("V3 balance request requires token and pool addresses")
         data = BALANCE_OF_SELECTOR + pool_address[2:].rjust(64, "0")
-        return "eth_call", [{"to": token, "data": data}, hex(block)]
+        return "eth_call", [
+            {"to": token, "data": data},
+            {"blockHash": block_hash, "requireCanonical": True},
+        ]
 
     def _balances_once(self) -> bool:
         if not self.v3_balances or self._stop.is_set():
@@ -4847,11 +4977,12 @@ class MarketIndexer:
         requested = []
         calls = []
         errors = []
+        canonical_rejections = []
         for row in pending:
             try:
                 pair = [
                     self._balance_call(
-                        str(row[token]), str(row["pool_id"]), int(row["block_number"]),
+                        str(row[token]), str(row["pool_id"]), str(row["block_hash"]),
                     )
                     for token in ("token0", "token1")
                 ]
@@ -4862,7 +4993,10 @@ class MarketIndexer:
                 calls.extend(pair)
         completed = []
         try:
-            results = self._rpc_state_batch(calls) if calls else []
+            results = (
+                self._rpc_state_batch(calls, self._clients["balance"])
+                if calls else []
+            )
         except Exception as exc:
             errors.extend((row, exc) for row in requested)
         else:
@@ -4875,30 +5009,59 @@ class MarketIndexer:
                 else:
                     completed.append((row, balance0, balance1))
         saved = 0
-        try:
-            with self.store.transaction():
-                for row, balance0, balance1 in completed:
-                    self.store.save_v3_balance(
-                        str(row["pool_id"]), int(row["block_number"]),
-                        str(row["block_hash"]), balance0, balance1,
-                    )
-        except (CanonicalConflict, ValueError) as exc:
-            errors.extend((row, exc) for row, _balance0, _balance1 in completed)
-        else:
-            saved = len(completed)
-        if errors:
-            with self.store.transaction():
-                for row, exc in errors:
-                    attempts = int(row.get("attempts", 0)) + 1
-                    self.store.mark_v3_balance_error(
-                        str(row["pool_id"]), int(row["block_number"]), str(exc),
-                        delay=min(300.0, 2.0 ** min(attempts, 8)),
-                    )
+        if completed:
+            outcomes = self.store.save_v3_balances([
+                (
+                    str(row["pool_id"]), int(row["block_number"]),
+                    str(row["block_hash"]), balance0, balance1,
+                )
+                for row, balance0, balance1 in completed
+            ])
+            for (row, _balance0, _balance1), outcome in zip(completed, outcomes):
+                if outcome is None:
+                    saved += 1
+                elif isinstance(outcome, CanonicalConflict):
+                    canonical_rejections.append((row, outcome))
+                else:
+                    errors.append((row, outcome))
+        rejected = errors + canonical_rejections
+        if rejected:
+            self.store.mark_v3_balance_errors([
+                (
+                    str(row["pool_id"]), int(row["block_number"]),
+                    str(row["block_hash"]), str(exc),
+                    min(
+                        300.0,
+                        2.0 ** min(int(row.get("attempts", 0)) + 1, 8),
+                    ),
+                )
+                for row, exc in rejected
+            ])
         self._set_runtime(
             "balances", error=errors[-1][1] if errors else None,
             latency=time.monotonic() - started, balances_batch=saved,
+            balances_rejected=len(canonical_rejections),
+            balances_state_reads=len(calls),
         )
         return True
+
+    def _balance_run(self) -> None:
+        backoff = 0.5
+        while not self._stop.is_set():
+            if not self._initialized.wait(0.5):
+                continue
+            try:
+                if not self._balance_verified:
+                    self._verify_chain("balance")
+                    self._balance_verified = True
+                worked = self._balances_once()
+            except Exception as exc:
+                self._set_runtime("balances", error=exc)
+                self._stop.wait(backoff)
+                backoff = min(30.0, backoff * 2.0)
+            else:
+                backoff = 0.5
+                self._stop.wait(0.01 if worked else 0.5)
 
     def _live_run(self) -> None:
         backoff = 0.25
@@ -5109,11 +5272,7 @@ class MarketIndexer:
                 continue
             try:
                 self.store.checkpoint()
-                if not self._projection_verified:
-                    self._verify_chain("enrichment")
-                    self._projection_verified = True
                 worked = self._reproject_once()
-                worked = self._balances_once() or worked
             except Exception as exc:
                 self._set_runtime("projection", error=exc)
                 self._stop.wait(backoff)

--- a/src/rhpools/lp_market_index.py
+++ b/src/rhpools/lp_market_index.py
@@ -59,9 +59,11 @@ LIVE_INITIAL_CHUNK = 256
 LIVE_MAX_CHUNK = 2_048
 RECENT_CATCHUP_PRIORITY_BLOCKS = 512
 HISTORY_MIN_CHUNK = 1
-HISTORY_INITIAL_CHUNK = 4_096
+HISTORY_INITIAL_CHUNK = 8
 HISTORY_MAX_CHUNK = 32_768
-MAX_INTERVAL_STORE_SECONDS = 2.0
+# Target half the chain's observed ~100 ms block interval, not multi-second
+# writer monopolies that stall live ingestion and every financial worker.
+MAX_INTERVAL_STORE_SECONDS = 0.05
 ENRICH_BATCH = 8
 ENRICHMENT_CAPABILITY_RECHECK_S = 300.0
 REPROJECT_BATCH = 128
@@ -3544,6 +3546,10 @@ class MarketIndexer:
                 current * 2,
                 sample_blocks * (MAX_LOGS_PER_RESPONSE * 4 // 5) // count,
             )
+        if store_seconds > 0:
+            candidate = min(candidate, max(
+                minimum, int(sample_blocks * MAX_INTERVAL_STORE_SECONDS / store_seconds),
+            ))
         if candidate <= current:
             return
         resized = min(maximum, max(current + 1, candidate))

--- a/src/rhpools/lp_market_index.py
+++ b/src/rhpools/lp_market_index.py
@@ -80,9 +80,10 @@ V3_BIRTH_REPAIR_PREFIXES = tuple(
     sorted(f"nft:{address}:" for address in V3_NFT_MANAGER_ADDRESSES)
 )
 DEFERRED_POOL_IDENTITY_BATCH = 64
-DEFERRED_POOL_IDENTITY_RPC_BATCH = 8
+DEFERRED_POOL_IDENTITY_RPC_BATCH = DEFERRED_POOL_IDENTITY_BATCH
 DEFERRED_POOL_IDENTITY_CANDIDATES_PER_POOL = 4
 DEFERRED_POOL_IDENTITY_SEED_BUSY_S = 1.0
+DEFERRED_POOL_IDENTITY_PUBLICATION_SECONDS = 0.2
 LEGACY_V4_IDENTITY_BATCH = 4
 DEFERRED_POOL_IDENTITY_PREFIX = "pool_identity_pending:"
 # A bounded snapshot wave shares exact-block state roots through Multicall3.
@@ -945,21 +946,47 @@ class MarketIndexer:
                 pool_id, header, [], "inspector", transaction_hash,
             )
 
-    def _resolve_current_v4_pool(
-        self, pool_id: str, number: int, block_hash: str,
-    ) -> dict[str, Any] | None:
+    def _resolve_current_v4_pools(
+        self, pool_ids: Iterable[str], number: int, block_hash: str,
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, Exception]]:
         # PosM stores a bytes25 prefix; only the complete PoolKey hash proves
         # identity. A zero/mismatched getter result is not a discovered pool.
-        result = self._clients["pool"].call("eth_call", [{
-            "to": V4_POSITION_MANAGER,
-            "data": V4_POOL_KEYS_SELECTOR + pool_id[2:52] + "00" * 7,
-        }, hex(number)])
-        if not isinstance(result, str) or len(result) != 322 or not result.startswith("0x"):
-            return None
-        return self._current_v4_pool_key(
-            pool_id, bytes.fromhex(result[2:]), number, block_hash,
-            source="PositionManager.poolKeys",
-        )
+        ordered = sorted(set(pool_ids))
+        results = self._optional_identity_batch("pool", [
+            (
+                "eth_call",
+                [{
+                    "to": V4_POSITION_MANAGER,
+                    "data": V4_POOL_KEYS_SELECTOR + pool_id[2:52] + "00" * 7,
+                }, hex(number)],
+            )
+            for pool_id in ordered
+        ])
+        resolved: dict[str, dict[str, Any]] = {}
+        failures: dict[str, Exception] = {}
+        for pool_id, result in zip(ordered, results):
+            if isinstance(result, Exception):
+                failures[pool_id] = result
+                continue
+            if (
+                not isinstance(result, str) or not result.startswith("0x")
+                or len(result) != 322
+            ):
+                continue
+            try:
+                raw = bytes.fromhex(result[2:])
+            except ValueError:
+                failures[pool_id] = RpcError(
+                    "PositionManager.poolKeys returned malformed data"
+                )
+                continue
+            pool = self._current_v4_pool_key(
+                pool_id, raw, number, block_hash,
+                source="PositionManager.poolKeys",
+            )
+            if pool is not None:
+                resolved[pool_id] = pool
+        return resolved, failures
 
     def _current_v4_pool_key(
         self, pool_id: str, raw: bytes, number: int, block_hash: str, *, source: str,
@@ -1059,63 +1086,167 @@ class MarketIndexer:
                         return pool
         return None
 
-    def _resolve_current_v4_input(
-        self, pool_id: str, logs: Sequence[Mapping[str, Any]], transaction_hash: str = "",
-    ) -> dict[str, Any] | None:
-        tx_hash = transaction_hash or next(
-            (_lower(log.get("transactionHash")) for log in logs if log.get("transactionHash")),
-            "",
-        )
-        if not tx_hash:
+    def _resolve_current_v4_inputs(
+        self,
+        candidates: Mapping[
+            str, tuple[Sequence[Mapping[str, Any]], str]
+        ],
+    ) -> tuple[dict[str, dict[str, Any]], dict[str, Exception]]:
+        tx_hashes: dict[str, str] = {}
+        missing: set[str] = set()
+        for pool_id, (logs, transaction_hash) in candidates.items():
+            tx_hash = _lower(transaction_hash) or next(
+                (
+                    _lower(log.get("transactionHash"))
+                    for log in logs if log.get("transactionHash")
+                ),
+                "",
+            )
+            if tx_hash:
+                tx_hashes[pool_id] = tx_hash
+            else:
+                missing.add(pool_id)
+        if missing:
             with self._feed_condition:
-                for header, events in reversed(self._observed_blocks.values()):
-                    event = next((row for row in events if row.get("pool_id") == pool_id), None)
-                    if event is not None:
-                        tx_hash = _lower(event["tx_hash"])
+                for _header_, events in reversed(self._observed_blocks.values()):
+                    for event in events:
+                        pool_id = _lower(event.get("pool_id"))
+                        if pool_id in missing:
+                            tx_hashes[pool_id] = _lower(event["tx_hash"])
+                            missing.remove(pool_id)
+                    if not missing:
                         break
-        if not tx_hash:
-            return None
+
+        ordered = [
+            (pool_id, tx_hashes[pool_id])
+            for pool_id in sorted(tx_hashes)
+        ]
         client = self._clients["pool"]
-        transaction = client.call("eth_getTransactionByHash", [tx_hash])
-        if not isinstance(transaction, Mapping):
-            raise RpcError("PoolKey transaction is temporarily unavailable")
-        receipt = client.call("eth_getTransactionReceipt", [tx_hash])
-        if not isinstance(receipt, Mapping):
-            raise RpcError("PoolKey transaction receipt is temporarily unavailable")
-        number = _hex_int(transaction.get("blockNumber"), "PoolKey transaction block")
-        block_hash = _lower(transaction.get("blockHash"))
+        fetched = self._rpc_state_batch([
+            (method, [tx_hash])
+            for _pool_id, tx_hash in ordered
+            for method in (
+                "eth_getTransactionByHash", "eth_getTransactionReceipt",
+            )
+        ], client)
+        errors: dict[str, Exception] = {}
+        prepared: dict[str, dict[str, Any]] = {}
+        for offset, (pool_id, tx_hash) in enumerate(ordered):
+            transaction, receipt = fetched[offset * 2:(offset + 1) * 2]
+            if not isinstance(transaction, Mapping) or "error" in transaction:
+                errors[pool_id] = RpcError(
+                    "PoolKey transaction is temporarily unavailable"
+                )
+                continue
+            if not isinstance(receipt, Mapping) or "error" in receipt:
+                errors[pool_id] = RpcError(
+                    "PoolKey transaction receipt is temporarily unavailable"
+                )
+                continue
+            try:
+                number = _hex_int(
+                    transaction.get("blockNumber"), "PoolKey transaction block",
+                )
+            except RpcError as exc:
+                errors[pool_id] = exc
+                continue
+            block_hash = _lower(transaction.get("blockHash"))
+            prepared[pool_id] = {
+                "tx_hash": tx_hash,
+                "transaction": transaction,
+                "receipt": receipt,
+                "number": number,
+                "block_hash": block_hash,
+            }
+
+        header_ids: list[str] = []
         with self._feed_condition:
-            cached = self._observed_blocks.get(number)
-        if cached is not None and cached[0]["hash"] == block_hash:
-            header = cached[0]
-        else:
-            header = client.call("eth_getBlockByNumber", [hex(number), False])
-            if not isinstance(header, Mapping):
-                raise RpcError("PoolKey transaction header is temporarily unavailable")
-            if (
-                _number(header) != number
-                or _lower(header.get("hash")) != block_hash
-            ):
-                raise CanonicalConflict("PoolKey transaction is no longer canonical")
-        pool = self._current_v4_input_key(
-            pool_id, transaction, receipt, header, tx_hash,
-        )
-        if cached is not None:
-            with self._feed_condition:
-                current = self._observed_blocks.get(number)
-                if current is None or current[0]["hash"] != block_hash:
-                    return None
-        else:
-            canonical = client.call("eth_getBlockByNumber", [hex(number), False])
-            if (
-                not isinstance(canonical, Mapping)
-                or _number(canonical) != number
-                or _lower(canonical.get("hash")) != block_hash
-            ):
-                raise CanonicalConflict(
+            for pool_id, entry in prepared.items():
+                cached = self._observed_blocks.get(entry["number"])
+                if cached is not None and cached[0]["hash"] == entry["block_hash"]:
+                    entry["header"] = cached[0]
+                    entry["cached"] = True
+                else:
+                    header_ids.append(pool_id)
+        headers = self._rpc_state_batch([
+            ("eth_getBlockByNumber", [hex(prepared[pool_id]["number"]), False])
+            for pool_id in header_ids
+        ], client)
+        for pool_id, raw_header in zip(header_ids, headers):
+            entry = prepared[pool_id]
+            if not isinstance(raw_header, Mapping) or "error" in raw_header:
+                errors[pool_id] = RpcError(
+                    "PoolKey transaction header is temporarily unavailable"
+                )
+                continue
+            try:
+                matches = (
+                    _number(raw_header) == entry["number"]
+                    and _lower(raw_header.get("hash")) == entry["block_hash"]
+                )
+            except RpcError as exc:
+                errors[pool_id] = exc
+                continue
+            if not matches:
+                errors[pool_id] = CanonicalConflict(
+                    "PoolKey transaction is no longer canonical"
+                )
+                continue
+            entry["header"] = raw_header
+            entry["cached"] = False
+
+        decoded: dict[str, dict[str, Any] | None] = {}
+        recheck_ids: list[str] = []
+        for pool_id, entry in prepared.items():
+            if pool_id in errors or "header" not in entry:
+                continue
+            try:
+                decoded[pool_id] = self._current_v4_input_key(
+                    pool_id, entry["transaction"], entry["receipt"],
+                    entry["header"], entry["tx_hash"],
+                )
+            except Exception as exc:
+                errors[pool_id] = exc
+                continue
+            if entry["cached"]:
+                with self._feed_condition:
+                    current = self._observed_blocks.get(entry["number"])
+                    if (
+                        current is None
+                        or current[0]["hash"] != entry["block_hash"]
+                    ):
+                        errors[pool_id] = CanonicalConflict(
+                            "PoolKey transaction changed during identity recovery"
+                        )
+            else:
+                recheck_ids.append(pool_id)
+
+        canonical = self._rpc_state_batch([
+            ("eth_getBlockByNumber", [hex(prepared[pool_id]["number"]), False])
+            for pool_id in recheck_ids
+        ], client)
+        for pool_id, raw_header in zip(recheck_ids, canonical):
+            entry = prepared[pool_id]
+            try:
+                matches = (
+                    isinstance(raw_header, Mapping)
+                    and "error" not in raw_header
+                    and _number(raw_header) == entry["number"]
+                    and _lower(raw_header.get("hash")) == entry["block_hash"]
+                )
+            except RpcError:
+                matches = False
+            if not matches:
+                errors[pool_id] = CanonicalConflict(
                     "PoolKey transaction changed during identity recovery"
                 )
-        return pool
+
+        resolved = {
+            pool_id: pool
+            for pool_id, pool in decoded.items()
+            if pool is not None and pool_id not in errors
+        }
+        return resolved, errors
 
     def _resolve_current_pool(
         self, address: str, number: int, block_hash: str,
@@ -1126,9 +1257,19 @@ class MarketIndexer:
             if self._stop.is_set():
                 return
             if len(address) == 66:
-                pool = self._resolve_current_v4_pool(address, number, block_hash)
+                getter_pools, getter_failures = self._resolve_current_v4_pools(
+                    [address], number, block_hash,
+                )
+                if address in getter_failures:
+                    raise getter_failures[address]
+                pool = getter_pools.get(address)
                 if pool is None:
-                    pool = self._resolve_current_v4_input(address, logs, transaction_hash)
+                    recovered, failures = self._resolve_current_v4_inputs({
+                        address: (logs, transaction_hash),
+                    })
+                    if address in failures:
+                        raise failures[address]
+                    pool = recovered.get(address)
             else:
                 pools = self._pools_for_logs(logs)
                 self._resolve_unknown_pools("pool", logs, pools)
@@ -2559,9 +2700,9 @@ class MarketIndexer:
             if code == 3 or "execution reverted" in str(error).lower():
                 results[index] = None
             else:
-                # A missing identity method is a contract outcome. Missing
-                # archive state or transport failure cannot reject an emitter.
-                raise RpcError(str(error), code=code)
+                # Preserve non-EVM failures per identity when the transport
+                # exposes them without failing the complete batch.
+                results[index] = RpcError(str(error), code=code)
         return results
 
     def _resolve_unknown_pools(
@@ -2569,10 +2710,17 @@ class MarketIndexer:
         pools: dict[str, dict[str, Any]], *,
         identity_block: int | None = None,
         identity_hash: str | None = None,
-    ) -> None:
+        addresses: Iterable[str] | None = None,
+    ) -> tuple[bool, dict[str, Exception]]:
         if (identity_block is None) != (identity_hash is None):
             raise ValueError("current identity resolution requires a block and hash")
         unknown = set(unknown_pool_candidates(logs, pools))
+        requested = (
+            {_lower(address) for address in addresses}
+            if addresses is not None else None
+        )
+        if requested is not None:
+            unknown.intersection_update(requested)
         unresolved: dict[str, dict[str, Any] | None] = {
             address: None for address in unknown
         }
@@ -2601,12 +2749,14 @@ class MarketIndexer:
                 ):
                     continue
                 address = _lower(pool["address"])
+                if requested is not None and address not in requested:
+                    continue
                 unresolved[address] = pool
                 first_blocks[address] = min(first_blocks.get(address, number), number)
                 if first_blocks[address] == number:
                     first_hashes[address] = block_hash
         if not unresolved:
-            return
+            return False, {}
 
         unresolved_addresses = set(unresolved)
         for key, pool in tuple(pools.items()):
@@ -2615,7 +2765,9 @@ class MarketIndexer:
 
         with self._identity_resolve_lock:
             available: list[dict[str, Any]] = []
+            pending: list[dict[str, Any]] = []
             resolved: list[dict[str, Any]] = []
+            failures: dict[str, Exception] = {}
             checked: set[str] = set()
             for address in sorted(unresolved):
                 current = self._pool(address)
@@ -2625,25 +2777,50 @@ class MarketIndexer:
                     continue
                 if address in self._identity_checked:
                     continue
-                prior = current or unresolved[address]
                 observed_block = first_blocks.get(address)
                 if observed_block is None:
                     continue
-                observed_hash = first_hashes.get(address)
-                verification_block = (
-                    int(identity_block)
-                    if identity_block is not None else observed_block
+                pending.append({
+                    "address": address,
+                    "prior": current or unresolved[address],
+                    "observed_block": observed_block,
+                    "observed_hash": first_hashes.get(address),
+                    "verification_block": (
+                        int(identity_block)
+                        if identity_block is not None else observed_block
+                    ),
+                    "verification_hash": (
+                        _lower(identity_hash)
+                        if identity_hash is not None else first_hashes.get(address)
+                    ),
+                })
+
+            probes = self._optional_identity_batch(lane, [
+                (
+                    "eth_call",
+                    [{"to": entry["address"], "data": selector},
+                     hex(entry["verification_block"])],
                 )
-                verification_hash = (
-                    _lower(identity_hash)
-                    if identity_hash is not None else observed_hash
+                for entry in pending
+                for selector in (
+                    FACTORY_SELECTOR, TOKEN0_SELECTOR, TOKEN1_SELECTOR,
+                    FEE_SELECTOR, TICK_SPACING_SELECTOR,
                 )
-                tag = hex(verification_block)
-                identity = self._optional_identity_batch(lane, [
-                    ("eth_call", [{"to": address, "data": FACTORY_SELECTOR}, tag]),
-                    ("eth_call", [{"to": address, "data": TOKEN0_SELECTOR}, tag]),
-                    ("eth_call", [{"to": address, "data": TOKEN1_SELECTOR}, tag]),
-                ])
+            ])
+            membership_candidates: list[dict[str, Any]] = []
+            for offset, entry in enumerate(pending):
+                identity = probes[offset * 5:(offset + 1) * 5]
+                failure = next(
+                    (
+                        value for value in identity[:3]
+                        if isinstance(value, Exception)
+                    ),
+                    None,
+                )
+                if failure is not None:
+                    failures[entry["address"]] = failure
+                    continue
+                address = entry["address"]
                 factory = self._abi_address(identity[0])
                 token0 = self._abi_address(identity[1])
                 token1 = self._abi_address(identity[2])
@@ -2655,6 +2832,7 @@ class MarketIndexer:
                     checked.add(address)
                     continue
                 protocol = "v2" if factory in V2_FACTORIES else "v3"
+                prior = entry["prior"]
                 if prior is not None and (
                     prior.get("protocol") != protocol
                     or _lower(prior.get("token0")) != token0
@@ -2669,13 +2847,19 @@ class MarketIndexer:
                     membership_data = GET_PAIR_SELECTOR + token_args
                     discovery_basis = "pinned_factory_getPair_membership"
                 else:
-                    details = self._optional_identity_batch(lane, [
-                        ("eth_call", [{"to": address, "data": FEE_SELECTOR}, tag]),
-                        ("eth_call", [{"to": address, "data": TICK_SPACING_SELECTOR}, tag]),
-                    ])
+                    failure = next(
+                        (
+                            value for value in identity[3:]
+                            if isinstance(value, Exception)
+                        ),
+                        None,
+                    )
+                    if failure is not None:
+                        failures[address] = failure
+                        continue
                     try:
-                        fee = _hex_int(details[0], "pool fee")
-                        spacing_word = _hex_int(details[1], "pool tick spacing")
+                        fee = _hex_int(identity[3], "pool fee")
+                        spacing_word = _hex_int(identity[4], "pool tick spacing")
                     except RpcError:
                         checked.add(address)
                         continue
@@ -2694,14 +2878,35 @@ class MarketIndexer:
                         else GET_POOL_SELECTOR + token_args + f"{fee:064x}"
                     )
                     discovery_basis = "pinned_factory_getPool_membership"
-                membership = self._optional_identity_batch(lane, [
-                    ("eth_call", [{"to": factory, "data": membership_data}, tag]),
-                ])
-                if self._abi_address(membership[0]) != address:
+                membership_candidates.append({
+                    **entry,
+                    "factory": factory,
+                    "token0": token0,
+                    "token1": token1,
+                    "protocol": protocol,
+                    "fee": fee,
+                    "spacing": spacing,
+                    "membership_data": membership_data,
+                    "discovery_basis": discovery_basis,
+                })
+
+            memberships = self._optional_identity_batch(lane, [
+                (
+                    "eth_call",
+                    [{"to": entry["factory"], "data": entry["membership_data"]},
+                     hex(entry["verification_block"])],
+                )
+                for entry in membership_candidates
+            ])
+            for entry, membership in zip(membership_candidates, memberships):
+                if isinstance(membership, Exception):
+                    failures[entry["address"]] = membership
+                    continue
+                address = entry["address"]
+                if self._abi_address(membership) != address:
                     checked.add(address)
                     continue
-
-                payload = dict(prior or {})
+                payload = dict(entry["prior"] or {})
                 metadata = payload.get("metadata_json")
                 if isinstance(metadata, str):
                     try:
@@ -2713,9 +2918,9 @@ class MarketIndexer:
                     "creation_block_known", payload.get("created_block") is not None,
                 )
                 verified_metadata.update({
-                    "discovery_basis": discovery_basis,
-                    "identity_verified_block": verification_block,
-                    "identity_verified_hash": verification_hash,
+                    "discovery_basis": entry["discovery_basis"],
+                    "identity_verified_block": entry["verification_block"],
+                    "identity_verified_hash": entry["verification_hash"],
                     "identity_state_basis": (
                         "current_canonical_factory_membership"
                         if identity_block is not None
@@ -2724,20 +2929,21 @@ class MarketIndexer:
                 })
                 if identity_block is not None:
                     verified_metadata.update({
-                        "identity_observed_block": observed_block,
-                        "identity_observed_hash": observed_hash,
+                        "identity_observed_block": entry["observed_block"],
+                        "identity_observed_hash": entry["observed_hash"],
                     })
-                if protocol == "v3":
+                if entry["protocol"] == "v3":
                     verified_metadata["pool_family"] = (
-                        "slipstream" if factory == SLIPSTREAM_FACTORY else "v3"
+                        "slipstream"
+                        if entry["factory"] == SLIPSTREAM_FACTORY else "v3"
                     )
                 payload.update({
                     "id": address,
-                    "protocol": protocol,
+                    "protocol": entry["protocol"],
                     "address": address,
-                    "token0": token0,
-                    "token1": token1,
-                    "factory": factory,
+                    "token0": entry["token0"],
+                    "token1": entry["token1"],
+                    "factory": entry["factory"],
                     "source": payload.get("source") or (
                         "historical_event_with_current_factory_membership"
                         if identity_block is not None
@@ -2745,28 +2951,29 @@ class MarketIndexer:
                     ),
                     "metadata_json": verified_metadata,
                 })
-                if protocol == "v3":
-                    payload["fee_ppm"] = fee
-                    payload["tick_spacing"] = spacing
+                if entry["protocol"] == "v3":
+                    payload["fee_ppm"] = entry["fee"]
+                    payload["tick_spacing"] = entry["spacing"]
                 pool = self._normalize_pool(payload)
-                if pool is None:
-                    checked.add(address)
-                    continue
-                resolved.append(pool)
+                if pool is not None:
+                    resolved.append(pool)
                 checked.add(address)
 
+            guarded = False
             if identity_block is not None and checked:
                 canonical = self._block(lane, int(identity_block))
                 if canonical["hash"] != _lower(identity_hash):
                     raise CanonicalConflict(
                         "current pool identity anchor changed during resolution"
                     )
+                guarded = True
             for pool in (*available, *resolved):
                 pools[_lower(pool["id"])] = pool
                 pools[_lower(pool["address"])] = pool
             for pool in resolved:
                 self._remember_pool(pool)
             self._identity_checked.update(checked)
+            return guarded, failures
 
     @staticmethod
     def _pool_identity_marker(value: Any) -> dict[str, Any] | None:
@@ -3126,7 +3333,8 @@ class MarketIndexer:
 
     def _finish_pool_identity_replay(
         self, row: Mapping[str, Any], marker: str,
-        payload: Mapping[str, Any], processed: set[str],
+        payload: Mapping[str, Any], processed: set[str], *,
+        pending_error: BaseException | str | None = None,
     ) -> None:
         remaining = set(payload["addresses"]).difference(processed)
         with self.store.transaction() as connection:
@@ -3138,15 +3346,24 @@ class MarketIndexer:
                         log for log in payload["logs"]
                         if self._pool_identity_candidates(log).intersection(remaining)
                     ],
-                    "identity_attempts": 0,
                 })
-                updated.pop("identity_error", None)
+                next_attempt = 0.0
+                if pending_error is None:
+                    updated["identity_attempts"] = 0
+                    updated.pop("identity_error", None)
+                else:
+                    attempts = int(payload.get("identity_attempts", 0)) + 1
+                    updated["identity_attempts"] = attempts
+                    updated["identity_error"] = str(pending_error)[:1000]
+                    next_attempt = time.time() + min(
+                        300.0, 2.0 ** min(attempts, 8),
+                    )
                 connection.execute(
-                    "UPDATE pending_enrichment SET next_attempt=0,last_error=?,"
+                    "UPDATE pending_enrichment SET next_attempt=?,last_error=?,"
                     "updated_at=?,generation=generation+1 WHERE tx_hash=? AND last_error=?",
                     (
-                        self._encode_pool_identity_marker(updated), time.time(),
-                        _lower(row["tx_hash"]), marker,
+                        next_attempt, self._encode_pool_identity_marker(updated),
+                        time.time(), _lower(row["tx_hash"]), marker,
                     ),
                 )
                 return
@@ -3194,14 +3411,18 @@ class MarketIndexer:
             current_pending = set(self._current_pool_pending)
         self._pool_identity_replay_turn = (self._pool_identity_replay_turn + 1) % 4
         started = time.monotonic()
-        identity_block: int | None = None
-        identity_header: dict[str, Any] | None = None
-        address_budget = DEFERRED_POOL_IDENTITY_RPC_BATCH
         worked = False
         replayed = 0
         rejected = 0
         inserted_count = 0
         batch_error: Exception | None = None
+        selected_network: set[str] = set()
+        known_pools: dict[str, dict[str, Any] | None] = {}
+        prepared: list[dict[str, Any]] = []
+        combined_logs: dict[tuple[str, str, int], dict[str, Any]] = {}
+
+        # Preserve the row selector's oldest/newest/requested ordering while
+        # charging the RPC budget once for each distinct fresh identity.
         for row in rows:
             if self._stop.is_set():
                 break
@@ -3209,65 +3430,65 @@ class MarketIndexer:
             payload = self._pool_identity_marker(marker)
             if payload is None:
                 continue
-            addresses: set[str] = set()
-            needs_state = False
-            for address in payload["addresses"]:
-                known = (
-                    self._verified_pool(address) is not None
-                    or address in self._identity_checked
-                )
-                if known:
-                    addresses.add(address)
-                elif address_budget > 0 and address not in current_pending:
-                    addresses.add(address)
-                    address_budget -= 1
-                    needs_state = True
-            if not payload["addresses"]:
+            payload_addresses = set(payload["addresses"])
+            if not payload_addresses:
                 self._finish_pool_identity_replay(row, marker, payload, set())
                 worked = True
                 continue
-            if not addresses:
+            stored = self.store.read().execute(
+                "SELECT hash,parent_hash,timestamp FROM blocks WHERE number=?",
+                (int(row["block_number"]),),
+            ).fetchone()
+            if stored is None or _lower(stored["hash"]) != _lower(
+                row["block_hash"]
+            ):
+                self._finish_pool_identity_replay(
+                    row, marker, payload, payload_addresses,
+                )
+                rejected += len(payload_addresses)
+                worked = True
                 continue
-            worked = True
+            header = {
+                "number": hex(int(row["block_number"])),
+                "hash": _lower(stored["hash"]),
+                "parentHash": _lower(stored["parent_hash"]),
+                "timestamp": hex(int(stored["timestamp"])),
+            }
+            newly_selected: set[str] = set()
             try:
-                # Known identities and already-rejected emitters need no RPC.
-                # They must not wait behind either a new identity or the live feed.
-                if needs_state and identity_header is None:
-                    identity_block = _hex_int(
-                        self._clients["pool"].call("eth_blockNumber", []),
-                        "current pool identity block",
-                    )
-                    identity_header = self._block("pool", identity_block)
-                stored = self.store.read().execute(
-                    "SELECT hash,parent_hash,timestamp FROM blocks WHERE number=?",
-                    (int(row["block_number"]),),
-                ).fetchone()
-                if stored is None or _lower(stored["hash"]) != _lower(
-                    row["block_hash"]
-                ):
-                    self._finish_pool_identity_replay(
-                        row, marker, payload, set(payload["addresses"]),
-                    )
-                    rejected += len(addresses)
+                addresses: set[str] = set()
+                for address in payload["addresses"]:
+                    if address not in known_pools:
+                        known_pools[address] = self._verified_pool(address)
+                    if (
+                        known_pools[address] is not None
+                        or address in self._identity_checked
+                    ):
+                        addresses.add(address)
+                    elif address in selected_network:
+                        addresses.add(address)
+                    elif (
+                        address not in current_pending
+                        and len(selected_network)
+                        < DEFERRED_POOL_IDENTITY_RPC_BATCH
+                    ):
+                        selected_network.add(address)
+                        newly_selected.add(address)
+                        addresses.add(address)
+                if not addresses:
                     continue
-                header = {
-                    "number": hex(int(row["block_number"])),
-                    "hash": _lower(stored["hash"]),
-                    "parentHash": _lower(stored["parent_hash"]),
-                    "timestamp": hex(int(stored["timestamp"])),
-                }
-                logs = [
-                    dict(log) for log in payload["logs"]
-                    if self._pool_identity_candidates(log).intersection(addresses)
-                ]
+
+                raw_logs: list[dict[str, Any]] = []
                 observed_addresses: set[str] = set()
-                for log in logs:
+                for raw_log in payload["logs"]:
+                    log = dict(raw_log)
                     identities = self._pool_identity_candidates(log).intersection(
                         addresses
                     )
+                    if not identities:
+                        continue
                     if (
-                        not identities
-                        or _lower(log.get("transactionHash"))
+                        _lower(log.get("transactionHash"))
                         != _lower(row["tx_hash"])
                         or _hex_int(log.get("blockNumber"), "replay block")
                         != int(row["block_number"])
@@ -3277,84 +3498,321 @@ class MarketIndexer:
                         raise CanonicalConflict(
                             "deferred pool log no longer matches its canonical queue"
                         )
+                    self._log_key(log)
+                    raw_logs.append(log)
                     observed_addresses.update(identities)
                 if observed_addresses != addresses:
                     raise RpcError("deferred pool identity queue omitted raw logs")
-                pools = self._verified_pools_for_deferred_logs(logs)
-                legacy_addresses = {
-                    address for address in addresses if len(address) == 42
+
+                logs = raw_logs
+                entry = {
+                    "row": row,
+                    "marker": marker,
+                    "payload": payload,
+                    "addresses": addresses,
+                    "header": header,
+                    "logs": logs,
                 }
-                if legacy_addresses:
-                    self._resolve_unknown_pools(
-                        "pool", logs, pools,
-                        identity_block=identity_block if needs_state else None,
-                        identity_hash=(
-                            identity_header["hash"]
-                            if needs_state and identity_header is not None else None
-                        ),
-                    )
-                resolved_v4: list[dict[str, Any]] = []
-                for pool_id in sorted(
-                    address for address in addresses if len(address) == 66
-                ):
-                    pool = self._verified_pool(pool_id)
-                    if pool is not None:
-                        pools[pool_id] = pool
-                        resolved_v4.append(pool)
-                        continue
-                    assert identity_block is not None and identity_header is not None
-                    pool = self._resolve_current_v4_pool(
-                        pool_id, identity_block, identity_header["hash"],
-                    )
-                    if pool is None:
-                        pool = self._resolve_current_v4_input(
-                            pool_id, logs, _lower(row["tx_hash"]),
+                prepared.append(entry)
+                for log in logs:
+                    combined_logs.setdefault(self._log_key(log), log)
+                worked = True
+            except Exception as exc:
+                selected_network.difference_update(newly_selected)
+                batch_error = exc
+                worked = True
+                self._mark_pool_identity_replay_error(
+                    row, marker, payload, exc,
+                )
+
+        if not prepared:
+            self._set_runtime(
+                "pool_identity", error=batch_error,
+                latency=time.monotonic() - started,
+                pool_identity_replayed=replayed,
+                pool_identity_rejected=rejected,
+                pool_identity_inserted_events=inserted_count,
+            )
+            return worked
+
+        active_addresses = set().union(*(
+            entry["addresses"] for entry in prepared
+        ))
+        selected_network.intersection_update(active_addresses)
+        identity_block: int | None = None
+        identity_header: dict[str, Any] | None = None
+        anchor_error: Exception | None = None
+        transient: dict[str, Exception] = {}
+        processed_network: set[str] = set()
+        resolved_v4: dict[str, dict[str, Any]] = {}
+        guarded = False
+        if selected_network:
+            try:
+                identity_block = _hex_int(
+                    self._clients["pool"].call("eth_blockNumber", []),
+                    "current pool identity block",
+                )
+                identity_header = self._block("pool", identity_block)
+            except Exception as exc:
+                anchor_error = exc
+                batch_error = exc
+                transient.update({
+                    address: exc for address in selected_network
+                })
+
+        if identity_header is not None:
+            assert identity_block is not None
+            v4_ids = {
+                address for address in selected_network if len(address) == 66
+            }
+            if v4_ids:
+                try:
+                    getter_pools, getter_failures = (
+                        self._resolve_current_v4_pools(
+                            v4_ids, identity_block, identity_header["hash"],
                         )
-                    if pool is not None:
-                        pools[pool_id] = pool
-                        resolved_v4.append(pool)
-                if needs_state:
-                    assert identity_block is not None and identity_header is not None
+                    )
+                    resolved_v4.update(getter_pools)
+                    transient.update(getter_failures)
+                    if getter_failures:
+                        batch_error = getter_failures[
+                            sorted(getter_failures)[0]
+                        ]
+                except Exception as exc:
+                    batch_error = exc
+                    transient.update({pool_id: exc for pool_id in v4_ids})
+                else:
+                    fallback_ids = (
+                        v4_ids.difference(resolved_v4).difference(transient)
+                    )
+                    fallback_candidates = {
+                        pool_id: (
+                            tuple(
+                                log for log in combined_logs.values()
+                                if pool_id in self._pool_identity_candidates(log)
+                            ),
+                            "",
+                        )
+                        for pool_id in fallback_ids
+                    }
+                    try:
+                        recovered, failures = self._resolve_current_v4_inputs(
+                            fallback_candidates,
+                        )
+                    except Exception as exc:
+                        batch_error = exc
+                        transient.update({
+                            pool_id: exc for pool_id in fallback_ids
+                        })
+                    else:
+                        resolved_v4.update(recovered)
+                        transient.update(failures)
+                        if failures:
+                            batch_error = failures[sorted(failures)[0]]
+                        processed_network.update(
+                            fallback_ids.difference(failures)
+                        )
+                    processed_network.update(resolved_v4)
+
+            legacy_ids = {
+                address for address in selected_network if len(address) == 42
+            }
+            if legacy_ids:
+                pools = self._verified_pools_for_deferred_logs(
+                    list(combined_logs.values())
+                )
+                try:
+                    guarded, legacy_failures = self._resolve_unknown_pools(
+                        "pool", list(combined_logs.values()), pools,
+                        identity_block=identity_block,
+                        identity_hash=identity_header["hash"],
+                        addresses=legacy_ids,
+                    )
+                    transient.update(legacy_failures)
+                    if legacy_failures:
+                        batch_error = legacy_failures[
+                            sorted(legacy_failures)[0]
+                        ]
+                except CanonicalConflict as exc:
+                    anchor_error = exc
+                    batch_error = exc
+                except Exception as exc:
+                    batch_error = exc
+                    transient.update({
+                        address: exc for address in legacy_ids
+                    })
+                else:
+                    processed_network.update(legacy_ids.difference(transient))
+
+            if anchor_error is None and processed_network and not guarded:
+                try:
                     canonical = self._block("pool", identity_block)
                     if canonical["hash"] != identity_header["hash"]:
                         raise CanonicalConflict(
                             "current pool identity anchor changed during resolution"
                         )
+                except Exception as exc:
+                    anchor_error = exc
+                    batch_error = exc
+
+        # No network work follows the anchor guard. Decode outside the writer,
+        # then publish prepared rows in short transactions with per-row guards.
+        publication: list[dict[str, Any]] = []
+        for entry in prepared:
+            row = entry["row"]
+            addresses = entry["addresses"]
+            network_addresses = addresses.intersection(selected_network)
+            if anchor_error is not None and network_addresses:
+                publication.append({**entry, "error": anchor_error})
+                continue
+            failed = addresses.intersection(transient)
+            processed = addresses.difference(failed)
+            if not processed:
+                publication.append({
+                    **entry,
+                    "error": transient[sorted(failed)[0]],
+                })
+                continue
+            pending_error = (
+                transient[sorted(failed)[0]] if failed else None
+            )
+            row_v4 = [
+                resolved_v4[pool_id]
+                for pool_id in sorted(processed)
+                if pool_id in resolved_v4
+            ]
+            processed_logs = [
+                log for log in entry["logs"]
+                if self._pool_identity_candidates(log).intersection(processed)
+            ]
+            try:
                 events = self._decode(
-                    "pool", logs, {int(row["block_number"]): header},
+                    "pool", processed_logs,
+                    {int(row["block_number"]): entry["header"]},
                     resolve_unknown=False,
-                    known_pools=resolved_v4,
+                    known_pools=row_v4,
                 )
-                with self.store.transaction():
-                    inserted = self.store.ingest(
-                        [header], events, lane="history",
-                    )
-                    self._finish_pool_identity_replay(
-                        row, marker, payload, addresses,
-                    )
+            except Exception as exc:
+                batch_error = exc
+                publication.append({**entry, "error": exc})
+                continue
+            publication.append({
+                **entry,
+                "processed": processed,
+                "pending_error": pending_error,
+                "row_v4": row_v4,
+                "events": events,
+            })
+
+        published = 0
+        while published < len(publication):
+            completed: list[tuple[dict[str, Any], list[dict[str, Any]]]] = []
+            try:
+                with self.store.transaction() as connection:
+                    acquired_at = time.monotonic()
+                    first = published
+                    while (
+                        published < len(publication)
+                        and (
+                            published == first
+                            or time.monotonic() - acquired_at
+                            < DEFERRED_POOL_IDENTITY_PUBLICATION_SECONDS
+                        )
+                    ):
+                        item = publication[published]
+                        published += 1
+                        row = item["row"]
+                        marker = item["marker"]
+                        payload = item["payload"]
+                        pending = connection.execute(
+                            "SELECT generation,last_error,block_hash "
+                            "FROM pending_enrichment WHERE tx_hash=?",
+                            (_lower(row["tx_hash"]),),
+                        ).fetchone()
+                        if (
+                            pending is None
+                            or int(pending["generation"])
+                            != int(row["generation"])
+                            or str(pending["last_error"] or "") != marker
+                            or _lower(pending["block_hash"])
+                            != _lower(row["block_hash"])
+                        ):
+                            continue
+                        stored = connection.execute(
+                            "SELECT hash FROM blocks WHERE number=?",
+                            (int(row["block_number"]),),
+                        ).fetchone()
+                        if (
+                            stored is None
+                            or _lower(stored["hash"]) != item["header"]["hash"]
+                        ):
+                            error = CanonicalConflict(
+                                "deferred pool log changed before publication"
+                            )
+                            batch_error = error
+                            self._mark_pool_identity_replay_error(
+                                row, marker, payload, error,
+                            )
+                            continue
+                        error = item.get("error")
+                        if isinstance(error, BaseException):
+                            self._mark_pool_identity_replay_error(
+                                row, marker, payload, error,
+                            )
+                            continue
+
+                        connection.execute("SAVEPOINT pool_identity_row")
+                        try:
+                            inserted = self.store.ingest(
+                                [item["header"]], item["events"], lane="history",
+                            )
+                            self._finish_pool_identity_replay(
+                                row, marker, payload, item["processed"],
+                                pending_error=item["pending_error"],
+                            )
+                        except Exception as exc:
+                            connection.execute(
+                                "ROLLBACK TO SAVEPOINT pool_identity_row"
+                            )
+                            connection.execute(
+                                "RELEASE SAVEPOINT pool_identity_row"
+                            )
+                            batch_error = exc
+                            self._mark_pool_identity_replay_error(
+                                row, marker, payload, exc,
+                            )
+                        else:
+                            connection.execute(
+                                "RELEASE SAVEPOINT pool_identity_row"
+                            )
+                            completed.append((item, list(inserted)))
+            except Exception as exc:
+                batch_error = exc
+                completed.clear()
+
+            for item, inserted in completed:
+                processed = item["processed"]
                 inserted_count += len(inserted)
                 resolved_pools = {
                     address: self._verified_pool(address)
-                    for address in addresses
+                    for address in processed
                 }
                 resolved_count = sum(
                     pool is not None for pool in resolved_pools.values()
                 )
                 replayed += resolved_count
-                rejected += len(addresses) - resolved_count
+                rejected += len(processed) - resolved_count
                 publish = list(inserted)
                 publish.extend(
                     {"pool": self._stored_pool(stored)}
-                    for pool in resolved_v4
+                    for pool in item["row_v4"]
                     if (stored := self.store.pool(str(pool["id"]))) is not None
                 )
                 if publish:
-                    self._publish_event_pools(publish)
-            except Exception as exc:
-                batch_error = exc
-                self._mark_pool_identity_replay_error(
-                    row, marker, payload, exc,
-                )
+                    try:
+                        self._publish_event_pools(publish)
+                    except Exception as exc:
+                        batch_error = exc
         self._set_runtime(
             "pool_identity", error=batch_error,
             latency=time.monotonic() - started,
@@ -3995,7 +4453,10 @@ class MarketIndexer:
         with self._status_lock:
             head = max(observed_number, int(self._runtime_status.get("head") or 0))
             lag = max(0, head - int(cursor["block_number"]))
-            pending = lag > 0
+            # The live worker normally trails a continuously advancing tip.
+            # Reserve recent-gap priority for debt larger than one adaptive
+            # live batch; exact-tip admission can starve history indefinitely.
+            pending = lag > self._live_chunk
             self._runtime_status.update({
                 "recent_catchup_priority": pending,
                 "recent_catchup_lag_blocks": lag,

--- a/src/rhpools/lp_market_index.py
+++ b/src/rhpools/lp_market_index.py
@@ -64,13 +64,15 @@ HISTORY_MAX_CHUNK = 32_768
 # Background history uses a shorter writer target so financial lanes can run.
 MAX_INTERVAL_STORE_SECONDS = 2.0
 HISTORY_MAX_INTERVAL_STORE_SECONDS = 0.2
-ENRICH_BATCH = 4
+ENRICH_BATCH = 8
 ENRICHMENT_CAPABILITY_RECHECK_S = 300.0
 ENRICH_TRACE_BATCH = 2
 ENRICH_WORKERS = 8
 ENRICH_TRACE_WORKERS = 4
-ENRICH_INFLIGHT_LIMIT = ENRICH_BATCH * ENRICH_WORKERS
+ENRICH_REGULAR_INFLIGHT_LIMIT = ENRICH_BATCH * ENRICH_WORKERS
+ENRICH_TRACE_INFLIGHT_LIMIT = ENRICH_TRACE_BATCH * ENRICH_TRACE_WORKERS
 REPROJECT_BATCH = 128
+CORE_POSITION_REPAIR_BATCH = 128
 V4_OWNER_REPAIR_LIMIT = 32
 V4_OWNER_REPAIR_SCAN = 8192
 V3_BIRTH_REPAIR_PREFIXES = tuple(
@@ -4469,13 +4471,19 @@ class MarketIndexer:
     def _fill_enrichment_jobs(
         self, reserved: Iterable[str] = (),
     ) -> None:
-        active = sum(
-            len(rows)
-            for rows, _future, _started, _trace
-            in self._enrichment_jobs.values()
+        active_by_lane = {False: 0, True: 0}
+        for rows, _future, _started, trace in self._enrichment_jobs.values():
+            active_by_lane[trace] += len(rows)
+        regular_capacity = max(
+            0, ENRICH_REGULAR_INFLIGHT_LIMIT - active_by_lane[False],
         )
-        capacity = ENRICH_INFLIGHT_LIMIT - active
-        if capacity <= 0 or self._stop.is_set():
+        trace_capacity = max(
+            0, ENRICH_TRACE_INFLIGHT_LIMIT - active_by_lane[True],
+        )
+        if (
+            (regular_capacity == 0 and trace_capacity == 0)
+            or self._stop.is_set()
+        ):
             return
         blocked = {
             str(row["tx_hash"])
@@ -4483,21 +4491,21 @@ class MarketIndexer:
             for row in rows
         }
         blocked.update(str(tx_hash) for tx_hash in reserved)
-        selection_limit = min(256, capacity + len(blocked))
-        candidates = []
-        for row in self.store.pending_enrichments(selection_limit):
-            if str(row["tx_hash"]) in blocked:
-                continue
-            candidates.append(row)
-            if len(candidates) == capacity:
-                break
+        selection_limit = min(
+            256, regular_capacity + trace_capacity + len(blocked),
+        )
+        candidates = [
+            row
+            for row in self.store.pending_enrichments(selection_limit)
+            if str(row["tx_hash"]) not in blocked
+        ]
         trace_hashes = self._pending_v4_trace_hashes(candidates)
         trace_rows = [
             row for row in candidates if str(row["tx_hash"]) in trace_hashes
-        ]
+        ][:trace_capacity]
         regular_rows = [
             row for row in candidates if str(row["tx_hash"]) not in trace_hashes
-        ]
+        ][:regular_capacity]
         batches = [
             *(
                 (tuple(regular_rows[offset:offset + ENRICH_BATCH]), False)
@@ -5008,7 +5016,12 @@ class MarketIndexer:
         while not self._stop.is_set():
             try:
                 started = time.monotonic()
-                worked = self.store.repair_v3_birth_history(V3_BIRTH_REPAIR_PREFIXES)
+                worked = self.store.repair_legacy_core_position_keys(
+                    limit=CORE_POSITION_REPAIR_BATCH,
+                )
+                worked = worked or self.store.repair_v3_birth_history(
+                    V3_BIRTH_REPAIR_PREFIXES,
+                )
                 worked = self._repair_v4_owners_once() or worked
                 if worked:
                     self._set_runtime("repair", latency=time.monotonic() - started)

--- a/src/rhpools/lp_market_index.py
+++ b/src/rhpools/lp_market_index.py
@@ -57,7 +57,6 @@ MAX_LOGS_PER_RESPONSE = 10_000
 LIVE_MIN_CHUNK = 1
 LIVE_INITIAL_CHUNK = 256
 LIVE_MAX_CHUNK = 2_048
-RECENT_CATCHUP_PRIORITY_BLOCKS = 512
 HISTORY_MIN_CHUNK = 1
 HISTORY_INITIAL_CHUNK = 8
 HISTORY_MAX_CHUNK = 32_768
@@ -3916,7 +3915,7 @@ class MarketIndexer:
         with self._status_lock:
             head = max(observed_number, int(self._runtime_status.get("head") or 0))
             lag = max(0, head - int(cursor["block_number"]))
-            pending = lag > RECENT_CATCHUP_PRIORITY_BLOCKS
+            pending = lag > 0
             self._runtime_status.update({
                 "recent_catchup_priority": pending,
                 "recent_catchup_lag_blocks": lag,

--- a/src/rhpools/lp_market_index.py
+++ b/src/rhpools/lp_market_index.py
@@ -406,6 +406,7 @@ class MarketIndexer:
             tuple[str, ...],
             tuple[tuple[Mapping[str, Any], ...], Future, float, bool],
         ] = {}
+        self._enrichment_admission_turn = {False: 0, True: 0}
         self._worker_clients: list[Any] = []
         self._worker_clients_lock = threading.Lock()
         self._feed_condition = threading.Condition()
@@ -3136,9 +3137,16 @@ class MarketIndexer:
 
     def _resolve_deferred_pool_identities_once(self) -> bool:
         self._seed_deferred_v4_pool_identities()
-        rows = self._pending_pool_identity_replays(
-            newest=self._pool_identity_replay_turn != 0,
-        )
+        turn = self._pool_identity_replay_turn
+        if turn == 1:
+            rows = self.store.requested_enrichments(
+                DEFERRED_POOL_IDENTITY_BATCH,
+                identity=True,
+            )
+            if not rows:
+                rows = self._pending_pool_identity_replays(newest=True)
+        else:
+            rows = self._pending_pool_identity_replays(newest=turn != 0)
         if not rows:
             return False
         with self._current_receipt_lock:
@@ -4474,16 +4482,16 @@ class MarketIndexer:
         active_by_lane = {False: 0, True: 0}
         for rows, _future, _started, trace in self._enrichment_jobs.values():
             active_by_lane[trace] += len(rows)
-        regular_capacity = max(
-            0, ENRICH_REGULAR_INFLIGHT_LIMIT - active_by_lane[False],
-        )
-        trace_capacity = max(
-            0, ENRICH_TRACE_INFLIGHT_LIMIT - active_by_lane[True],
-        )
-        if (
-            (regular_capacity == 0 and trace_capacity == 0)
-            or self._stop.is_set()
-        ):
+        capacity_by_lane = {
+            False: max(
+                0, ENRICH_REGULAR_INFLIGHT_LIMIT - active_by_lane[False],
+            ),
+            True: max(
+                0, ENRICH_TRACE_INFLIGHT_LIMIT - active_by_lane[True],
+            ),
+        }
+        available_capacity = sum(capacity_by_lane.values())
+        if available_capacity == 0 or self._stop.is_set():
             return
         blocked = {
             str(row["tx_hash"])
@@ -4491,29 +4499,53 @@ class MarketIndexer:
             for row in rows
         }
         blocked.update(str(tx_hash) for tx_hash in reserved)
-        selection_limit = min(
-            256, regular_capacity + trace_capacity + len(blocked),
+        selection_limit = min(256, max(16, available_capacity * 4))
+        candidates = self.store.pending_enrichments(
+            selection_limit,
+            exclude=blocked,
+            prioritized=True,
         )
-        candidates = [
-            row
-            for row in self.store.pending_enrichments(selection_limit)
-            if str(row["tx_hash"]) not in blocked
-        ]
         trace_hashes = self._pending_v4_trace_hashes(candidates)
-        trace_rows = [
-            row for row in candidates if str(row["tx_hash"]) in trace_hashes
-        ][:trace_capacity]
-        regular_rows = [
-            row for row in candidates if str(row["tx_hash"]) not in trace_hashes
-        ][:regular_capacity]
+        admission_pattern = ("historical", "requested", "recent", "recent")
+        selected_by_lane: dict[bool, list[Mapping[str, Any]]] = {
+            False: [],
+            True: [],
+        }
+        for trace, capacity in capacity_by_lane.items():
+            if capacity == 0:
+                continue
+            by_priority: dict[str, deque[Mapping[str, Any]]] = {
+                priority: deque() for priority in dict.fromkeys(admission_pattern)
+            }
+            for row in candidates:
+                if (str(row["tx_hash"]) in trace_hashes) != trace:
+                    continue
+                by_priority[str(row["_enrichment_priority"])].append(row)
+            turn = self._enrichment_admission_turn[trace]
+            while len(selected_by_lane[trace]) < capacity and any(by_priority.values()):
+                for offset in range(len(admission_pattern)):
+                    priority = admission_pattern[
+                        (turn + offset) % len(admission_pattern)
+                    ]
+                    if by_priority[priority]:
+                        selected_by_lane[trace].append(
+                            by_priority[priority].popleft(),
+                        )
+                        turn = (turn + 1) % len(admission_pattern)
+                        break
+            self._enrichment_admission_turn[trace] = turn
         batches = [
             *(
-                (tuple(regular_rows[offset:offset + ENRICH_BATCH]), False)
-                for offset in range(0, len(regular_rows), ENRICH_BATCH)
+                (tuple(selected_by_lane[False][offset:offset + ENRICH_BATCH]), False)
+                for offset in range(0, len(selected_by_lane[False]), ENRICH_BATCH)
             ),
             *(
-                (tuple(trace_rows[offset:offset + ENRICH_TRACE_BATCH]), True)
-                for offset in range(0, len(trace_rows), ENRICH_TRACE_BATCH)
+                (tuple(
+                    selected_by_lane[True][offset:offset + ENRICH_TRACE_BATCH],
+                ), True)
+                for offset in range(
+                    0, len(selected_by_lane[True]), ENRICH_TRACE_BATCH,
+                )
             ),
         ]
         for rows, trace in batches:

--- a/src/rhpools/lp_market_index.py
+++ b/src/rhpools/lp_market_index.py
@@ -315,6 +315,7 @@ class MarketIndexer:
         history_disk_reserve_bytes: int = DEFAULT_HISTORY_DISK_RESERVE_BYTES,
         current_observer: Any | None = None,
         accounting_projector: Callable[[], bool] | None = None,
+        accounting_recovery: Callable[[], bool] | None = None,
     ) -> None:
         if history_days < 0:
             raise ValueError("history_days must be nonnegative")
@@ -324,6 +325,7 @@ class MarketIndexer:
         self.market = market
         self.current_observer = current_observer
         self._accounting_projector = accounting_projector
+        self._accounting_recovery = accounting_recovery
         self.rpc_url = rpc_url
         self.history_days = int(history_days)
         self.v3_balances = bool(v3_balances)
@@ -1891,6 +1893,12 @@ class MarketIndexer:
                     self._threads.append(threading.Thread(
                         target=self._accounting_run,
                         name="lp-market-accounting",
+                        daemon=True,
+                    ))
+                if self._accounting_recovery is not None:
+                    self._threads.append(threading.Thread(
+                        target=self._accounting_recovery_run,
+                        name="lp-market-identity-recovery",
                         daemon=True,
                     ))
                 if self._head_wss_urls:
@@ -4717,6 +4725,27 @@ class MarketIndexer:
                     self._set_runtime("accounting", latency=time.monotonic() - started)
             except Exception as exc:
                 self._set_runtime("accounting", error=exc)
+                self._stop.wait(backoff)
+                backoff = min(30.0, backoff * 2.0)
+            else:
+                backoff = 0.5
+                self._stop.wait(0.01 if worked else 0.1)
+
+    def _accounting_recovery_run(self) -> None:
+        backoff = 0.5
+        while not self._stop.is_set():
+            if not self._initialized.wait(0.5):
+                continue
+            try:
+                started = time.monotonic()
+                worked = self._accounting_recovery()
+                if worked:
+                    self._set_runtime(
+                        "identity_recovery",
+                        latency=time.monotonic() - started,
+                    )
+            except Exception as exc:
+                self._set_runtime("identity_recovery", error=exc)
                 self._stop.wait(backoff)
                 backoff = min(30.0, backoff * 2.0)
             else:

--- a/src/rhpools/lp_market_index.py
+++ b/src/rhpools/lp_market_index.py
@@ -61,9 +61,10 @@ RECENT_CATCHUP_PRIORITY_BLOCKS = 512
 HISTORY_MIN_CHUNK = 1
 HISTORY_INITIAL_CHUNK = 8
 HISTORY_MAX_CHUNK = 32_768
-# Target half the chain's observed ~100 ms block interval, not multi-second
-# writer monopolies that stall live ingestion and every financial worker.
-MAX_INTERVAL_STORE_SECONDS = 0.05
+# Live catch-up must amortize fixed commit costs across all available blocks.
+# Background history uses a shorter writer target so financial lanes can run.
+MAX_INTERVAL_STORE_SECONDS = 2.0
+HISTORY_MAX_INTERVAL_STORE_SECONDS = 0.2
 ENRICH_BATCH = 8
 ENRICHMENT_CAPABILITY_RECHECK_S = 300.0
 REPROJECT_BATCH = 128
@@ -2955,24 +2956,23 @@ class MarketIndexer:
             stored = self.store.pool(pool_id)
             if stored is not None and self._identity_verified(stored):
                 continue
-            pending = reader.execute(
-                "SELECT 1 FROM pending_enrichment "
-                "WHERE last_error GLOB 'pool_identity_pending:*' "
-                "AND instr(last_error,?)>0 LIMIT 1",
-                (pool_id,),
-            ).fetchone()
-            if pending is not None:
-                continue
             rows = reader.execute(
-                "SELECT * FROM events WHERE pool_id=? AND protocol='v4' "
-                "AND kind IN ('add','remove','collect') "
-                "ORDER BY timestamp DESC,id DESC LIMIT ?",
+                "SELECT e.*,p.last_error AS enrichment_error FROM events e "
+                "LEFT JOIN pending_enrichment p ON p.tx_hash=e.tx_hash "
+                "WHERE e.pool_id=? AND e.protocol='v4' "
+                "AND e.kind IN ('add','remove','collect') "
+                "ORDER BY e.timestamp DESC,e.id DESC LIMIT ?",
                 (
                     pool_id,
                     DEFERRED_POOL_IDENTITY_CANDIDATES_PER_POOL,
                 ),
             ).fetchall()
             for row in rows:
+                # Check only this canonical candidate's job, not every
+                # serialized error payload in the global receipt backlog.
+                pending = self._pool_identity_marker(row["enrichment_error"])
+                if pending is not None and pool_id in pending["addresses"]:
+                    continue
                 log = self._stored_v4_modify_log(dict(row))
                 if log is not None:
                     logs.append(log)
@@ -3513,10 +3513,14 @@ class MarketIndexer:
         current = self._live_chunk if lane == "live" else self._history_chunk
         minimum = LIVE_MIN_CHUNK if lane == "live" else HISTORY_MIN_CHUNK
         maximum = LIVE_MAX_CHUNK if lane == "live" else HISTORY_MAX_CHUNK
+        store_target = (
+            MAX_INTERVAL_STORE_SECONDS if lane == "live"
+            else HISTORY_MAX_INTERVAL_STORE_SECONDS
+        )
         sample_blocks = max(
             1, current if scanned_blocks is None else int(scanned_blocks),
         )
-        if store_seconds > MAX_INTERVAL_STORE_SECONDS and current > minimum:
+        if store_seconds > store_target and current > minimum:
             # Size the next transaction from measured durable-store throughput.
             # This bounds both writers' lock residency during traffic or memory
             # pressure, while successful cheap intervals grow again below.
@@ -3525,7 +3529,7 @@ class MarketIndexer:
                 min(
                     current - 1,
                     int(
-                        sample_blocks * MAX_INTERVAL_STORE_SECONDS
+                        sample_blocks * store_target
                         / max(store_seconds, 1e-9)
                     ),
                 ),
@@ -3548,7 +3552,7 @@ class MarketIndexer:
             )
         if store_seconds > 0:
             candidate = min(candidate, max(
-                minimum, int(sample_blocks * MAX_INTERVAL_STORE_SECONDS / store_seconds),
+                minimum, int(sample_blocks * store_target / store_seconds),
             ))
         if candidate <= current:
             return

--- a/src/rhpools/lp_market_index.py
+++ b/src/rhpools/lp_market_index.py
@@ -8,7 +8,7 @@ import shutil
 import threading
 import time
 from collections import OrderedDict, deque
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any
 from urllib.parse import urlsplit
@@ -44,6 +44,7 @@ from .lp_market_protocols import (
     position_state_requests,
     unknown_pool_candidates,
     resolve_v4_tick_spacing,
+    repair_v4_owners,
 )
 from .lp_market_store import (
     LP_ENRICHMENT_KINDS, CanonicalConflict, MarketStore,
@@ -64,6 +65,8 @@ MAX_INTERVAL_STORE_SECONDS = 2.0
 ENRICH_BATCH = 8
 ENRICHMENT_CAPABILITY_RECHECK_S = 300.0
 REPROJECT_BATCH = 128
+V4_OWNER_REPAIR_LIMIT = 32
+V4_OWNER_REPAIR_SCAN = 8192
 V3_BIRTH_REPAIR_PREFIXES = tuple(
     sorted(f"nft:{address}:" for address in V3_NFT_MANAGER_ADDRESSES)
 )
@@ -193,7 +196,10 @@ class _HttpRpc:
             raise RpcError(f"{method} response omitted result")
         return response["result"]
 
-    def batch(self, calls: Iterable[tuple[str, Sequence[Any]]]) -> list[Any]:
+    def batch(
+        self, calls: Iterable[tuple[str, Sequence[Any]]], *,
+        allow_reverts: bool = False,
+    ) -> list[Any]:
         specifications = list(calls)
         if not specifications:
             return []
@@ -223,6 +229,13 @@ class _HttpRpc:
             error = item.get("error")
             if error is not None:
                 code = error.get("code") if isinstance(error, Mapping) else None
+                if (
+                    allow_reverts and method in {"eth_call", "eth_estimateGas"}
+                    and isinstance(error, Mapping)
+                    and (code == 3 or "execution reverted" in str(error.get("message", "")).lower())
+                ):
+                    results.append({"error": dict(error)})
+                    continue
                 raise RpcError(f"{method}: {error}", code=code if isinstance(code, int) else None)
             if "result" not in item:
                 raise RpcError(f"batch RPC {method} omitted result")
@@ -298,6 +311,7 @@ class MarketIndexer:
         v3_balances: bool = False,
         history_disk_reserve_bytes: int = DEFAULT_HISTORY_DISK_RESERVE_BYTES,
         current_observer: Any | None = None,
+        accounting_projector: Callable[[], bool] | None = None,
     ) -> None:
         if history_days < 0:
             raise ValueError("history_days must be nonnegative")
@@ -306,6 +320,7 @@ class MarketIndexer:
         self.store = store
         self.market = market
         self.current_observer = current_observer
+        self._accounting_projector = accounting_projector
         self.rpc_url = rpc_url
         self.history_days = int(history_days)
         self.v3_balances = bool(v3_balances)
@@ -353,6 +368,7 @@ class MarketIndexer:
         self._runtime_persist_at = 0.0
         self._runtime_error_signature: tuple[tuple[str, str], ...] = ()
         self._stop = threading.Event()
+        self._live_wakeup = threading.Event()
         self._started = False
         self._initialized = threading.Event()
         self._lifecycle_lock = threading.Lock()
@@ -372,12 +388,11 @@ class MarketIndexer:
         self._process_lock_fd: int | None = None
         self._history_verified = False
         self._enrichment_verified = False
-        self._enrichment_deferred_until = 0.0
-        self._enrichment_deferred_reason: str | None = None
         self._projection_verified = False
         self._publish_after_id = ""
         self._market_epoch = int(self.store.status().get("epoch", 0))
         self._enrichment_local = threading.local()
+        self._enrichment_jobs: dict[str, tuple[Mapping[str, Any], Future, float]] = {}
         self._worker_clients: list[Any] = []
         self._worker_clients_lock = threading.Lock()
         self._feed_condition = threading.Condition()
@@ -404,7 +419,7 @@ class MarketIndexer:
             max_workers=2, thread_name_prefix="lp-current-pool",
         )
         self._enrichment_executor = ThreadPoolExecutor(
-            max_workers=4, thread_name_prefix="lp-market-fetch",
+            max_workers=ENRICH_BATCH, thread_name_prefix="lp-market-fetch",
         )
         self._header_executor = ThreadPoolExecutor(
             max_workers=2, thread_name_prefix="lp-market-headers",
@@ -1309,6 +1324,7 @@ class MarketIndexer:
             self._observed_blocks.move_to_end(number)
             while len(self._observed_blocks) > HEAD_REPLAY_LIMIT * 2:
                 self._observed_blocks.popitem(last=False)
+        self._live_wakeup.set()
         self._submit_market_observer("observe_current_block", dict(current))
         self._submit_market_observer(
             "observe_current_events", dict(current),
@@ -1661,19 +1677,39 @@ class MarketIndexer:
         return {}
 
     def _batch_on(
-        self, client: Any, calls: list[tuple[str, Sequence[Any]]],
+        self, client: Any, calls: list[tuple[str, Sequence[Any]]], *,
+        allow_reverts: bool = False,
     ) -> list[Any]:
         if not calls:
             return []
         if len(calls) > MAX_BATCH_CALLS:
             output: list[Any] = []
             for index in range(0, len(calls), MAX_BATCH_CALLS):
-                output.extend(self._batch_on(client, calls[index:index + MAX_BATCH_CALLS]))
+                output.extend(self._batch_on(
+                    client, calls[index:index + MAX_BATCH_CALLS],
+                    allow_reverts=allow_reverts,
+                ))
             return output
         batch = getattr(client, "batch", None)
         if callable(batch):
-            return list(batch(calls))
-        return [client.call(method, list(params)) for method, params in calls]
+            results = list(
+                batch(calls, allow_reverts=True) if allow_reverts else batch(calls)
+            )
+            if len(results) != len(calls):
+                raise RpcError("batch RPC returned an incomplete result set")
+            return results
+        results = []
+        for method, params in calls:
+            try:
+                results.append(client.call(method, list(params)))
+            except RpcError as exc:
+                if allow_reverts and method in {"eth_call", "eth_estimateGas"} and (
+                    exc.code == 3 or "execution reverted" in str(exc).lower()
+                ):
+                    results.append({"error": str(exc)})
+                else:
+                    raise
+        return results
 
     def _rpc_batch(self, lane: str, calls: list[tuple[str, Sequence[Any]]]) -> list[Any]:
         return self._batch_on(self._clients[lane], calls)
@@ -1837,7 +1873,23 @@ class MarketIndexer:
                         name="lp-market-projection",
                         daemon=True,
                     ),
+                    threading.Thread(
+                        target=self._metadata_run,
+                        name="lp-market-metadata",
+                        daemon=True,
+                    ),
+                    threading.Thread(
+                        target=self._source_repair_run,
+                        name="lp-market-repair",
+                        daemon=True,
+                    ),
                 ]
+                if self._accounting_projector is not None:
+                    self._threads.append(threading.Thread(
+                        target=self._accounting_run,
+                        name="lp-market-accounting",
+                        daemon=True,
+                    ))
                 if self._head_wss_urls:
                     self._threads[0:0] = [
                         threading.Thread(
@@ -2801,7 +2853,7 @@ class MarketIndexer:
             })
             connection.execute(
                 "UPDATE pending_enrichment SET next_attempt=0,last_error=?,"
-                "updated_at=? WHERE tx_hash=?",
+                "updated_at=?,generation=generation+1 WHERE tx_hash=?",
                 (self._encode_pool_identity_marker(payload), now, tx_hash),
             )
         return len(grouped)
@@ -2996,7 +3048,7 @@ class MarketIndexer:
         with self.store.transaction() as connection:
             connection.execute(
                 "UPDATE pending_enrichment SET next_attempt=?,last_error=?,"
-                "updated_at=? WHERE tx_hash=? AND last_error=?",
+                "updated_at=?,generation=generation+1 WHERE tx_hash=? AND last_error=?",
                 (
                     time.time() + delay,
                     self._encode_pool_identity_marker(updated),
@@ -3023,7 +3075,7 @@ class MarketIndexer:
                 updated.pop("identity_error", None)
                 connection.execute(
                     "UPDATE pending_enrichment SET next_attempt=0,last_error=?,"
-                    "updated_at=? WHERE tx_hash=? AND last_error=?",
+                    "updated_at=?,generation=generation+1 WHERE tx_hash=? AND last_error=?",
                     (
                         self._encode_pool_identity_marker(updated), time.time(),
                         _lower(row["tx_hash"]), marker,
@@ -3039,7 +3091,7 @@ class MarketIndexer:
             if needs_enrichment is not None:
                 connection.execute(
                     "UPDATE pending_enrichment SET next_attempt=?,last_error=?,"
-                    "updated_at=? WHERE tx_hash=? AND last_error=?",
+                    "updated_at=?,generation=generation+1 WHERE tx_hash=? AND last_error=?",
                     (
                         float(payload.get("prior_next_attempt", 0.0)),
                         payload.get("prior_error"), time.time(),
@@ -3737,6 +3789,15 @@ class MarketIndexer:
                         "timestamp": _timestamp(interval_end),
                     },
                 )
+                if self.v3_balances:
+                    latest_by_pool: dict[str, dict[str, Any]] = {}
+                    for event in inserted:
+                        pool = event.get("pool")
+                        if isinstance(pool, Mapping) and pool.get("protocol") == "v3":
+                            latest_by_pool[str(pool["id"])] = event
+                    self.store.queue_v3_balances(
+                        latest_by_pool, end, interval_end["hash"],
+                    )
             store_s = time.monotonic() - store_acquired
         except CanonicalConflict as exc:
             self._recover_reorg(cursor, str(exc))
@@ -3750,15 +3811,6 @@ class MarketIndexer:
             self._publish_event_pools(inserted)
         except Exception as exc:
             self._set_runtime("metadata", error=exc)
-        if self.v3_balances:
-            latest_by_pool: dict[str, dict[str, Any]] = {}
-            for event in inserted:
-                pool = event.get("pool")
-                if isinstance(pool, Mapping) and pool.get("protocol") == "v3":
-                    latest_by_pool[str(pool["id"])] = event
-            self.store.queue_v3_balances(
-                latest_by_pool, end, interval_end["hash"],
-            )
         postprocess_s = time.monotonic() - postprocess_started
         self._resize_after_success(
             "live", len(logs), store_s, end - start + 1,
@@ -4038,21 +4090,19 @@ class MarketIndexer:
         self, calls: list[tuple[str, Sequence[Any]]], client: Any | None = None,
     ) -> list[Any]:
         selected = client or self._clients["enrichment"]
-        try:
-            return self._batch_on(selected, calls)
-        except RpcError:
-            results: list[Any] = []
-            for method, params in calls:
-                if self._stop.is_set():
-                    raise RpcError("indexer closed during pinned state batch")
-                try:
-                    results.append(selected.call(method, list(params)))
-                except RpcError as exc:
-                    if "revert" in str(exc).lower():
-                        results.append({"error": str(exc)})
-                    else:
-                        raise
-            return results
+        unique: list[tuple[str, Sequence[Any]]] = []
+        indexes: dict[tuple[str, str], int] = {}
+        order: list[int] = []
+        for method, params in calls:
+            key = (method, json.dumps(params, sort_keys=True, separators=(",", ":")))
+            index = indexes.get(key)
+            if index is None:
+                index = len(unique)
+                indexes[key] = index
+                unique.append((method, params))
+            order.append(index)
+        results = self._batch_on(selected, unique, allow_reverts=True)
+        return [results[index] for index in order]
 
     def _enrich_transaction(
         self, pending: Mapping[str, Any],
@@ -4071,22 +4121,29 @@ class MarketIndexer:
         block_hash = _lower(receipt.get("blockHash"))
         if block_number != int(pending["block_number"]) or block_hash != _lower(pending["block_hash"]):
             raise CanonicalConflict(f"pending transaction {tx_hash} moved to another block")
-        trace = client.call("debug_traceTransaction", [
-            tx_hash,
-            {
-                "tracer": "callTracer", "tracerConfig": {"withLog": True},
-                # Never rebuild missing historical state on the authoritative
-                # live node. Unavailable traces remain pending, not fabricated.
-                "reexec": 0, "timeout": "5s",
-            },
-        ])
-        if not isinstance(trace, Mapping):
-            raise RpcError(f"transaction {tx_hash} returned a malformed call trace")
         raw_logs = receipt.get("logs")
         if not isinstance(raw_logs, list):
             raise RpcError(f"transaction {tx_hash} receipt omitted logs")
         if any(not isinstance(log, Mapping) for log in raw_logs):
             raise RpcError(f"transaction {tx_hash} receipt contains malformed logs")
+        traces = None
+        if any(
+            _lower(log.get("address")) == POOL_MANAGER
+            and _lower((log.get("topics") or [None])[0]) == V4_MODIFY_LIQUIDITY_TOPIC
+            for log in raw_logs
+        ):
+            trace = client.call("debug_traceTransaction", [
+                tx_hash,
+                {
+                    "tracer": "callTracer", "tracerConfig": {"withLog": True},
+                    # Missing historical state stays pending; never rebuild it
+                    # on the authoritative live node.
+                    "reexec": 0, "timeout": "5s",
+                },
+            ])
+            if not isinstance(trace, Mapping):
+                raise RpcError(f"transaction {tx_hash} returned a malformed call trace")
+            traces = {tx_hash: dict(trace)}
         header = _header(
             client.call("eth_getBlockByNumber", [hex(block_number), False]),
             block_number,
@@ -4098,7 +4155,7 @@ class MarketIndexer:
             [dict(log) for log in raw_logs],
             {block_number: header},
             receipts={tx_hash: dict(receipt)},
-            traces={tx_hash: dict(trace)},
+            traces=traces,
             resolve_unknown=False,
         )
         if not events:
@@ -4152,88 +4209,83 @@ class MarketIndexer:
             or "trace rpc exhausted" in text
         )
 
-    def _defer_enrichment(self, reason: str, delay: float) -> None:
-        self._enrichment_deferred_reason = str(reason)[:1000]
-        self._enrichment_deferred_until = time.monotonic() + max(
-            1.0, float(delay),
+    def _current_enrichment_jobs(
+        self, conn: Any, jobs: Sequence[Mapping[str, Any]],
+    ) -> set[str]:
+        expected = {str(job["tx_hash"]): job for job in jobs}
+        marks = ",".join("?" for _ in expected)
+        current = conn.execute(
+            "SELECT tx_hash,block_hash,generation,last_error FROM pending_enrichment "
+            f"WHERE tx_hash IN ({marks})", tuple(expected),
         )
-        self._set_runtime(
-            "enrichment", error=self._enrichment_deferred_reason,
-            enrichment_deferred=True,
-            enrichment_deferred_reason=self._enrichment_deferred_reason,
-            enrichment_retry_in_s=round(max(1.0, float(delay)), 1),
-        )
+        return {
+            str(row["tx_hash"]) for row in current
+            if row["block_hash"] == expected[str(row["tx_hash"])]["block_hash"]
+            and row["generation"] == expected[str(row["tx_hash"])]["generation"]
+            and self._pool_identity_marker(row["last_error"]) is None
+        }
 
-    def _pool_identity_is_pending(self, tx_hash: str) -> bool:
-        row = self.store.read().execute(
-            "SELECT last_error FROM pending_enrichment WHERE tx_hash=?",
-            (_lower(tx_hash),),
-        ).fetchone()
-        return (
-            row is not None
-            and self._pool_identity_marker(row["last_error"]) is not None
-        )
+    def _mark_enrichment_failure(
+        self, row: Mapping[str, Any], error: Exception, *, delay: float,
+    ) -> bool:
+        with self.store.transaction() as conn:
+            if not self._current_enrichment_jobs(conn, [row]):
+                return False
+            self.store.mark_enrichment_error(str(row["tx_hash"]), str(error), delay=delay)
+        return True
 
     def _enrich_once(self) -> bool:
-        now = time.monotonic()
-        if now < self._enrichment_deferred_until:
-            retry_in = self._enrichment_deferred_until - now
-            self._set_runtime(
-                "enrichment", error=self._enrichment_deferred_reason,
-                enrichment_deferred=True,
-                enrichment_deferred_reason=self._enrichment_deferred_reason,
-                enrichment_retry_in_s=round(retry_in, 1),
-            )
+        capacity = ENRICH_BATCH - len(self._enrichment_jobs)
+        if capacity and not self._stop.is_set():
+            for row in self.store.pending_enrichments(ENRICH_BATCH):
+                tx_hash = str(row["tx_hash"])
+                if tx_hash in self._enrichment_jobs:
+                    continue
+                self._enrichment_jobs[tx_hash] = (
+                    row, self._enrichment_executor.submit(self._enrich_transaction, row),
+                    time.monotonic(),
+                )
+                capacity -= 1
+                if not capacity:
+                    break
+        if not self._enrichment_jobs:
             return False
-        pending = self.store.pending_enrichments(ENRICH_BATCH)
-        if not pending:
-            return False
-        trace = self.source_status().get("trace")
-        if isinstance(trace, Mapping) and trace.get("configured") is False:
-            self._defer_enrichment(
-                "trace RPC unavailable; configure LP_RPC_TRACE_URLS",
-                ENRICHMENT_CAPABILITY_RECHECK_S,
-            )
-            return False
-        started = time.monotonic()
+        wait(
+            [job[1] for job in self._enrichment_jobs.values()],
+            timeout=0.05, return_when=FIRST_COMPLETED,
+        )
         jobs = [
-            (
-                row,
-                self._enrichment_executor.submit(
-                    self._enrich_transaction, row,
-                ),
-            )
-            for row in pending
+            self._enrichment_jobs.pop(tx_hash)
+            for tx_hash, job in tuple(self._enrichment_jobs.items())
+            if job[1].done()
         ]
+        if not jobs:
+            return False
+        started = min(job[2] for job in jobs)
         successful_rows: list[Mapping[str, Any]] = []
         events: list[dict[str, Any]] = []
         transactions: list[dict[str, Any]] = []
         orphan: Mapping[str, Any] | None = None
         batch_error: Exception | None = None
-        capability_error: Exception | None = None
-        for row, future in jobs:
+        for row, future, _submitted_at in jobs:
             try:
                 row_events, transaction = future.result()
             except CanonicalConflict:
                 orphan = orphan or row
             except Exception as exc:
-                batch_error = exc
-                if self._trace_capability_error(exc):
-                    # This is a lane-level prerequisite, not a failure of this
-                    # canonical job. Preserve its attempts/error fields.
-                    capability_error = capability_error or exc
-                    continue
-                if self._pool_identity_is_pending(str(row["tx_hash"])):
-                    continue
                 attempts = int(row.get("attempts", 0)) + 1
-                self.store.mark_enrichment_error(
-                    str(row["tx_hash"]), str(exc),
-                    delay=min(300.0, 2.0 ** min(attempts, 8)),
-                )
+                if not self._mark_enrichment_failure(
+                    row, exc,
+                    delay=(
+                        ENRICHMENT_CAPABILITY_RECHECK_S
+                        if self._trace_capability_error(exc)
+                        else min(300.0, 2.0 ** min(attempts, 8))
+                    ),
+                ):
+                    continue
+                batch_error = exc
                 self._set_runtime("enrichment", error=exc)
             else:
-                if self._pool_identity_is_pending(str(row["tx_hash"])):
-                    continue
                 successful_rows.append(row)
                 events.extend(row_events)
                 transactions.append(transaction)
@@ -4249,7 +4301,23 @@ class MarketIndexer:
             return True
         if transactions:
             try:
-                self.store.enrich(events, transactions=transactions)
+                with self.store.transaction() as conn:
+                    # Identity replay may have added canonical inputs while
+                    # this receipt was in flight. Never clear that newer job.
+                    ready = self._current_enrichment_jobs(conn, successful_rows)
+                    if not ready:
+                        return True
+                    if len(ready) != len(successful_rows):
+                        successful_rows = [
+                            row for row in successful_rows if str(row["tx_hash"]) in ready
+                        ]
+                        transactions = [
+                            row for row in transactions if str(row["tx_hash"]) in ready
+                        ]
+                        events = [
+                            event for event in events if str(event["tx_hash"]) in ready
+                        ]
+                    self.store.enrich(events, transactions=transactions)
             except CanonicalConflict:
                 row = successful_rows[0]
                 self._recover_reorg(
@@ -4263,8 +4331,8 @@ class MarketIndexer:
             except Exception as exc:
                 for row in successful_rows:
                     attempts = int(row.get("attempts", 0)) + 1
-                    self.store.mark_enrichment_error(
-                        str(row["tx_hash"]), str(exc),
+                    self._mark_enrichment_failure(
+                        row, exc,
                         delay=min(300.0, 2.0 ** min(attempts, 8)),
                     )
                 self._set_runtime("enrichment", error=exc)
@@ -4276,9 +4344,6 @@ class MarketIndexer:
                     self._set_runtime(
                         "enrichment", latency=time.monotonic() - started,
                         enrichment_batch=len(transactions),
-                        enrichment_deferred=False,
-                        enrichment_deferred_reason=None,
-                        enrichment_retry_in_s=0.0,
                     )
                 else:
                     self._set_runtime(
@@ -4286,16 +4351,6 @@ class MarketIndexer:
                         latency=time.monotonic() - started,
                         enrichment_batch=len(transactions),
                     )
-        if capability_error is not None:
-            delay = (
-                ENRICHMENT_CAPABILITY_RECHECK_S
-                if "unavailable" in str(capability_error).lower()
-                else 60.0
-            )
-            self._defer_enrichment(str(capability_error), delay)
-        elif successful_rows:
-            self._enrichment_deferred_until = 0.0
-            self._enrichment_deferred_reason = None
         return True
 
     @staticmethod
@@ -4486,6 +4541,7 @@ class MarketIndexer:
         backoff = 0.25
         while not self._stop.is_set():
             try:
+                self._live_wakeup.clear()
                 if not self._initialized.is_set():
                     head_number, head, latency = self._bootstrap()
                     self._initialized.set()
@@ -4502,7 +4558,8 @@ class MarketIndexer:
                 backoff = min(10.0, backoff * 2.0)
             else:
                 backoff = 0.25
-                self._stop.wait(0.05 if worked else 0.35)
+                if not worked:
+                    self._live_wakeup.wait(0.1)
 
     def _history_run(self) -> None:
         backoff = 0.5
@@ -4529,19 +4586,132 @@ class MarketIndexer:
                     self._verify_chain("enrichment")
                     self._enrichment_verified = True
                 worked = self._sync_market_reorg()
-                worked = self._publish_stored_pool_page() or worked
-                if not self._recent_catchup_pending():
-                    worked = self._resolve_deferred_pool_identities_once() or worked
-                    worked = self._enrich_once() or worked
-                worked = self._metadata_once() or worked
-                worked = self._recover_legacy_v4_pool_page() or worked
+                worked = self._enrich_once() or worked
             except Exception as exc:
                 self._set_runtime("enrichment", error=exc)
                 self._stop.wait(backoff)
                 backoff = min(30.0, backoff * 2.0)
             else:
                 backoff = 0.5
+                self._stop.wait(0.05 if worked or self._enrichment_jobs else 0.5)
+
+    def _metadata_run(self) -> None:
+        backoff = 0.5
+        verified = False
+        while not self._stop.is_set():
+            if not self._initialized.wait(0.5):
+                continue
+            try:
+                if not verified:
+                    self._verify_chain("enrichment")
+                    verified = True
+                worked = self._publish_stored_pool_page()
+                worked = self._resolve_deferred_pool_identities_once() or worked
+                worked = self._metadata_once() or worked
+                worked = self._recover_legacy_v4_pool_page() or worked
+            except Exception as exc:
+                self._set_runtime("metadata", error=exc)
+                self._stop.wait(backoff)
+                backoff = min(30.0, backoff * 2.0)
+            else:
+                backoff = 0.5
                 self._stop.wait(0.05 if worked else 0.5)
+
+    def _repair_v4_owners_once(self) -> bool:
+        reader = self.store.read()
+        checkpoint_key = "v4_owner_correlation_repair_v1"
+        checkpoint = self.store._metadata(reader, checkpoint_key, {})
+        if checkpoint.get("complete"):
+            return False
+        epoch = int(self.store._metadata(reader, "epoch", 0))
+        after = int(checkpoint.get("after_event_id", (1 << 63) - 1))
+        page = reader.execute(
+            "SELECT MIN(id) AS first_id,COUNT(*) AS count FROM "
+            "(SELECT id FROM events WHERE id<=? ORDER BY id DESC LIMIT ?)",
+            (after, V4_OWNER_REPAIR_SCAN),
+        ).fetchone()
+        if page["first_id"] is None:
+            with self.store.transaction() as conn:
+                self.store._set_metadata(conn, checkpoint_key, {**checkpoint, "complete": True})
+            return False
+        candidates = reader.execute(
+            "SELECT e.id,e.tx_hash FROM events e "
+            "WHERE e.id>=? AND e.id<=? AND e.protocol='v4' "
+            "AND e.custody=? AND e.token_id IS NOT NULL AND e.owner IS NULL "
+            "AND e.position_key='nft:'||e.custody||':'||e.token_id "
+            "AND json_extract(e.data,'$.trace_complete')=1 "
+            "AND NOT EXISTS(SELECT 1 FROM pending_enrichment p WHERE p.tx_hash=e.tx_hash) "
+            "AND EXISTS(SELECT 1 FROM events t WHERE t.tx_hash=e.tx_hash "
+            "AND t.protocol='nft' AND t.kind='transfer' AND t.custody=e.custody "
+            "AND t.token_id=e.token_id AND t.position_key=e.position_key) "
+            "ORDER BY e.id DESC LIMIT ?",
+            (page["first_id"], after, V4_POSITION_MANAGER, V4_OWNER_REPAIR_LIMIT),
+        ).fetchall()
+        next_after = int(
+            candidates[-1]["id"] if len(candidates) == V4_OWNER_REPAIR_LIMIT
+            else page["first_id"]
+        ) - 1
+        repaired_events = repaired_transactions = 0
+        with self.store.transaction() as conn:
+            if int(self.store._metadata(conn, "epoch", 0)) != epoch:
+                return True
+            for tx_hash in dict.fromkeys(str(row["tx_hash"]) for row in candidates):
+                if conn.execute(
+                    "SELECT 1 FROM pending_enrichment WHERE tx_hash=?", (tx_hash,),
+                ).fetchone() is not None:
+                    continue
+                events = [dict(row) for row in conn.execute(
+                    "SELECT * FROM events WHERE tx_hash=? "
+                    "ORDER BY block_number,tx_index,log_index", (tx_hash,),
+                )]
+                for event in events:
+                    event["data"] = json.loads(event["data"])
+                changes = repair_v4_owners(events)
+                if changes:
+                    self.store.enrich(changes)
+                    repaired_events += len(changes)
+                    repaired_transactions += 1
+            self.store._set_metadata(conn, checkpoint_key, {
+                "after_event_id": next_after,
+                "scanned_events": int(checkpoint.get("scanned_events", 0)) + int(page["count"]),
+                "repaired_events": int(checkpoint.get("repaired_events", 0)) + repaired_events,
+                "repaired_transactions": int(checkpoint.get("repaired_transactions", 0)) + repaired_transactions,
+                "complete": False,
+            })
+        return True
+
+    def _source_repair_run(self) -> None:
+        backoff = 0.5
+        while not self._stop.is_set():
+            try:
+                started = time.monotonic()
+                worked = self.store.repair_v3_birth_history(V3_BIRTH_REPAIR_PREFIXES)
+                worked = self._repair_v4_owners_once() or worked
+                if worked:
+                    self._set_runtime("repair", latency=time.monotonic() - started)
+            except Exception as exc:
+                self._set_runtime("repair", error=exc)
+                self._stop.wait(backoff)
+                backoff = min(30.0, backoff * 2.0)
+            else:
+                backoff = 0.5
+                self._stop.wait(0.05 if worked else 1.0)
+
+    def _accounting_run(self) -> None:
+        backoff = 0.5
+        while not self._stop.is_set():
+            try:
+                started = time.monotonic()
+                worked = self._accounting_projector()
+                if worked:
+                    self._set_runtime("accounting", latency=time.monotonic() - started)
+            except Exception as exc:
+                self._set_runtime("accounting", error=exc)
+                self._stop.wait(backoff)
+                backoff = min(30.0, backoff * 2.0)
+            else:
+                backoff = 0.5
+                self._stop.wait(0.01 if worked else 0.1)
 
     def _projection_run(self) -> None:
         backoff = 0.5
@@ -4550,17 +4720,11 @@ class MarketIndexer:
                 continue
             try:
                 self.store.checkpoint()
-                if self._recent_catchup_pending():
-                    self._stop.wait(0.25)
-                    continue
                 if not self._projection_verified:
                     self._verify_chain("enrichment")
                     self._projection_verified = True
                 worked = self._reproject_once()
                 worked = self._balances_once() or worked
-                worked = self.store.repair_v3_birth_history(
-                    V3_BIRTH_REPAIR_PREFIXES,
-                ) or worked
             except Exception as exc:
                 self._set_runtime("projection", error=exc)
                 self._stop.wait(backoff)
@@ -4579,6 +4743,7 @@ class MarketIndexer:
                 return
             was_started = self._started
             self._stop.set()
+            self._live_wakeup.set()
             try:
                 current = threading.current_thread()
                 for thread in self._threads:

--- a/src/rhpools/lp_market_protocols.py
+++ b/src/rhpools/lp_market_protocols.py
@@ -2056,6 +2056,7 @@ def position_state_requests(events: Iterable[Mapping[str, Any]]) -> list[dict[st
         token_id: int | None = None
         proof_identity: tuple[str, str, int] | None = None
         mint_absence_basis: str | None = None
+        burn_absence_basis: str | None = None
         if token_id_value is not None and custody in NFT_MANAGER_ADDRESSES:
             token_id = _integer(token_id_value, "NFT token id")
             if (
@@ -2073,6 +2074,12 @@ def position_state_requests(events: Iterable[Mapping[str, Any]]) -> list[dict[st
                     if custody in V3_NFT_MANAGER_ADDRESSES
                     else "same_receipt_verified_v4_manager_mint"
                 )
+            if (
+                custody == V4_POSITION_MANAGER
+                and proof_identity is not None
+                and (*proof_identity, "burn") in lifecycle_proofs
+            ):
+                burn_absence_basis = "same_receipt_verified_v4_manager_burn"
         for field, pin in pins:
             if field == "position_before" and mint_absence_basis is not None:
                 # An allowlisted manager's canonical zero-address mint proves
@@ -2136,6 +2143,9 @@ def position_state_requests(events: Iterable[Mapping[str, Any]]) -> list[dict[st
                         mint_absence_basis if field == "position_after" else None
                     ),
                     position_before_block=max(block - 1, 0),
+                    position_after_absence_basis=(
+                        burn_absence_basis if field == "position_after" else None
+                    ),
                 )
             if request is not None:
                 key = (tuple(request["correlation"]["identity"].items()), field, request["params"][0]["to"], request["params"][0]["data"], pin)
@@ -2281,7 +2291,7 @@ def _decode_position_result(decoder: str, result: str | None) -> dict[str, Any]:
         words = _words(result, "V4 StateView position result", 3)
         liquidity = _uint(words[0], 128, "V4 position liquidity")
         return {
-            "exists": bool(liquidity or words[1] or words[2]),
+            "exists": True if liquidity or words[1] or words[2] else None,
             "liquidity": str(liquidity),
             "fee_growth_inside0_last_x128": str(words[1]),
             "fee_growth_inside1_last_x128": str(words[2]),
@@ -2349,6 +2359,27 @@ def decode_position_state_results(
                             f"NFPM token state {actual_name} does not match core event"
                         )
             update["data"][field] = position
+            after_absence_basis = correlation.get(
+                "position_after_absence_basis"
+            )
+            if after_absence_basis is not None:
+                if (
+                    decoder != "v4_state_view_position"
+                    or field != "position_after"
+                    or after_absence_basis
+                    != "same_receipt_verified_v4_manager_burn"
+                    or position.get("liquidity") != "0"
+                ):
+                    raise ProtocolDecodeError(
+                        "verified V4 manager burn absence proof is inconsistent"
+                    )
+                # StateView reads the PoolManager's position record, whose fee
+                # growth fields may remain after liquidity reaches zero. The
+                # receipt burn proves NFT absence, not storage deletion.
+                position.update(
+                    nft_exists=False,
+                    nft_absence_basis=after_absence_basis,
+                )
             absence_basis = correlation.get("position_before_absence_basis")
             if absence_basis is not None:
                 expected_basis = {

--- a/src/rhpools/lp_market_protocols.py
+++ b/src/rhpools/lp_market_protocols.py
@@ -1327,8 +1327,116 @@ def _owner_from_same_tx_transfers(
     return prior, "manager_transfer_same_tx_prestate"
 
 
+def repair_v4_owners(
+    events: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return V4 manager core rows whose owner is proven by same-tx transfers.
+
+    The input is not mutated.  Returned rows retain all canonical enrichment
+    fields and differ only in owner attribution and its evidence basis.
+    """
+    rows: list[Mapping[str, Any]] = []
+    transfers: dict[
+        tuple[str, int], dict[int, tuple[str, str]]
+    ] = defaultdict(dict)
+    for row in events:
+        if not isinstance(row, Mapping):
+            raise TypeError("normalized transaction events must be mappings")
+        rows.append(row)
+        custody = _address(row.get("custody"), "normalized event custody", strict=False)
+        if (
+            row.get("protocol") != "nft"
+            or row.get("kind") != "transfer"
+            or custody != V4_POSITION_MANAGER
+        ):
+            continue
+        token_id = _integer(row.get("token_id"), "V4 transfer token id")
+        if (
+            str(row.get("position_key") or "").lower()
+            != nft_position_key(V4_POSITION_MANAGER, token_id)
+        ):
+            raise ProtocolDecodeError(
+                "V4 manager transfer has inconsistent NFT position key"
+            )
+        data = row.get("data")
+        if not isinstance(data, Mapping):
+            raise ProtocolDecodeError("V4 manager transfer data is missing")
+        prior_owner = _address(data.get("prior_owner"), "V4 transfer prior owner")
+        new_owner = _address(data.get("new_owner"), "V4 transfer new owner")
+        if prior_owner == ZERO_ADDRESS and new_owner == ZERO_ADDRESS:
+            raise ProtocolDecodeError("V4 manager transfer has two zero endpoints")
+        identity = (
+            _hash(row.get("tx_hash"), "V4 transfer transaction"),
+            token_id,
+        )
+        log_index = _integer(row.get("log_index"), "V4 transfer log index")
+        existing = transfers[identity].get(log_index)
+        endpoints = (prior_owner, new_owner)
+        if existing is not None and existing != endpoints:
+            raise ProtocolDecodeError("conflicting normalized V4 manager transfers")
+        transfers[identity][log_index] = endpoints
+
+    changed: list[dict[str, Any]] = []
+    for row in rows:
+        custody = _address(row.get("custody"), "normalized event custody", strict=False)
+        if (
+            row.get("protocol") != "v4"
+            or custody != V4_POSITION_MANAGER
+            or row.get("liquidity_delta") is None
+        ):
+            continue
+        token_id = _integer(row.get("token_id"), "V4 core token id")
+        if (
+            str(row.get("position_key") or "").lower()
+            != nft_position_key(V4_POSITION_MANAGER, token_id)
+        ):
+            raise ProtocolDecodeError(
+                "V4 manager core row has inconsistent NFT position key"
+            )
+        tx_hash = _hash(row.get("tx_hash"), "V4 core transaction")
+        candidates = sorted(
+            (index, *owners)
+            for index, owners in transfers.get((tx_hash, token_id), {}).items()
+        )
+        if not candidates:
+            continue
+        action_index = _integer(row.get("log_index"), "V4 core log index")
+        before = [item for item in candidates if item[0] <= action_index]
+        if before:
+            _index, prior_owner, new_owner = before[-1]
+            owner = new_owner if new_owner != ZERO_ADDRESS else prior_owner
+            basis = "manager_transfer_same_tx"
+        else:
+            _index, prior_owner, new_owner = candidates[0]
+            if prior_owner == ZERO_ADDRESS:
+                owner = new_owner
+                basis = "manager_mint_transfer_same_tx"
+            else:
+                owner = prior_owner
+                basis = "manager_transfer_same_tx_prestate"
+        if owner == ZERO_ADDRESS:
+            raise ProtocolDecodeError("V4 manager transfer cannot prove a zero owner")
+        data = row.get("data")
+        if not isinstance(data, Mapping):
+            raise ProtocolDecodeError("V4 manager core data is missing")
+        if (
+            row.get("owner") == owner
+            and row.get("identity_basis") == basis
+            and data.get("identity_basis") == basis
+        ):
+            continue
+        repaired = dict(row)
+        repaired_data = dict(data)
+        repaired.update(owner=owner, identity_basis=basis, data=repaired_data)
+        repaired_data["identity_basis"] = basis
+        changed.append(repaired)
+    return changed
+
+
 def _correlate_manager_events(
-    rows: list[dict[str, Any]], evidence: Mapping[str, Sequence[Mapping[str, Any]]]
+    rows: list[dict[str, Any]],
+    evidence: Mapping[str, Sequence[Mapping[str, Any]]],
+    headers: Mapping[Any, Mapping[str, Any]],
 ) -> None:
     by_tx: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for row in rows:
@@ -1398,6 +1506,33 @@ def _correlate_manager_events(
                 int(row["liquidity_delta"]), row["data"]["salt"],
             )
             v4_core_groups[key].append(row)
+        if v4_core_groups:
+            repair_input: list[Mapping[str, Any]] = list(tx_rows)
+            known = {_identity(row) for row in tx_rows}
+            for log in logs:
+                if (
+                    _topic0(log) != TRANSFER_TOPIC
+                    or _address(
+                        log.get("address"), "transfer emitter", strict=False
+                    ) != V4_POSITION_MANAGER
+                ):
+                    continue
+                transfer = _decode_transfer(log, headers)
+                if transfer is not None and _identity(transfer) not in known:
+                    repair_input.append(transfer)
+            repairs = {
+                _identity(row): row for row in repair_v4_owners(repair_input)
+            }
+            for row in tx_rows:
+                repaired = repairs.get(_identity(row))
+                if repaired is None:
+                    continue
+                row["owner"] = repaired["owner"]
+                row["identity_basis"] = repaired["identity_basis"]
+                row["data"] = repaired["data"]
+            for cores in v4_core_groups.values():
+                for row in cores:
+                    row["data"].setdefault("identity_basis", row["identity_basis"])
         v4_aux_groups: dict[tuple[Any, ...], list[dict[str, Any]]] = defaultdict(list)
         for aux in v4_aux:
             key = (aux["pool_id"], aux["tick_lower"], aux["tick_upper"], aux["liquidity_delta"], aux["salt"])
@@ -1410,14 +1545,9 @@ def _correlate_manager_events(
             if len(cores) != len(auxiliaries):
                 raise ProtocolDecodeError("ambiguous V4 PositionManager/core event correlation")
             for row, aux in zip(cores, auxiliaries):
-                token_id = int(row["token_id"])
-                owner, basis = _owner_from_same_tx_transfers(logs, V4_POSITION_MANAGER, token_id, row["log_index"])
-                row["owner"] = owner
-                row["identity_basis"] = basis or "verified_v4_nft_salt"
                 row["data"].update(
                     position_manager_operator=aux["operator"],
                     position_manager_event_log_index=aux["log_index"],
-                    identity_basis=row["identity_basis"],
                 )
 
         # Enrich Transfer rows when a same-transaction core action resolved the
@@ -1780,7 +1910,7 @@ def decode_logs(
             rows.append(row)
 
     evidence = _evidence_logs(ordered_logs, receipts)
-    _correlate_manager_events(rows, evidence)
+    _correlate_manager_events(rows, evidence, headers)
     _enrich_v4_traces(rows, receipts, traces, local_pools)
     rows.sort(key=lambda row: (row["block_number"], row["tx_index"], row["log_index"]))
     return rows
@@ -1882,12 +2012,17 @@ def position_state_requests(events: Iterable[Mapping[str, Any]]) -> list[dict[st
         if (
             proof_row.get("protocol") != "nft"
             or proof_row.get("kind") != "transfer"
-            or manager not in V3_NFT_MANAGER_ADDRESSES
-            or proof_data.get("manager_protocol") != "v3"
+            or manager not in NFT_MANAGER_ADDRESSES
+            or proof_data.get("manager_protocol") != MANAGER_INFO[manager]["protocol"]
             or token_value is None
         ):
             continue
         token_id = _integer(token_value, "lifecycle proof token id")
+        if (
+            str(proof_row.get("position_key") or "").lower()
+            != nft_position_key(manager, token_id)
+        ):
+            continue
         tx_hash = _hash(proof_row.get("tx_hash"), "lifecycle proof transaction")
         prior_owner = _address(
             proof_data.get("prior_owner"), "lifecycle prior owner", strict=False
@@ -1918,23 +2053,39 @@ def position_state_requests(events: Iterable[Mapping[str, Any]]) -> list[dict[st
         data = row.get("data") if isinstance(row.get("data"), Mapping) else {}
         core_key = data.get("core_position_key") or row.get("position_key")
         pool_value = row.get("pool") if isinstance(row.get("pool"), Mapping) else {}
-        for field, pin in pins:
-            request: dict[str, Any] | None = None
-            if token_id_value is not None and custody in V3_NFT_MANAGER_ADDRESSES:
-                token_id = _integer(token_id_value, "NFT token id")
+        token_id: int | None = None
+        proof_identity: tuple[str, str, int] | None = None
+        mint_absence_basis: str | None = None
+        if token_id_value is not None and custody in NFT_MANAGER_ADDRESSES:
+            token_id = _integer(token_id_value, "NFT token id")
+            if (
+                str(row.get("position_key") or "").lower()
+                == nft_position_key(custody, token_id)
+            ):
                 proof_identity = (
-                    _hash(row.get("tx_hash"), "NFPM event transaction"),
+                    _hash(row.get("tx_hash"), "NFT event transaction"),
                     custody,
                     token_id,
                 )
+            if proof_identity is not None and (*proof_identity, "mint") in lifecycle_proofs:
+                mint_absence_basis = (
+                    "same_receipt_verified_nfpm_mint"
+                    if custody in V3_NFT_MANAGER_ADDRESSES
+                    else "same_receipt_verified_v4_manager_mint"
+                )
+        for field, pin in pins:
+            if field == "position_before" and mint_absence_basis is not None:
+                # An allowlisted manager's canonical zero-address mint proves
+                # this monotonically assigned NFT position did not exist at
+                # the parent block. Attach that proof to the required after
+                # read instead of spending an archive call on a known revert.
+                continue
+            request: dict[str, Any] | None = None
+            if token_id is not None and custody in V3_NFT_MANAGER_ADDRESSES:
                 missing_basis = None
                 if (
-                    field == "position_before"
-                    and (*proof_identity, "mint") in lifecycle_proofs
-                ):
-                    missing_basis = "same_receipt_verified_nfpm_mint"
-                elif (
                     field == "position_after"
+                    and proof_identity is not None
                     and (*proof_identity, "burn") in lifecycle_proofs
                 ):
                     missing_basis = "same_receipt_verified_nfpm_burn"
@@ -1949,6 +2100,10 @@ def position_state_requests(events: Iterable[Mapping[str, Any]]) -> list[dict[st
                     token_id=str(token_id),
                     allow_missing=missing_basis is not None,
                     missing_basis=missing_basis,
+                    position_before_absence_basis=(
+                        mint_absence_basis if field == "position_after" else None
+                    ),
+                    position_before_block=max(block - 1, 0),
                     expected_tick_lower=row.get("tick_lower"),
                     expected_tick_upper=row.get("tick_upper"),
                     expected_token0=pool_value.get("token0"),
@@ -1977,6 +2132,10 @@ def position_state_requests(events: Iterable[Mapping[str, Any]]) -> list[dict[st
                 request = _state_request(
                     row, field, "v4_state_view_position", STATE_VIEW,
                     STATE_VIEW_POSITION_SELECTOR + pool_id[2:] + position_key[2:], pin,
+                    position_before_absence_basis=(
+                        mint_absence_basis if field == "position_after" else None
+                    ),
+                    position_before_block=max(block - 1, 0),
                 )
             if request is not None:
                 key = (tuple(request["correlation"]["identity"].items()), field, request["params"][0]["to"], request["params"][0]["data"], pin)
@@ -2190,6 +2349,44 @@ def decode_position_state_results(
                             f"NFPM token state {actual_name} does not match core event"
                         )
             update["data"][field] = position
+            absence_basis = correlation.get("position_before_absence_basis")
+            if absence_basis is not None:
+                expected_basis = {
+                    "v3_nfpm_position": "same_receipt_verified_nfpm_mint",
+                    "v4_state_view_position": "same_receipt_verified_v4_manager_mint",
+                }.get(decoder)
+                parent_block = _integer(
+                    correlation.get("position_before_block"),
+                    "verified mint parent block",
+                )
+                if (
+                    absence_basis != expected_basis
+                    or field != "position_after"
+                    or parent_block
+                    != max(_integer(correlation.get("block_number"), "pinned block") - 1, 0)
+                ):
+                    raise ProtocolDecodeError(
+                        "verified manager mint absence proof is inconsistent"
+                    )
+                if decoder == "v4_state_view_position":
+                    before = {
+                        "exists": False,
+                        "liquidity": "0",
+                        "fee_growth_inside0_last_x128": "0",
+                        "fee_growth_inside1_last_x128": "0",
+                        "tokens_owed0": None,
+                        "tokens_owed1": None,
+                        "claims_empty": True,
+                        "claim_model": "fees_settled_on_modify_no_tokens_owed_storage",
+                        "source": "verified_v4_manager_mint_absence",
+                    }
+                else:
+                    before = _decode_position_result(decoder, None)
+                before.update(
+                    pinned_block=parent_block,
+                    absence_basis=absence_basis,
+                )
+                update["data"]["position_before"] = before
             if decoder == "v3_nfpm_position" and position.get("exists"):
                 update["data"]["position_identity"] = {
                     "manager": correlation.get("manager"),
@@ -2314,6 +2511,6 @@ __all__ = [
     "SLIPSTREAM_FACTORY", "PANCAKE_V3_FACTORY",
     "MODIFY_LIQUIDITY_SELECTOR", "SWAP_SELECTOR", "ProtocolDecodeError",
     "decode_logs", "decode_gas_record", "manager_descriptor", "nft_position_key",
-    "unknown_pool_candidates", "position_state_requests",
+    "repair_v4_owners", "unknown_pool_candidates", "position_state_requests",
     "decode_position_state_results",
 ]

--- a/src/rhpools/lp_market_protocols.py
+++ b/src/rhpools/lp_market_protocols.py
@@ -284,6 +284,19 @@ def nft_position_key(manager: str, token_id: int | str) -> str:
     return f"nft:{address}:{token}"
 
 
+def core_position_key(protocol: str, pool_id: str, core_key: str) -> str:
+    """Qualify an EVM core-position hash by its globally unique pool."""
+    normalized_protocol = str(protocol).lower()
+    if normalized_protocol == "v3":
+        normalized_pool = _address(pool_id, "V3 core position pool")
+    elif normalized_protocol == "v4":
+        normalized_pool = _hash(pool_id, "V4 core position pool")
+    else:
+        raise ProtocolDecodeError("core position protocol must be v3 or v4")
+    raw_key = _hash(core_key, "core position key")
+    return f"{normalized_protocol}:{normalized_pool}:{raw_key}"
+
+
 def unknown_pool_candidates(
     logs: Iterable[Mapping[str, Any]], pools: Mapping[str, Mapping[str, Any]]
 ) -> tuple[str, ...]:
@@ -982,14 +995,17 @@ def _decode_event(
             lower = _topic_sint(topics[2], 24, "V3 tickLower")
             upper = _topic_sint(topics[3], 24, "V3 tickUpper")
             liquidity = _uint(words[1], 128, "V3 Mint liquidity")
+            raw_core_key = _v3_position_key(owner, lower, upper)
             row.update(
-                kind="add", custody=owner, position_key=_v3_position_key(owner, lower, upper),
+                kind="add",
+                custody=owner,
+                position_key=core_position_key("v3", row["pool_id"], raw_core_key),
                 tick_lower=lower, tick_upper=upper, liquidity_delta=str(liquidity),
                 amount0=str(words[2]), amount1=str(words[3]),
                 cashflow0=str(-words[2]), cashflow1=str(-words[3]),
                 accounting_basis="core_mint_exact_position_flow", identity_basis="core_position_custody",
             )
-            row["data"] = {"sender": sender, "core_position_key": row["position_key"]}
+            row["data"] = {"sender": sender, "core_position_key": raw_core_key}
         elif topic0 == V3_BURN_TOPIC:
             if len(topics) != 4:
                 raise ProtocolDecodeError("malformed V3 Burn topics")
@@ -998,10 +1014,13 @@ def _decode_event(
             lower = _topic_sint(topics[2], 24, "V3 tickLower")
             upper = _topic_sint(topics[3], 24, "V3 tickUpper")
             liquidity = _uint(words[0], 128, "V3 Burn liquidity")
+            raw_core_key = _v3_position_key(owner, lower, upper)
             row.update(
                 kind="remove" if liquidity else "checkpoint",
                 custody=owner,
-                position_key=_v3_position_key(owner, lower, upper),
+                position_key=core_position_key(
+                    "v3", row["pool_id"], raw_core_key
+                ),
                 tick_lower=lower,
                 tick_upper=upper,
                 liquidity_delta=str(-liquidity),
@@ -1014,7 +1033,7 @@ def _decode_event(
                 ),
                 identity_basis="core_position_custody",
             )
-            row["data"] = {"core_position_key": row["position_key"]}
+            row["data"] = {"core_position_key": raw_core_key}
         elif topic0 == V3_COLLECT_TOPIC:
             if len(topics) != 4:
                 raise ProtocolDecodeError("malformed V3 Collect topics")
@@ -1025,13 +1044,21 @@ def _decode_event(
             recipient = _word_address(words[0], "V3 Collect recipient")
             amount0 = _uint(words[1], 128, "V3 Collect amount0")
             amount1 = _uint(words[2], 128, "V3 Collect amount1")
+            raw_core_key = _v3_position_key(owner, lower, upper)
             row.update(
-                kind="collect", custody=owner, position_key=_v3_position_key(owner, lower, upper),
+                kind="collect",
+                custody=owner,
+                position_key=core_position_key(
+                    "v3", row["pool_id"], raw_core_key
+                ),
                 tick_lower=lower, tick_upper=upper, amount0=str(amount0), amount1=str(amount1),
                 cashflow0=str(amount0), cashflow1=str(amount1),
                 accounting_basis="core_collect_exact_position_flow", identity_basis="core_position_custody",
             )
-            row["data"] = {"recipient": recipient, "core_position_key": row["position_key"]}
+            row["data"] = {
+                "recipient": recipient,
+                "core_position_key": raw_core_key,
+            }
         elif topic0 == V3_FLASH_TOPIC:
             if len(topics) != 3:
                 raise ProtocolDecodeError("malformed V3 Flash topics")
@@ -1150,12 +1177,12 @@ def _decode_event(
             liquidity_delta = _sint(words[2], 256, "V4 liquidityDelta")
             salt = "0x" + words[3].to_bytes(32, "big").hex()
             kind = "add" if liquidity_delta > 0 else "remove" if liquidity_delta < 0 else "collect"
-            core_position_key = _v4_position_key(custody, lower, upper, salt)
+            raw_core_key = _v4_position_key(custody, lower, upper, salt)
             token_id = str(words[3]) if custody == V4_POSITION_MANAGER else None
             position_key = (
                 nft_position_key(custody, token_id)
                 if token_id is not None
-                else core_position_key
+                else core_position_key("v4", pool_id, raw_core_key)
             )
             row.update(
                 kind=kind, custody=custody, position_key=position_key, token_id=token_id,
@@ -1164,7 +1191,7 @@ def _decode_event(
             )
             row["data"] = {
                 "salt": salt,
-                "core_position_key": core_position_key,
+                "core_position_key": raw_core_key,
                 "trace_complete": False,
                 "cashflow_basis": "pending_trace",
             }
@@ -1481,7 +1508,10 @@ def _correlate_manager_events(
                 continue
             for row, aux in zip(cores, auxiliaries):
                 token_id = aux["token_id"]
-                core_key = row["position_key"]
+                core_key = _hash(
+                    row["data"].get("core_position_key"),
+                    "V3 core position key",
+                )
                 row["token_id"] = str(token_id)
                 row["position_key"] = nft_position_key(aux["manager"], token_id)
                 owner, basis = _owner_from_same_tx_transfers(logs, aux["manager"], token_id, row["log_index"])
@@ -2051,7 +2081,15 @@ def position_state_requests(events: Iterable[Mapping[str, Any]]) -> list[dict[st
         custody = _address(row.get("custody"), "position custody", strict=False)
         token_id_value = row.get("token_id")
         data = row.get("data") if isinstance(row.get("data"), Mapping) else {}
-        core_key = data.get("core_position_key") or row.get("position_key")
+        core_key_value = data.get("core_position_key")
+        if core_key_value is None:
+            legacy_key = str(row.get("position_key") or "").lower()
+            core_key_value = legacy_key if _HASH_RE.fullmatch(legacy_key) else None
+        core_key = (
+            _hash(core_key_value, "core position key")
+            if core_key_value is not None
+            else None
+        )
         pool_value = row.get("pool") if isinstance(row.get("pool"), Mapping) else {}
         token_id: int | None = None
         proof_identity: tuple[str, str, int] | None = None
@@ -2117,7 +2155,7 @@ def position_state_requests(events: Iterable[Mapping[str, Any]]) -> list[dict[st
                     expected_token1=pool_value.get("token1"),
                     expected_fee_ppm=pool_value.get("fee_ppm"),
                 )
-            elif protocol == "v3" and isinstance(core_key, str) and _HASH_RE.fullmatch(core_key.lower()):
+            elif protocol == "v3" and core_key is not None:
                 pool_address = _address(row.get("pool_id"), "V3 pool", strict=False)
                 if pool_address is not None:
                     request = _state_request(
@@ -2132,7 +2170,7 @@ def position_state_requests(events: Iterable[Mapping[str, Any]]) -> list[dict[st
             elif (
                 (protocol == "v4" or custody == V4_POSITION_MANAGER)
                 and isinstance(row.get("pool_id"), str)
-                and isinstance(core_key, str)
+                and core_key is not None
             ):
                 pool_id = _hash(row["pool_id"], "V4 pool id")
                 position_key = _hash(core_key, "V4 position key")
@@ -2541,7 +2579,8 @@ __all__ = [
     "V2_FACTORIES", "V3_FACTORIES", "CONCENTRATED_FACTORIES",
     "SLIPSTREAM_FACTORY", "PANCAKE_V3_FACTORY",
     "MODIFY_LIQUIDITY_SELECTOR", "SWAP_SELECTOR", "ProtocolDecodeError",
-    "decode_logs", "decode_gas_record", "manager_descriptor", "nft_position_key",
+    "core_position_key", "decode_logs", "decode_gas_record", "manager_descriptor",
+    "nft_position_key",
     "repair_v4_owners", "unknown_pool_candidates", "position_state_requests",
     "decode_position_state_results",
 ]

--- a/src/rhpools/lp_market_service.py
+++ b/src/rhpools/lp_market_service.py
@@ -1064,7 +1064,7 @@ class LPMarketService:
         self.market = market
         self.store = MarketStore(path, checkpoint_on_commit=not start)
         self.prices = PriceProjection(self.store)
-        self.book = AccountBook(self.store)
+        self.book = AccountBook(self.store, deferred=start)
         self.book.install()
         self._current_activity_lock = threading.RLock()
         self._current_activity_headers: OrderedDict[int, dict[str, Any]] = OrderedDict()
@@ -1083,6 +1083,7 @@ class LPMarketService:
             self.store, market, rpc_url, history_days=history_days,
             history_disk_reserve_bytes=history_disk_reserve_bytes, v3_balances=True,
             current_observer=self,
+            accounting_projector=self.book.project_pending if start else None,
         )
         # Restore the durable catalog before serving requests. Exact cold
         # inspectors can then reuse an already-qualified stored identity even
@@ -2629,12 +2630,18 @@ class LPMarketService:
                     "tx_hash": None, "event_count": 1,
                     "qualification": "durable_canonical_index",
                 }
-            current_at = int(row["activity"].get("timestamp") or 0)
-            pending = (
+            through_order = row.pop("financial_through_order", None)
+            financial_as_of = row.pop("financial_through_as_of", accounting_as_of)
+            current_order = row.get("_activity_order")
+            pending = bool(row.pop("financial_pending", False)) or (
                 row["activity"].get("qualification") == "provisional_canonical"
                 and (
-                    accounting_as_of is None
-                    or current_at > int(accounting_as_of)
+                    not isinstance(through_order, Mapping)
+                    or not current_order
+                    or tuple(current_order) > tuple(
+                        int(through_order.get(name) or 0)
+                        for name in ("block_number", "tx_index", "log_index")
+                    )
                 )
             )
             row["coverage"] = {
@@ -2650,7 +2657,8 @@ class LPMarketService:
                 )
             row["financials"] = {
                 "qualification": "durable_canonical_accounting",
-                "as_of": accounting_as_of,
+                "as_of": financial_as_of,
+                "through_order": through_order,
                 "current_activity_included": False,
                 "pending": pending,
             }

--- a/src/rhpools/lp_market_service.py
+++ b/src/rhpools/lp_market_service.py
@@ -27,6 +27,7 @@ BUCKET_FIELDS = (
     "deposit_usd", "withdrawal_usd", "priced_swaps", "priced_fees", "priced_flows", "flows",
 )
 _SUM_FIELDS = ",".join(f"SUM({name}) AS {name}" for name in BUCKET_FIELDS)
+_BUCKET_INDEX = {name: index for index, name in enumerate(BUCKET_FIELDS)}
 
 _MISSING = object()
 
@@ -1790,6 +1791,63 @@ class LPMarketService:
                 "(resolution=60 AND ((bucket>=? AND bucket<?) OR (bucket>=? AND bucket<=?))))",
                 [low_hour, high_hour, low_minute, low_hour, high_hour, high_minute])
 
+    def _bucket_aggregates(self, status, start, end):
+        """Share one canonical interval scan across overview and pool metrics."""
+        clause, args = self._bucket_clause(start, end)
+        events_revision = int(status.get("events_revision") or 0)
+
+        def load():
+            rows = self.store.read().execute(
+                f"SELECT pool_id,{_SUM_FIELDS} FROM lp_pool_buckets "
+                f"WHERE {clause} GROUP BY pool_id",
+                args,
+            ).fetchall()
+            return {
+                str(row["pool_id"]): tuple(
+                    row[field] or 0 for field in BUCKET_FIELDS
+                )
+                for row in rows
+            }
+
+        epoch = int(status.get("epoch") or 0)
+        cache_key = ("bucket-aggregates", events_revision, clause, *args)
+        aggregates = self._cached(
+            cache_key, load, ttl=float("inf"), epoch=epoch,
+        )
+        # These values are much larger than ordinary response-cache entries.
+        # Keep enough for every public window without retaining 64 revisions.
+        with self._cache_lock:
+            keys = [
+                key for key in self._cache
+                if len(key) > 1 and key[1] == "bucket-aggregates"
+            ]
+            for key in keys[:-8]:
+                self._cache.pop(key, None)
+        return aggregates
+
+    @staticmethod
+    def _bucket_sort_value(sort, values):
+        if values is None:
+            return 0 if sort in {"swaps", "adds", "removes", "activity"} else None
+        if sort == "volume":
+            return (
+                values[_BUCKET_INDEX["volume_usd"]]
+                if values[_BUCKET_INDEX["priced_swaps"]] > 0 else None
+            )
+        if sort == "fees":
+            return (
+                values[_BUCKET_INDEX["fees_usd"]]
+                if values[_BUCKET_INDEX["priced_fees"]] > 0 else None
+            )
+        if sort == "flow":
+            return (
+                values[_BUCKET_INDEX["deposit_usd"]]
+                - values[_BUCKET_INDEX["withdrawal_usd"]]
+                if values[_BUCKET_INDEX["priced_flows"]] > 0 else None
+            )
+        field = "events" if sort == "activity" else sort
+        return values[_BUCKET_INDEX[field]]
+
     @staticmethod
     def _filters(params, prefix="p"):
         conditions, values = [], []
@@ -1818,24 +1876,27 @@ class LPMarketService:
         status = self.status()
         name, start, end, coverage = self._window(params, status)
         def load():
-            clause, args = self._bucket_clause(start, end)
-            conn = self.store.read()
-            row = conn.execute(f"SELECT {_SUM_FIELDS},COUNT(DISTINCT pool_id) AS active_pools "
-                               f"FROM lp_pool_buckets WHERE {clause}", args).fetchone()
-            totals = {field: row[field] or 0 for field in BUCKET_FIELDS}
-            priced_swaps = int(totals["priced_swaps"])
-            priced_fees = int(totals["priced_fees"])
-            priced_flows = int(totals["priced_flows"])
+            aggregates = self._bucket_aggregates(status, start, end)
+            totals = [0] * len(BUCKET_FIELDS)
+            for values in aggregates.values():
+                for index, value in enumerate(values):
+                    totals[index] += value
+            total = lambda field: totals[_BUCKET_INDEX[field]]
+            priced_swaps = int(total("priced_swaps"))
+            priced_fees = int(total("priced_fees"))
+            priced_flows = int(total("priced_flows"))
             return {
-                "window": name, "volume_usd": totals["volume_usd"] if priced_swaps else None,
-                "fees_usd": totals["fees_usd"] if priced_fees else None,
-                "swaps": int(totals["swaps"]), "adds": int(totals["adds"]),
-                "removes": int(totals["removes"]), "collects": int(totals["collects"]),
-                "active_pools": row["active_pools"],
+                "window": name, "volume_usd": total("volume_usd") if priced_swaps else None,
+                "fees_usd": total("fees_usd") if priced_fees else None,
+                "swaps": int(total("swaps")), "adds": int(total("adds")),
+                "removes": int(total("removes")), "collects": int(total("collects")),
+                "active_pools": len(aggregates),
                 "active_owners": self.book.owner_count(name),
-                "net_deposits_usd": totals["deposit_usd"] - totals["withdrawal_usd"] if priced_flows else None,
-                "coverage": {**coverage, "priced_swaps": priced_swaps, "unpriced_swaps": int(totals["swaps"]) - priced_swaps,
-                             "priced_flows": priced_flows, "unpriced_flows": int(totals["flows"]) - priced_flows},
+                "net_deposits_usd": total("deposit_usd") - total("withdrawal_usd") if priced_flows else None,
+                "coverage": {**coverage, "priced_swaps": priced_swaps,
+                             "unpriced_swaps": int(total("swaps")) - priced_swaps,
+                             "priced_flows": priced_flows,
+                             "unpriced_flows": int(total("flows")) - priced_flows},
             }
         revision = int(status.get("revision") or 0)
         aggregate = self._cached(
@@ -1918,30 +1979,29 @@ class LPMarketService:
                 "sort must be fee, tvl, active_tvl, observed_active_tvl, volume, "
                 "fees, flow, swaps, adds, removes, lps, price, change or created"
             )
+        aggregate_fields = bucket_sort_fields.get(sort)
+        clause, bucket_args = self._bucket_clause(start, end)
         capital_sort = sort in {"active_tvl", "observed_active_tvl", "lps"}
         snapshot_revision = int(status.get("revision") or 0)
+        snapshot_events_revision = int(status.get("events_revision") or 0)
+        snapshot_pool_metadata_token = self.store.pool_metadata_token
         owner_revision = self.book.owners_revision
         metric_revision = (
-            snapshot_revision,
+            (
+                snapshot_events_revision, clause, *bucket_args
+            ) if aggregate_fields is not None else (
+                snapshot_revision, start, end
+            ),
             owner_revision if capital_sort else None,
-            start,
-            end,
+            snapshot_pool_metadata_token,
         )
         def load():
-            clause, args = self._bucket_clause(start, end)
             conn = self.store.read()
+            bucket_aggregates = (
+                self._bucket_aggregates(status, start, end)
+                if aggregate_fields is not None else None
+            )
             metric_ctes = []
-            metric_args: list[Any] = []
-            aggregate_fields = bucket_sort_fields.get(sort)
-            if aggregate_fields is not None:
-                sums = ",".join(
-                    f"SUM({field}) AS {field}" for field in aggregate_fields
-                )
-                metric_ctes.append(
-                    f"t AS (SELECT pool_id,{sums} FROM lp_pool_buckets "
-                    f"WHERE {clause} GROUP BY pool_id)"
-                )
-                metric_args.extend(args)
             if sort == "lps":
                 metric_ctes.append(
                     "a AS (SELECT pool_id,"
@@ -1971,24 +2031,55 @@ class LPMarketService:
                 "WITH " + ",".join(metric_ctes) + " " if metric_ctes else ""
             )
             metric_joins = (
-                "FROM pools p "
-                + ("LEFT JOIN t ON t.pool_id=p.id " if aggregate_fields is not None else "")
-                + "LEFT JOIN lp_pool_state s ON s.pool_id=p.id "
+                "FROM pools p LEFT JOIN lp_pool_state s ON s.pool_id=p.id "
                 + ("LEFT JOIN a ON a.pool_id=p.id " if capital_sort else "")
             )
             def metric_rows():
+                if bucket_aggregates is not None:
+                    def load_pool_ids():
+                        return tuple(sorted(
+                            str(row["id"])
+                            for row in conn.execute(
+                                f"SELECT p.id FROM pools p WHERE {where}", filters,
+                            ).fetchall()
+                        ))
+                    pool_ids = self._cached(
+                        (
+                            "pool-filter-base", snapshot_pool_metadata_token,
+                            where, *filters,
+                        ),
+                        load_pool_ids,
+                        ttl=float("inf"),
+                        epoch=int(status.get("epoch") or 0),
+                    )
+                    return [
+                        (
+                            pool_id,
+                            self._bucket_sort_value(
+                                sort, bucket_aggregates.get(pool_id),
+                            ),
+                        )
+                        for pool_id in pool_ids
+                    ]
                 return [
                     (str(row["id"]), row["sort_value"])
                     for row in conn.execute(
                         metric_prefix + f"SELECT p.id,{ordering_value} AS sort_value "
                         + metric_joins + f"WHERE {where}",
-                        [*metric_args, *ordering_args, *filters],
+                        [*ordering_args, *filters],
                     ).fetchall()
                 ]
-            metrics = self._cached(
-                ("pool-sort-base", metric_revision, name, where, *filters, sort),
-                metric_rows, ttl=float("inf"),
-                epoch=int(status.get("epoch") or 0),
+            metrics = (
+                metric_rows()
+                if bucket_aggregates is not None
+                else self._cached(
+                    (
+                        "pool-sort-base", metric_revision, name, where, *filters,
+                        sort,
+                    ),
+                    metric_rows, ttl=float("inf"),
+                    epoch=int(status.get("epoch") or 0),
+                )
             )
             valued = sorted(
                 ((pool_id, value) for pool_id, value in metrics if value is not None),
@@ -2001,26 +2092,36 @@ class LPMarketService:
             page_ids = ordered_ids[offset:offset + limit]
             if page_ids:
                 marks = ",".join("?" for _ in page_ids)
-                row_sums = ",".join(
-                    f"SUM({field}) AS {field}" for field in row_bucket_fields
-                )
-                page_totals = (
-                    f"WITH t AS (SELECT pool_id,{row_sums} FROM lp_pool_buckets "
-                    f"WHERE {clause} AND pool_id IN ({marks}) GROUP BY pool_id) "
-                )
-                page_joins = (
-                    "FROM pools p LEFT JOIN t ON t.pool_id=p.id "
-                    "LEFT JOIN lp_pool_state s ON s.pool_id=p.id "
-                )
-                raw_rows = conn.execute(
-                    page_totals
-                    + "SELECT p.*,s.price,s.price0_usd,s.price1_usd,"
-                    "s.timestamp AS last_event_at,s.liquidity AS active_liquidity,"
-                    "s.fee_ppm AS current_fee,"
-                    + ",".join(f"t.{field}" for field in row_bucket_fields)
-                    + " " + page_joins + f"WHERE p.id IN ({marks})",
-                    [*args, *page_ids, *page_ids],
-                ).fetchall()
+                if bucket_aggregates is not None:
+                    raw_rows = conn.execute(
+                        "SELECT p.*,s.price,s.price0_usd,s.price1_usd,"
+                        "s.timestamp AS last_event_at,"
+                        "s.liquidity AS active_liquidity,"
+                        "s.fee_ppm AS current_fee "
+                        "FROM pools p LEFT JOIN lp_pool_state s ON s.pool_id=p.id "
+                        f"WHERE p.id IN ({marks})",
+                        page_ids,
+                    ).fetchall()
+                else:
+                    row_sums = ",".join(
+                        f"SUM({field}) AS {field}" for field in row_bucket_fields
+                    )
+                    page_totals = (
+                        f"WITH t AS (SELECT pool_id,{row_sums} FROM lp_pool_buckets "
+                        f"WHERE {clause} AND pool_id IN ({marks}) GROUP BY pool_id) "
+                    )
+                    raw_rows = conn.execute(
+                        page_totals
+                        + "SELECT p.*,s.price,s.price0_usd,s.price1_usd,"
+                        "s.timestamp AS last_event_at,"
+                        "s.liquidity AS active_liquidity,"
+                        "s.fee_ppm AS current_fee,"
+                        + ",".join(f"t.{field}" for field in row_bucket_fields)
+                        + " FROM pools p LEFT JOIN t ON t.pool_id=p.id "
+                        "LEFT JOIN lp_pool_state s ON s.pool_id=p.id "
+                        f"WHERE p.id IN ({marks})",
+                        [*bucket_args, *page_ids, *page_ids],
+                    ).fetchall()
                 by_id = {str(row["id"]): row for row in raw_rows}
                 rows = [by_id[pool_id] for pool_id in page_ids if pool_id in by_id]
             else:
@@ -2035,8 +2136,16 @@ class LPMarketService:
             result = []
             for row in rows:
                 row = dict(row)
-                for field in row_bucket_fields:
-                    row[field] = row.get(field) or 0
+                if bucket_aggregates is not None:
+                    aggregate = bucket_aggregates.get(row["id"])
+                    for field in row_bucket_fields:
+                        row[field] = (
+                            aggregate[_BUCKET_INDEX[field]]
+                            if aggregate is not None else 0
+                        )
+                else:
+                    for field in row_bucket_fields:
+                        row[field] = row.get(field) or 0
                 stats = capital.get(row["id"], {})
                 risks = []
                 if not coverage["complete"]:
@@ -2134,8 +2243,8 @@ class LPMarketService:
             }
         return self._cached(
             (
-                "pools", snapshot_revision, owner_revision, name, where,
-                *filters, sort, order, limit, offset,
+                "pools", snapshot_revision, snapshot_pool_metadata_token,
+                owner_revision, name, where, *filters, sort, order, limit, offset,
             ),
             load, ttl=3.0, epoch=int(status.get("epoch") or 0),
         )
@@ -2408,10 +2517,11 @@ class LPMarketService:
                               "(e.kind='checkpoint' AND e.position_key IS NOT NULL))")
         elif kind != "all":
             raise ValueError("kind must be lp or all")
-        for key, column in (("pool", "e.pool_id"), ("owner", "COALESCE(e.owner,e.custody)")):
-            if params.get(key):
-                conditions.append(f"{column}=?")
-                args.append(str(params[key]).lower()[:66])
+        pool = str(params.get("pool") or "").lower()[:66]
+        if pool:
+            conditions.append("e.pool_id=?")
+            args.append(pool)
+        owner = str(params.get("owner") or "").lower()[:66]
         before = params.get("before")
         if before:
             # Cursor identifies a row, but chronological order is block/tx/log.
@@ -2425,14 +2535,17 @@ class LPMarketService:
         snapshot_events_revision = int(status.get("events_revision") or 0)
         snapshot_pool_metadata_token = self.store.pool_metadata_token
         snapshot_epoch = int(status.get("epoch") or 0)
-        # Only an exact pool predicate has an index that also satisfies the
-        # canonical feed order. Leading-wildcard search, protocol, and
-        # COALESCE(owner,custody) predicates do not. Letting SQLite choose an
-        # index for those predicates can sort every match before LIMIT.
+        # Canonical-order indexes let LIMIT stop before unrelated history.
+        # Owner/custody are separate because COALESCE(owner,custody) means
+        # custody participates only when owner is NULL.
         event_source = "events e INDEXED BY events_block_idx"
-        if params.get("pool"):
+        if owner:
+            event_source = None
+        elif pool:
             event_source = "events e INDEXED BY lp_events_pool_order"
-        cache_args = tuple(args)
+        elif kind == "lp":
+            event_source = "events e INDEXED BY events_lp_order_idx"
+        cache_args = (owner, *args)
         window_floor = None
         if start:
             # Event timestamps come from canonical block headers and increase
@@ -2455,13 +2568,42 @@ class LPMarketService:
                 args.append(window_floor)
 
         def load():
+            selected_columns = (
+                "e.id,e.block_number,e.tx_index,e.log_index "
+            )
+            selected_where = " AND ".join(conditions)
+            if owner:
+                selection = (
+                    "SELECT " + selected_columns
+                    + "FROM events e INDEXED BY events_owner_order_idx "
+                    "LEFT JOIN pools p ON p.id=e.pool_id WHERE "
+                    + selected_where + " AND e.owner=? UNION ALL "
+                    "SELECT " + selected_columns
+                    + "FROM events e INDEXED BY events_custody_order_idx "
+                    "LEFT JOIN pools p ON p.id=e.pool_id WHERE "
+                    + selected_where
+                    + " AND e.owner IS NULL AND e.custody=? "
+                    "ORDER BY block_number DESC,tx_index DESC,log_index DESC LIMIT ?"
+                )
+                query_args = [*args, owner, *args, owner, limit]
+            else:
+                selection = (
+                    "SELECT " + selected_columns + f"FROM {event_source} "
+                    "LEFT JOIN pools p ON p.id=e.pool_id WHERE "
+                    + selected_where
+                    + " ORDER BY e.block_number DESC,e.tx_index DESC,"
+                    "e.log_index DESC LIMIT ?"
+                )
+                query_args = [*args, limit]
             rows = self.store.read().execute(
-                "SELECT e.*,p.token0,p.token1,p.symbol0,p.symbol1,p.decimals0,p.decimals1,"
-                "p.protocol AS pool_protocol,p.fee_ppm AS pool_fee_raw "
-                f"FROM {event_source} LEFT JOIN pools p ON p.id=e.pool_id WHERE "
-                + " AND ".join(conditions)
-                + " ORDER BY e.block_number DESC,e.tx_index DESC,e.log_index DESC LIMIT ?",
-                [*args, limit],
+                "WITH selected AS MATERIALIZED (" + selection + ") "
+                "SELECT e.*,p.token0,p.token1,p.symbol0,p.symbol1,"
+                "p.decimals0,p.decimals1,p.protocol AS pool_protocol,"
+                "p.fee_ppm AS pool_fee_raw FROM selected s "
+                "JOIN events e ON e.id=s.id "
+                "LEFT JOIN pools p ON p.id=e.pool_id "
+                "ORDER BY s.block_number DESC,s.tx_index DESC,s.log_index DESC",
+                query_args,
             ).fetchall()
             output = []
             for raw in rows:

--- a/src/rhpools/lp_market_service.py
+++ b/src/rhpools/lp_market_service.py
@@ -1084,6 +1084,9 @@ class LPMarketService:
             history_disk_reserve_bytes=history_disk_reserve_bytes, v3_balances=True,
             current_observer=self,
             accounting_projector=self.book.project_pending if start else None,
+            accounting_recovery=(
+                self.book.recover_pending_identities if start else None
+            ),
         )
         # Restore the durable catalog before serving requests. Exact cold
         # inspectors can then reuse an already-qualified stored identity even

--- a/src/rhpools/lp_market_service.py
+++ b/src/rhpools/lp_market_service.py
@@ -2742,6 +2742,24 @@ class LPMarketService:
         }
 
 
+    def _materialize_owner_projection(
+            self, params: Mapping[str, Any],
+    ) -> tuple[tuple[int, int, int, int], float | None, dict[str, Any]]:
+        version, valid_until, envelope = self._owners_result(params)
+        view_key = self._owner_view_key(params)
+        with self._frame_lock:
+            self._owner_result_revision += 1
+            envelope = {**envelope, "revision": self._owner_result_revision}
+            ready = (version, valid_until, envelope)
+            self._owner_results[view_key] = ready
+            self._owner_results.move_to_end(view_key)
+            self._owner_last_started[view_key] = time.monotonic()
+            while len(self._owner_results) > 64:
+                stale_view, _ = self._owner_results.popitem(last=False)
+                if ("owners", stale_view) not in self._frame_futures:
+                    self._owner_last_started.pop(stale_view, None)
+        return ready
+
     def _owner_projection(
             self, raw_params: Mapping[str, Any], *, wait: bool,
     ) -> dict[str, Any] | None:
@@ -2757,29 +2775,17 @@ class LPMarketService:
             ] | None = None
             pending: Future | None = None
             delay = 0.0
+            leader = False
             failure: BaseException | None = None
             with self._frame_lock:
                 pending = self._frame_futures.get(future_key)
                 if pending is not None and pending.done():
                     self._frame_futures.pop(future_key, None)
                     try:
-                        version, valid_until, envelope = pending.result()
+                        ready = pending.result()
                     except BaseException as exc:
                         failure = exc
                     else:
-                        self._owner_result_revision += 1
-                        envelope = {
-                            **envelope,
-                            "revision": self._owner_result_revision,
-                        }
-                        ready = (version, valid_until, envelope)
-                        self._owner_results[view_key] = ready
-                        self._owner_results.move_to_end(view_key)
-                        self._owner_last_started[view_key] = time.monotonic()
-                        while len(self._owner_results) > 64:
-                            stale_view, _ = self._owner_results.popitem(last=False)
-                            if ("owners", stale_view) not in self._frame_futures:
-                                self._owner_last_started.pop(stale_view, None)
                         pending = None
                 if failure is None:
                     cached = self._owner_results.get(view_key)
@@ -2810,13 +2816,30 @@ class LPMarketService:
                         earliest = self._owner_last_started.get(view_key, 0.0) + 1.0
                         delay = max(0.0, earliest - now)
                         if delay == 0.0:
-                            pending = self._frame_executor.submit(
-                                self._owners_result, dict(params),
-                            )
+                            if wait and ready is None:
+                                pending = Future()
+                                leader = True
+                            else:
+                                pending = self._frame_executor.submit(
+                                    self._materialize_owner_projection, dict(params),
+                                )
                             self._frame_futures[future_key] = pending
                             self._owner_last_started[view_key] = now
             if failure is not None:
                 raise failure
+            if leader:
+                assert pending is not None
+                try:
+                    pending.set_result(self._materialize_owner_projection(params))
+                except BaseException as exc:
+                    pending.set_exception(exc)
+            if ready is None and wait and pending is not None:
+                try:
+                    ready = pending.result()
+                finally:
+                    with self._frame_lock:
+                        if self._frame_futures.get(future_key) is pending:
+                            self._frame_futures.pop(future_key, None)
             if ready is not None:
                 version, _valid_until, envelope = ready
                 # Continuous appends cannot starve completed, qualified snapshots.
@@ -2832,15 +2855,6 @@ class LPMarketService:
                 return fresh
             if not wait:
                 return None
-            if pending is not None:
-                try:
-                    pending.result()
-                except BaseException:
-                    with self._frame_lock:
-                        if self._frame_futures.get(future_key) is pending:
-                            self._frame_futures.pop(future_key, None)
-                    raise
-                continue
             if delay:
                 time.sleep(delay)
 

--- a/src/rhpools/lp_market_service.py
+++ b/src/rhpools/lp_market_service.py
@@ -2786,17 +2786,27 @@ class LPMarketService:
                     if ready is None and cached is not None:
                         version, valid_until, envelope = cached
                         if (
-                            version == target
+                            version[2:] == target[2:]
                             and (
-                                valid_until is None
-                                or wall_now < valid_until
+                                not wait
+                                or (
+                                    version == target
+                                    and (
+                                        valid_until is None
+                                        or wall_now < valid_until
+                                    )
+                                )
                             )
                         ):
                             self._owner_results.move_to_end(view_key)
                             ready = cached
                         else:
                             ready = None
-                    if ready is None and pending is None:
+                    needs_refresh = (
+                        ready is None or ready[0] != target
+                        or (ready[1] is not None and wall_now >= ready[1])
+                    )
+                    if needs_refresh and pending is None:
                         earliest = self._owner_last_started.get(view_key, 0.0) + 1.0
                         delay = max(0.0, earliest - now)
                         if delay == 0.0:

--- a/src/rhpools/lp_market_service.py
+++ b/src/rhpools/lp_market_service.py
@@ -1061,6 +1061,7 @@ class LPMarketService:
         from .lp_market_store import MarketStore
         from .lp_market_index import MarketIndexer
         from .lp_market_accounting import AccountBook
+        from .lp_market_claims import PositionClaims
         self.market = market
         self.store = MarketStore(path, checkpoint_on_commit=not start)
         self.prices = PriceProjection(self.store)
@@ -1087,6 +1088,9 @@ class LPMarketService:
             accounting_recovery=(
                 self.book.recover_pending_identities if start else None
             ),
+        )
+        self.claims = PositionClaims(
+            self.store, self.book, self.prices, self.indexer._worker_rpc,
         )
         # Restore the durable catalog before serving requests. Exact cold
         # inspectors can then reuse an already-qualified stored identity even
@@ -1131,6 +1135,7 @@ class LPMarketService:
         ] = [None] * 1024
         if start:
             self.indexer.start(deferred=deferred_start)
+            self.claims.start()
             self._search_thread = threading.Thread(
                 target=self._search_index_run,
                 name="lp-market-search-index",
@@ -1633,6 +1638,7 @@ class LPMarketService:
         self._search_stop.set()
         if self._search_thread is not None:
             self._search_thread.join()
+        self.claims.close()
         self.indexer.close()
         self._frame_executor.shutdown(wait=True, cancel_futures=True)
         self.store.close()
@@ -1665,6 +1671,7 @@ class LPMarketService:
         out["as_of"] = time.time()
         providers = self.indexer.source_status()
         out["providers"] = providers
+        out["current_claims"] = self.claims.status()
         trace = providers.get("trace") or {}
         out["source_coverage"] = {
             "head": "independent newHeads subscription with bounded public-RPC gap reconciliation",
@@ -2852,6 +2859,9 @@ class LPMarketService:
                         return None
                     continue
                 fresh = self._fresh_owner_envelope(envelope)
+                self.claims.request([
+                    row["owner"] for row in fresh.get("rows", ()) if row.get("owner")
+                ])
                 return fresh
             if not wait:
                 return None
@@ -2896,6 +2906,7 @@ class LPMarketService:
             int(owner[2:], 16)
         except ValueError as exc:
             raise ValueError("owner must be a hexadecimal address") from exc
+        self.claims.request([owner], priority=True)
         return self._cached(
             ("owner", *sorted(params.items())),
             lambda: self.book.owner(owner, params), ttl=5.0,

--- a/src/rhpools/lp_market_service.py
+++ b/src/rhpools/lp_market_service.py
@@ -1066,7 +1066,9 @@ class LPMarketService:
         self.market = market
         self.store = MarketStore(path, checkpoint_on_commit=not start)
         self.prices = PriceProjection(self.store)
-        self.book = AccountBook(self.store, deferred=start)
+        self.book = AccountBook(
+            self.store, deferred=start, preparation_workers=2 if start else 0,
+        )
         self.book.install()
         self._current_activity_lock = threading.RLock()
         self._current_activity_headers: OrderedDict[int, dict[str, Any]] = OrderedDict()
@@ -1641,6 +1643,7 @@ class LPMarketService:
             self._search_thread.join()
         self.claims.close()
         self.indexer.close()
+        self.book.close()
         self._frame_executor.shutdown(wait=True, cancel_futures=True)
         self.store.close()
 

--- a/src/rhpools/lp_market_store.py
+++ b/src/rhpools/lp_market_store.py
@@ -2333,77 +2333,173 @@ class MarketStore:
 
     def prioritize_enrichment(self, tx_hashes: Iterable[str]) -> None:
         """Prefer requested financial evidence without writing from a reader."""
+        requested: dict[str, None] = {}
+        for value in islice(tx_hashes, 256):
+            tx_hash = str(value).strip().lower()
+            if not tx_hash:
+                continue
+            requested.pop(tx_hash, None)
+            requested[tx_hash] = None
+        if not requested:
+            return
         expires = time.monotonic() + 180.0
         with self._financial_interest_lock:
-            for tx_hash in islice(tx_hashes, 256):
-                self._financial_interest[str(tx_hash).lower()] = expires
+            for tx_hash in requested:
+                self._financial_interest.pop(tx_hash, None)
+                self._financial_interest[tx_hash] = expires
             while len(self._financial_interest) > 2048:
                 self._financial_interest.pop(next(iter(self._financial_interest)))
 
-    def pending_enrichments(
-        self, limit: int = 16, *, now: float | None = None,
+    def requested_enrichments(
+        self,
+        limit: int,
+        *,
+        identity: bool = False,
+        now: float | None = None,
+        exclude: Iterable[str] = (),
     ) -> list[dict[str, Any]]:
-        # Reserve historical progress without making current financials wait
-        # for the entire backfill. Identity discovery has its own worker.
+        """Return the newest requested work eligible for one enrichment lane."""
         limit = max(1, min(int(limit), 256))
-        historical = max(1, limit // 4)
         due = time.time() if now is None else now
+        excluded = {
+            str(value).strip().lower() for value in exclude if str(value).strip()
+        }
         with self._financial_interest_lock:
             current = time.monotonic()
             expired = [
-                key for key, expires in self._financial_interest.items()
-                if expires <= current
+                key for key, expires_at in self._financial_interest.items()
+                if expires_at <= current
             ]
             for key in expired:
-                self._financial_interest.pop(key)
+                self._financial_interest.pop(key, None)
             interests = dict(self._financial_interest)
-        preferred = {}
-        for batch in _batches(tuple(interests)):
+
+        selected: list[dict[str, Any]] = []
+        missing_interests: dict[str, float] = {}
+        for batch in _batches(tuple(reversed(interests)), size=32):
             marks = ",".join("?" for _ in batch)
-            preferred.update({
-                str(row["tx_hash"]): dict(row)
+            found = {
+                str(row["tx_hash"]).lower(): dict(row)
                 for row in self.read().execute(
                     f"SELECT * FROM pending_enrichment WHERE tx_hash IN ({marks})",
                     batch,
                 ).fetchall()
-            })
-        with self._financial_interest_lock:
-            for key, expires in interests.items():
-                if key not in preferred and self._financial_interest.get(key) == expires:
-                    self._financial_interest.pop(key, None)
-        requested = [
-            preferred[key] for key in interests
-            if key in preferred and preferred[key]["next_attempt"] <= due
-            and not str(preferred[key]["last_error"] or "").startswith(
-                "pool_identity_pending:"
-            )
-        ][:min(historical, limit - historical)]
-        rows = self.read().execute(
-            "WITH oldest AS ("
-            "SELECT block_number,tx_hash FROM pending_enrichment "
-            "INDEXED BY pending_enrichment_financial_order_idx "
-            "WHERE next_attempt<=? AND (last_error IS NULL "
-            "OR last_error NOT GLOB 'pool_identity_pending:*') "
-            "ORDER BY block_number,tx_hash LIMIT ?"
-            "),newest AS ("
-            "SELECT block_number,tx_hash FROM pending_enrichment "
-            "INDEXED BY pending_enrichment_financial_order_idx "
-            "WHERE next_attempt<=? AND (last_error IS NULL "
-            "OR last_error NOT GLOB 'pool_identity_pending:*') "
-            "ORDER BY block_number DESC,tx_hash DESC LIMIT ?"
-            "),selected AS (SELECT * FROM oldest UNION SELECT * FROM newest) "
-            "SELECT p.* FROM selected s JOIN pending_enrichment p "
-            "ON p.tx_hash=s.tx_hash ORDER BY s.block_number,s.tx_hash",
-            (due, historical, due, limit - historical),
-        ).fetchall()
-        # Keep the historical quota; requested wallets borrow recent slots.
-        selected = {}
-        for row in [*rows[:historical], *requested, *reversed(rows[historical:])]:
-            selected.setdefault(str(row["tx_hash"]), dict(row))
+            }
+            for tx_hash in batch:
+                if tx_hash not in found:
+                    missing_interests[tx_hash] = interests[tx_hash]
+            for tx_hash in batch:
+                row = found.get(tx_hash)
+                if row is None or tx_hash in excluded or row["next_attempt"] > due:
+                    continue
+                identity_pending = str(row["last_error"] or "").startswith(
+                    "pool_identity_pending:"
+                )
+                if identity_pending != identity:
+                    continue
+                selected.append(row)
+                if len(selected) == limit:
+                    break
             if len(selected) == limit:
                 break
+        if missing_interests:
+            with self._financial_interest_lock:
+                for tx_hash, expires_at in missing_interests.items():
+                    if self._financial_interest.get(tx_hash) == expires_at:
+                        self._financial_interest.pop(tx_hash, None)
+        return selected
+
+    def pending_enrichments(
+        self,
+        limit: int = 16,
+        *,
+        now: float | None = None,
+        exclude: Iterable[str] = (),
+        prioritized: bool = False,
+    ) -> list[dict[str, Any]]:
+        # Reserve historical progress without making current financials wait
+        # for the entire backfill. Identity discovery has its own worker.
+        limit = max(1, min(int(limit), 256))
+        historical_capacity = max(1, limit // 4)
+        requested_capacity = min(
+            max(0, limit - historical_capacity), max(1, limit // 4),
+        )
+        due = time.time() if now is None else now
+        excluded = tuple({
+            str(value).strip().lower() for value in exclude if str(value).strip()
+        })
+        excluded_set = set(excluded)
+        excluded_sql = ""
+        if excluded:
+            excluded_sql = (
+                f" AND tx_hash NOT IN ({','.join('?' for _ in excluded)})"
+            )
+        eligible_sql = (
+            "next_attempt<=? AND (last_error IS NULL "
+            "OR last_error NOT GLOB 'pool_identity_pending:*')"
+        )
+        connection = self.read()
+        historical_rows = [
+            dict(row) for row in connection.execute(
+                "SELECT * FROM pending_enrichment "
+                "INDEXED BY pending_enrichment_financial_order_idx "
+                f"WHERE {eligible_sql}{excluded_sql} "
+                "ORDER BY block_number,tx_hash LIMIT ?",
+                (due, *excluded, historical_capacity),
+            ).fetchall()
+        ]
+        selected_hashes = {
+            str(row["tx_hash"]).lower() for row in historical_rows
+        }
+
+        requested_rows = (
+            self.requested_enrichments(
+                requested_capacity,
+                now=due,
+                exclude=excluded_set | selected_hashes,
+            )
+            if requested_capacity
+            else []
+        )
+        selected_hashes.update(
+            str(row["tx_hash"]).lower() for row in requested_rows
+        )
+
+        recent_capacity = limit - len(historical_rows) - len(requested_rows)
+        recent_rows: list[dict[str, Any]] = []
+        if recent_capacity:
+            recent_excluded = tuple(excluded_set | selected_hashes)
+            recent_excluded_sql = ""
+            if recent_excluded:
+                recent_excluded_sql = (
+                    " AND tx_hash NOT IN "
+                    f"({','.join('?' for _ in recent_excluded)})"
+                )
+            recent_rows = [
+                dict(row) for row in connection.execute(
+                    "SELECT * FROM pending_enrichment "
+                    "INDEXED BY pending_enrichment_financial_order_idx "
+                    f"WHERE {eligible_sql}{recent_excluded_sql} "
+                    "ORDER BY block_number DESC,tx_hash DESC LIMIT ?",
+                    (due, *recent_excluded, recent_capacity),
+                ).fetchall()
+            ]
+
+        buckets = (
+            ("historical", historical_rows),
+            ("requested", requested_rows),
+            ("recent", recent_rows),
+        )
+        if prioritized:
+            selected: list[dict[str, Any]] = []
+            for priority, rows in buckets:
+                for row in rows:
+                    row["_enrichment_priority"] = priority
+                    selected.append(row)
+            return selected
         return sorted(
-            selected.values(), key=lambda row: (row["block_number"], row["tx_hash"]),
+            (row for _priority, rows in buckets for row in rows),
+            key=lambda row: (row["block_number"], row["tx_hash"]),
         )
 
     def pending_token_metadata(self, limit: int = 16) -> list[dict[str, Any]]:

--- a/src/rhpools/lp_market_store.py
+++ b/src/rhpools/lp_market_store.py
@@ -2370,6 +2370,8 @@ class MarketStore:
                 removed = connection.total_changes - before
                 if removed:
                     self._bump(connection, "pending_enrichment", -removed)
+            for event in enriched:
+                event.pop("_transaction_source", None)
             return enriched
 
     def prioritize_enrichment(self, tx_hashes: Iterable[str]) -> None:

--- a/src/rhpools/lp_market_store.py
+++ b/src/rhpools/lp_market_store.py
@@ -191,6 +191,8 @@ class MarketStore:
         self._closed = False
         self._change_token = 0
         self._pool_metadata_token = 0
+        self._financial_interest_lock = threading.Lock()
+        self._financial_interest: dict[str, float] = {}
         self._checkpoint_on_commit = checkpoint_on_commit
         if str(path) == ":memory:":
             self._database = f"file:lp-market-{id(self):x}?mode=memory&cache=shared"
@@ -2324,6 +2326,15 @@ class MarketStore:
                     self._bump(connection, "pending_enrichment", -removed)
             return enriched
 
+    def prioritize_enrichment(self, tx_hashes: Iterable[str]) -> None:
+        """Prefer requested financial evidence without writing from a reader."""
+        expires = time.monotonic() + 180.0
+        with self._financial_interest_lock:
+            for tx_hash in islice(tx_hashes, 256):
+                self._financial_interest[str(tx_hash).lower()] = expires
+            while len(self._financial_interest) > 2048:
+                self._financial_interest.pop(next(iter(self._financial_interest)))
+
     def pending_enrichments(
         self, limit: int = 16, *, now: float | None = None,
     ) -> list[dict[str, Any]]:
@@ -2332,6 +2343,36 @@ class MarketStore:
         limit = max(1, min(int(limit), 256))
         historical = max(1, limit // 4)
         due = time.time() if now is None else now
+        with self._financial_interest_lock:
+            current = time.monotonic()
+            expired = [
+                key for key, expires in self._financial_interest.items()
+                if expires <= current
+            ]
+            for key in expired:
+                self._financial_interest.pop(key)
+            interests = dict(self._financial_interest)
+        preferred = {}
+        for batch in _batches(tuple(interests)):
+            marks = ",".join("?" for _ in batch)
+            preferred.update({
+                str(row["tx_hash"]): dict(row)
+                for row in self.read().execute(
+                    f"SELECT * FROM pending_enrichment WHERE tx_hash IN ({marks})",
+                    batch,
+                ).fetchall()
+            })
+        with self._financial_interest_lock:
+            for key, expires in interests.items():
+                if key not in preferred and self._financial_interest.get(key) == expires:
+                    self._financial_interest.pop(key, None)
+        requested = [
+            preferred[key] for key in interests
+            if key in preferred and preferred[key]["next_attempt"] <= due
+            and not str(preferred[key]["last_error"] or "").startswith(
+                "pool_identity_pending:"
+            )
+        ][:min(historical, limit - historical)]
         rows = self.read().execute(
             "WITH oldest AS ("
             "SELECT block_number,tx_hash FROM pending_enrichment "
@@ -2350,7 +2391,15 @@ class MarketStore:
             "ON p.tx_hash=s.tx_hash ORDER BY s.block_number,s.tx_hash",
             (due, historical, due, limit - historical),
         ).fetchall()
-        return [dict(row) for row in rows]
+        # Keep the historical quota; requested wallets borrow recent slots.
+        selected = {}
+        for row in [*rows[:historical], *requested, *reversed(rows[historical:])]:
+            selected.setdefault(str(row["tx_hash"]), dict(row))
+            if len(selected) == limit:
+                break
+        return sorted(
+            selected.values(), key=lambda row: (row["block_number"], row["tx_hash"]),
+        )
 
     def pending_token_metadata(self, limit: int = 16) -> list[dict[str, Any]]:
         rows = self.read().execute(
@@ -2472,6 +2521,10 @@ class MarketStore:
                 "ORDER BY block_number,tx_index,log_index,id",
                 values,
             ).fetchall()
+            search_before = {
+                int(row["id"]): tuple(self._event_search_entities(dict(row)))
+                for row in rows
+            }
             revision = self._next_revision(connection)
             events = [dict(row) for row in rows]
             for event in events:
@@ -2479,8 +2532,12 @@ class MarketStore:
                 event["revision"] = revision
             search_rows: list[dict[str, Any]] = []
             if events:
-                search_rows = self._persist_projection_mutations(
-                    connection, events, revision,
+                # Repricing changes no canonical input before projections run.
+                # Rewriting the whole row here also rewrites every event index.
+                self._set_metadata(connection, "events_revision", revision)
+                connection.execute(
+                    f"UPDATE events SET revision=? WHERE id IN ({placeholders})",
+                    (revision, *values),
                 )
                 for apply, _rollback, _persists_events in self._projections:
                     apply(connection, events)
@@ -2490,7 +2547,11 @@ class MarketStore:
                     )
                 else:
                     search_rows = [self._event_row(event, revision) for event in events]
-            self._index_event_search_batch(connection, search_rows)
+            self._index_event_search_batch(connection, (
+                row for event, row in zip(events, search_rows)
+                if tuple(self._event_search_entities(row))
+                != search_before[int(event["id"])]
+            ))
             removed = connection.execute(
                 f"DELETE FROM pending_reprojection WHERE event_id IN ({placeholders})",
                 values,

--- a/src/rhpools/lp_market_store.py
+++ b/src/rhpools/lp_market_store.py
@@ -253,6 +253,11 @@ class MarketStore:
                 "ALTER TABLE lp_accounting_pending ADD COLUMN "
                 "append_only INTEGER NOT NULL DEFAULT 0"
             )
+        if "cost_only" not in pending_columns:
+            connection.execute(
+                "ALTER TABLE lp_accounting_pending ADD COLUMN "
+                "cost_only INTEGER NOT NULL DEFAULT 0"
+            )
         if "identities_ready" not in pending_columns:
             connection.execute(
                 "ALTER TABLE lp_accounting_pending ADD COLUMN "
@@ -2315,6 +2320,9 @@ class MarketStore:
                         current.get("data"), current.get("data"),
                     )
                     current["revision"] = revision
+                    # Projection callbacks can refresh transaction-dependent
+                    # state without replaying an otherwise unchanged event.
+                    current["_transaction_only"] = True
                     enriched.append(current)
                     represented_ids.add(int(current["id"]))
             enriched.sort(key=lambda event: (

--- a/src/rhpools/lp_market_store.py
+++ b/src/rhpools/lp_market_store.py
@@ -231,6 +231,45 @@ class MarketStore:
             connection.execute("PRAGMA query_only=ON")
         return connection
 
+    @staticmethod
+    def _install_accounting_pending_identities(
+        connection: sqlite3.Connection,
+    ) -> None:
+        pending_columns = {
+            str(row["name"])
+            for row in connection.execute(
+                "PRAGMA table_info(lp_accounting_pending)"
+            ).fetchall()
+        }
+        if "identities_ready" not in pending_columns:
+            connection.execute(
+                "ALTER TABLE lp_accounting_pending ADD COLUMN "
+                "identities_ready INTEGER NOT NULL DEFAULT 0"
+            )
+        if "identity_cursor" not in pending_columns:
+            connection.execute(
+                "ALTER TABLE lp_accounting_pending ADD COLUMN "
+                "identity_cursor INTEGER NOT NULL DEFAULT 0"
+            )
+        connection.execute(
+            "CREATE INDEX IF NOT EXISTS "
+            "lp_accounting_pending_identity_bootstrap "
+            "ON lp_accounting_pending(id) WHERE identities_ready=0"
+        )
+        connection.execute(
+            "CREATE TABLE IF NOT EXISTS lp_accounting_pending_identities("
+            "position_key TEXT NOT NULL "
+            "REFERENCES lp_accounting_pending(position_key) ON DELETE CASCADE,"
+            "kind TEXT NOT NULL,"
+            "identity TEXT NOT NULL,"
+            "protocol TEXT NOT NULL,"
+            "pool_id TEXT NOT NULL,"
+            "timestamp INTEGER NOT NULL,"
+            "PRIMARY KEY(position_key,kind,identity,protocol,pool_id)"
+            ") WITHOUT ROWID"
+        )
+
+
     def _initialize(self) -> None:
         schema = """
         CREATE TABLE IF NOT EXISTS pools(
@@ -505,6 +544,14 @@ class MarketStore:
                         "generation INTEGER NOT NULL DEFAULT 0"
                     )
                 self.connection.execute("PRAGMA user_version=8")
+            if int(self.connection.execute("PRAGMA user_version").fetchone()[0]) < 9:
+                accounting_pending_installed = self.connection.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='lp_accounting_pending'"
+                ).fetchone() is not None
+                if accounting_pending_installed:
+                    self._install_accounting_pending_identities(self.connection)
+                self.connection.execute("PRAGMA user_version=9")
             self.connection.execute(
                 "CREATE INDEX IF NOT EXISTS pending_reprojection_order_idx "
                 "ON pending_reprojection(block_number,tx_index,log_index,event_id)"

--- a/src/rhpools/lp_market_store.py
+++ b/src/rhpools/lp_market_store.py
@@ -13,6 +13,8 @@ from itertools import chain, islice
 from pathlib import Path
 from typing import Any
 
+from .lp_market_protocols import core_position_key
+
 
 ProjectionApply = Callable[[sqlite3.Connection, list[dict[str, Any]]], None]
 ProjectionRollback = Callable[[sqlite3.Connection, int], None]
@@ -62,6 +64,9 @@ SEARCH_KINDS = frozenset({
     "pool", "token", "protocol", "owner", "custody", "transaction", "position",
 })
 _SEARCH_WORD_RE = re.compile(r"[a-z0-9]+")
+_CORE_POSITION_REPAIR_CHECKPOINT = "core_position_key_source_repair_v1"
+_CORE_POSITION_KEY_START = "0x"
+_CORE_POSITION_KEY_END = "0y"
 
 
 class MarketStoreError(RuntimeError):
@@ -2559,6 +2564,115 @@ class MarketStore:
             if removed:
                 self._bump(connection, "pending_reprojection", -removed)
             return events
+
+    def repair_legacy_core_position_keys(self, *, limit: int = 128) -> bool:
+        """Qualify one bounded chronological page of legacy V3/V4 core rows."""
+        repair_limit = max(1, min(int(limit), 512))
+        eligible = (
+            "position_key=? AND protocol IN ('v3','v4') "
+            "AND pool_id IS NOT NULL AND TRIM(pool_id)<>''"
+        )
+        with self.transaction() as connection:
+            checkpoint = self._metadata(
+                connection, _CORE_POSITION_REPAIR_CHECKPOINT, {},
+            )
+            after = str(
+                checkpoint.get("after_position_key", _CORE_POSITION_KEY_START)
+            ).lower()
+            if after < _CORE_POSITION_KEY_START or after >= _CORE_POSITION_KEY_END:
+                after = _CORE_POSITION_KEY_START
+            events_revision = int(self._metadata(connection, "events_revision", 0))
+            if (
+                checkpoint
+                and after == _CORE_POSITION_KEY_START
+                and int(checkpoint.get("exhausted_revision", -1)) == events_revision
+            ):
+                return False
+            selected = connection.execute(
+                "SELECT position_key FROM events "
+                "INDEXED BY events_position_order_idx "
+                "WHERE position_key>? AND position_key<? "
+                "AND LENGTH(position_key)=66 "
+                "AND SUBSTR(position_key,3) NOT GLOB '*[^0-9a-f]*' "
+                "AND protocol IN ('v3','v4') "
+                "AND pool_id IS NOT NULL AND TRIM(pool_id)<>'' "
+                "ORDER BY position_key,block_number,tx_index,log_index LIMIT 1",
+                (after, _CORE_POSITION_KEY_END),
+            ).fetchone()
+            if selected is None:
+                reset = after != _CORE_POSITION_KEY_START
+                self._set_metadata(connection, _CORE_POSITION_REPAIR_CHECKPOINT, {
+                    "after_position_key": _CORE_POSITION_KEY_START,
+                    "cycles": (
+                        int(checkpoint.get("cycles", 0))
+                        + int(reset or not checkpoint)
+                    ),
+                    "completed_keys": int(checkpoint.get("completed_keys", 0)),
+                    "repaired_events": int(checkpoint.get("repaired_events", 0)),
+                    "repaired_pages": int(checkpoint.get("repaired_pages", 0)),
+                    **({} if reset else {"exhausted_revision": events_revision}),
+                })
+                return reset
+
+            legacy_key = str(selected["position_key"])
+            rows = connection.execute(
+                "SELECT * FROM events INDEXED BY events_position_order_idx "
+                f"WHERE {eligible} "
+                "ORDER BY block_number,tx_index,log_index LIMIT ?",
+                (legacy_key, repair_limit),
+            ).fetchall()
+            events = [dict(row) for row in rows]
+            revision = self._next_revision(connection)
+            for event in events:
+                event["data"] = _decode_json(event.get("data"), event.get("data"))
+                event["position_key"] = core_position_key(
+                    str(event["protocol"]),
+                    str(event["pool_id"]),
+                    legacy_key,
+                )
+                event["revision"] = revision
+            self._set_metadata(connection, "events_revision", revision)
+            connection.executemany(
+                "UPDATE events SET position_key=?,revision=? WHERE id=?",
+                ((event["position_key"], revision, int(event["id"])) for event in events),
+            )
+            for apply, _rollback, _persists_events in self._projections:
+                apply(connection, events)
+            if any(not item[2] for item in self._projections):
+                search_rows = self._persist_projection_mutations(
+                    connection, events, revision,
+                )
+            else:
+                search_rows = [
+                    self._event_row(event, revision) for event in events
+                ]
+            self._index_event_search_batch(connection, search_rows)
+            if connection.execute(
+                "SELECT 1 FROM events INDEXED BY events_position_order_idx "
+                "WHERE position_key=? LIMIT 1",
+                (legacy_key,),
+            ).fetchone() is None:
+                connection.execute(
+                    "DELETE FROM lp_search_entities WHERE kind='position' AND id=?",
+                    (legacy_key,),
+                )
+            key_complete = connection.execute(
+                "SELECT 1 FROM events INDEXED BY events_position_order_idx "
+                f"WHERE {eligible} LIMIT 1",
+                (legacy_key,),
+            ).fetchone() is None
+            self._set_metadata(connection, _CORE_POSITION_REPAIR_CHECKPOINT, {
+                "after_position_key": legacy_key if key_complete else after,
+                "cycles": int(checkpoint.get("cycles", 0)),
+                "completed_keys": (
+                    int(checkpoint.get("completed_keys", 0)) + int(key_complete)
+                ),
+                "repaired_events": (
+                    int(checkpoint.get("repaired_events", 0)) + len(events)
+                ),
+                "repaired_pages": int(checkpoint.get("repaired_pages", 0)) + 1,
+            })
+            return True
 
     def repair_v3_birth_history(
         self, prefixes: Sequence[str], *, limit: int = 32,

--- a/src/rhpools/lp_market_store.py
+++ b/src/rhpools/lp_market_store.py
@@ -248,6 +248,11 @@ class MarketStore:
                 "PRAGMA table_info(lp_accounting_pending)"
             ).fetchall()
         }
+        if "append_only" not in pending_columns:
+            connection.execute(
+                "ALTER TABLE lp_accounting_pending ADD COLUMN "
+                "append_only INTEGER NOT NULL DEFAULT 0"
+            )
         if "identities_ready" not in pending_columns:
             connection.execute(
                 "ALTER TABLE lp_accounting_pending ADD COLUMN "
@@ -571,6 +576,14 @@ class MarketStore:
                 self.connection.execute("PRAGMA user_version=9")
             if int(self.connection.execute("PRAGMA user_version").fetchone()[0]) < 10:
                 self.connection.execute("PRAGMA user_version=10")
+            if int(self.connection.execute("PRAGMA user_version").fetchone()[0]) < 11:
+                accounting_pending_installed = self.connection.execute(
+                    "SELECT 1 FROM sqlite_master "
+                    "WHERE type='table' AND name='lp_accounting_pending'"
+                ).fetchone() is not None
+                if accounting_pending_installed:
+                    self._install_accounting_pending_identities(self.connection)
+                self.connection.execute("PRAGMA user_version=11")
             self.connection.execute(
                 "CREATE INDEX IF NOT EXISTS pending_reprojection_order_idx "
                 "ON pending_reprojection(block_number,tx_index,log_index,event_id)"

--- a/src/rhpools/lp_market_store.py
+++ b/src/rhpools/lp_market_store.py
@@ -1797,7 +1797,7 @@ class MarketStore:
 
     @staticmethod
     def _event_data(event: Mapping[str, Any]) -> str | None:
-        known = set(EVENT_COLUMNS) | {"id", "pool"}
+        known = set(EVENT_COLUMNS) | {"id", "pool", "_transaction_source"}
         supplied = event.get("data")
         if isinstance(supplied, str):
             decoded = _decode_json(supplied, supplied)
@@ -2296,6 +2296,12 @@ class MarketStore:
                     result = connection.execute(insert_sql, tuple(row[column] for column in EVENT_COLUMNS))
                     merged["id"] = result.lastrowid
                     inserted += 1
+                if (
+                    current is not None
+                    and row["tx_hash"] in receipts
+                    and row == self._event_row(current, revision)
+                ):
+                    merged["_transaction_source"] = row
                 merged["revision"] = revision
                 enriched.append(merged)
             if inserted:
@@ -2320,9 +2326,11 @@ class MarketStore:
                         current.get("data"), current.get("data"),
                     )
                     current["revision"] = revision
-                    # Projection callbacks can refresh transaction-dependent
-                    # state without replaying an otherwise unchanged event.
-                    current["_transaction_only"] = True
+                    # Accounting must recheck this source after preceding
+                    # projections: receipt publication can also reprice it.
+                    current["_transaction_source"] = self._event_row(
+                        current, revision,
+                    )
                     enriched.append(current)
                     represented_ids.add(int(current["id"]))
             enriched.sort(key=lambda event: (

--- a/src/rhpools/lp_market_store.py
+++ b/src/rhpools/lp_market_store.py
@@ -303,7 +303,8 @@ class MarketStore:
             tx_hash TEXT PRIMARY KEY, block_number INTEGER NOT NULL,
             block_hash TEXT NOT NULL, attempts INTEGER NOT NULL DEFAULT 0,
             next_attempt REAL NOT NULL DEFAULT 0, last_error TEXT,
-            created_at REAL NOT NULL, updated_at REAL NOT NULL
+            created_at REAL NOT NULL, updated_at REAL NOT NULL,
+            generation INTEGER NOT NULL DEFAULT 0
         );
         CREATE INDEX IF NOT EXISTS pending_enrichment_ready_idx
             ON pending_enrichment(next_attempt, block_number, tx_hash);
@@ -491,6 +492,19 @@ class MarketStore:
                     "OR last_error NOT GLOB 'pool_identity_pending:*'"
                 )
                 self.connection.execute("PRAGMA user_version=7")
+            if int(self.connection.execute("PRAGMA user_version").fetchone()[0]) < 8:
+                enrichment_columns = {
+                    str(row["name"])
+                    for row in self.connection.execute(
+                        "PRAGMA table_info(pending_enrichment)"
+                    ).fetchall()
+                }
+                if "generation" not in enrichment_columns:
+                    self.connection.execute(
+                        "ALTER TABLE pending_enrichment ADD COLUMN "
+                        "generation INTEGER NOT NULL DEFAULT 0"
+                    )
+                self.connection.execute("PRAGMA user_version=8")
             self.connection.execute(
                 "CREATE INDEX IF NOT EXISTS pending_reprojection_order_idx "
                 "ON pending_reprojection(block_number,tx_index,log_index,event_id)"
@@ -551,7 +565,9 @@ class MarketStore:
                     "pending_pool_unpublish": "pending_pool_unpublish",
                     "pending_reprojection": "pending_reprojection",
                 }
-                default_keys = ("revision", "epoch", *count_tables)
+                default_keys = (
+                    "revision", "epoch", "pending_accounting", *count_tables,
+                )
                 marks = ",".join("?" for _ in default_keys)
                 existing = {
                     str(row[0]) for row in connection.execute(
@@ -560,7 +576,9 @@ class MarketStore:
                     ).fetchall()
                 }
                 defaults = {
-                    key: 0 for key in ("revision", "epoch")
+                    key: 0 for key in (
+                        "revision", "epoch", "pending_accounting",
+                    )
                     if key not in existing
                 }
                 for key, table in count_tables.items():
@@ -2539,9 +2557,13 @@ class MarketStore:
     def mark_enrichment_error(self, tx_hash: str, error: str, *, delay: float) -> None:
         with self.transaction() as connection:
             connection.execute(
-                "UPDATE pending_enrichment SET attempts=attempts+1,next_attempt=?,last_error=?,updated_at=? "
-                "WHERE tx_hash=?",
-                (time.time() + max(0.0, delay), str(error)[:1000], time.time(), tx_hash.lower()),
+                "UPDATE pending_enrichment SET attempts=attempts+1,"
+                "next_attempt=?,last_error=?,updated_at=?,"
+                "generation=generation+1 WHERE tx_hash=?",
+                (
+                    time.time() + max(0.0, delay), str(error)[:1000],
+                    time.time(), tx_hash.lower(),
+                ),
             )
 
     def queue_v3_balances(
@@ -2941,6 +2963,7 @@ class MarketStore:
             "pending_metadata": int(metadata.get("pending_metadata", 0)),
             "pending_pool_unpublish": int(metadata.get("pending_pool_unpublish", 0)),
             "pending_reprojection": int(metadata.get("pending_reprojection", 0)),
+            "pending_accounting": int(metadata.get("pending_accounting", 0)),
             "history_from": history_from,
             "history_to": history_to,
             "history_target": history.get("target_timestamp") if isinstance(history, dict) else None,

--- a/src/rhpools/lp_market_store.py
+++ b/src/rhpools/lp_market_store.py
@@ -324,8 +324,18 @@ class MarketStore:
             ON events(owner, timestamp DESC, id DESC) WHERE owner IS NOT NULL;
         CREATE INDEX IF NOT EXISTS events_custody_time_idx
             ON events(custody, timestamp DESC, id DESC) WHERE custody IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS events_owner_order_idx
+            ON events(owner,block_number DESC,tx_index DESC,log_index DESC)
+            WHERE owner IS NOT NULL;
+        CREATE INDEX IF NOT EXISTS events_custody_order_idx
+            ON events(custody,block_number DESC,tx_index DESC,log_index DESC)
+            WHERE custody IS NOT NULL;
         CREATE INDEX IF NOT EXISTS events_block_idx
             ON events(block_number, tx_index, log_index);
+        CREATE INDEX IF NOT EXISTS events_lp_order_idx
+            ON events(block_number,tx_index,log_index)
+            WHERE kind IN ('add','remove','collect')
+            OR (kind='checkpoint' AND position_key IS NOT NULL);
         CREATE INDEX IF NOT EXISTS events_revision_id_idx ON events(revision, id);
         CREATE INDEX IF NOT EXISTS events_tx_log_idx ON events(tx_hash, log_index);
         CREATE TABLE IF NOT EXISTS transactions(
@@ -559,6 +569,8 @@ class MarketStore:
                 if accounting_pending_installed:
                     self._install_accounting_pending_identities(self.connection)
                 self.connection.execute("PRAGMA user_version=9")
+            if int(self.connection.execute("PRAGMA user_version").fetchone()[0]) < 10:
+                self.connection.execute("PRAGMA user_version=10")
             self.connection.execute(
                 "CREATE INDEX IF NOT EXISTS pending_reprojection_order_idx "
                 "ON pending_reprojection(block_number,tx_index,log_index,event_id)"
@@ -2928,64 +2940,178 @@ class MarketStore:
         ).fetchall()
         return [dict(row) for row in rows]
 
-    def save_v3_balance(
-        self, pool_id: str, block_number: int, block_hash: str, balance0: Any, balance1: Any,
-    ) -> None:
-        pool_id = pool_id.lower()
+    def save_v3_balances(
+        self, balances: Sequence[tuple[str, int, str, Any, Any]],
+    ) -> list[Exception | None]:
+        """Publish one fetched batch and return an outcome aligned to each input."""
+        outcomes: list[Exception | None] = [None] * len(balances)
+        normalized: list[tuple[int, str, int, str, str, str]] = []
+        identities: set[tuple[str, int]] = set()
+        for index, item in enumerate(balances):
+            try:
+                pool_value, number_value, hash_value, balance0_value, balance1_value = item
+                pool_id = str(pool_value).lower()
+                block_number = _integer(number_value, "block_number")
+                block_hash = str(hash_value).lower()
+                balance0 = _decimal_text(balance0_value, "balance0")
+                balance1 = _decimal_text(balance1_value, "balance1")
+                if len(pool_id) != 42:
+                    raise ValueError("pool_id must be a 20-byte address")
+                if len(block_hash) != 66:
+                    raise ValueError("block_hash must be a 32-byte hash")
+                if block_number is None or balance0 is None or balance1 is None:
+                    raise ValueError("balance snapshot fields must not be null")
+                identity = (pool_id, block_number)
+                if identity in identities:
+                    raise ValueError("balance batch contains a duplicate pool and block")
+                identities.add(identity)
+            except (TypeError, ValueError) as exc:
+                outcomes[index] = exc
+            else:
+                normalized.append((
+                    index, pool_id, block_number, block_hash, balance0, balance1,
+                ))
+        if not normalized:
+            return outcomes
+
         with self.transaction() as connection:
-            pool = connection.execute(
-                "SELECT protocol,metadata_json FROM pools WHERE id=?", (pool_id,),
-            ).fetchone()
-            block = connection.execute(
-                "SELECT hash,timestamp FROM blocks WHERE number=?", (int(block_number),),
-            ).fetchone()
-            if pool is None or pool["protocol"] != "v3":
-                raise ValueError("per-pool balance snapshots are only valid for V3 pools")
-            if block is None or block["hash"] != block_hash.lower():
-                raise CanonicalConflict("balance snapshot belongs to an orphaned block")
-            connection.execute(
-                "INSERT INTO pool_balances(pool_id,block_number,block_hash,balance0,balance1) "
-                "VALUES(?,?,?,?,?) ON CONFLICT(pool_id,block_number) DO UPDATE SET "
-                "block_hash=excluded.block_hash,balance0=excluded.balance0,balance1=excluded.balance1",
-                (
-                    pool_id, int(block_number), block_hash.lower(),
-                    _decimal_text(balance0, "balance0"), _decimal_text(balance1, "balance1"),
-                ),
-            )
-            metadata = _decode_json(pool["metadata_json"], {})
-            if not isinstance(metadata, dict):
-                metadata = {}
-            prior_block = metadata.get("balance_block")
-            if prior_block is None or int(prior_block) <= int(block_number):
-                metadata.update({
-                    "balance0": _decimal_text(balance0, "balance0"),
-                    "balance1": _decimal_text(balance1, "balance1"),
-                    "balance_block": int(block_number),
-                    "balance_timestamp": int(block["timestamp"]),
-                })
-                serialized = _json(metadata)
-                if serialized != pool["metadata_json"]:
-                    connection.execute(
+            pool_ids = tuple(dict.fromkeys(item[1] for item in normalized))
+            block_numbers = tuple(dict.fromkeys(item[2] for item in normalized))
+            pool_marks = ",".join("?" for _ in pool_ids)
+            block_marks = ",".join("?" for _ in block_numbers)
+            pools = {
+                str(row["id"]): row
+                for row in connection.execute(
+                    f"SELECT id,protocol,metadata_json FROM pools WHERE id IN ({pool_marks})",
+                    pool_ids,
+                )
+            }
+            blocks = {
+                int(row["number"]): row
+                for row in connection.execute(
+                    f"SELECT number,hash,timestamp FROM blocks WHERE number IN ({block_marks})",
+                    block_numbers,
+                )
+            }
+            pending = {
+                (str(row["pool_id"]), int(row["block_number"])): str(row["block_hash"])
+                for row in connection.execute(
+                    "SELECT pool_id,block_number,block_hash FROM pending_balances "
+                    f"WHERE pool_id IN ({pool_marks}) AND block_number IN ({block_marks})",
+                    (*pool_ids, *block_numbers),
+                )
+            }
+            publishable: list[tuple[int, str, int, str, str, str]] = []
+            for item in normalized:
+                index, pool_id, block_number, block_hash, _balance0, _balance1 = item
+                pool = pools.get(pool_id)
+                block = blocks.get(block_number)
+                if pool is None or pool["protocol"] != "v3":
+                    outcomes[index] = ValueError(
+                        "per-pool balance snapshots are only valid for V3 pools"
+                    )
+                elif block is None or str(block["hash"]) != block_hash:
+                    outcomes[index] = CanonicalConflict(
+                        "balance snapshot belongs to an orphaned block"
+                    )
+                elif pending.get((pool_id, block_number)) != block_hash:
+                    outcomes[index] = CanonicalConflict(
+                        "balance snapshot work is stale"
+                    )
+                else:
+                    publishable.append(item)
+
+            if publishable:
+                _insert_rows(
+                    connection,
+                    "INSERT INTO pool_balances"
+                    "(pool_id,block_number,block_hash,balance0,balance1)",
+                    (
+                        (pool_id, block_number, block_hash, balance0, balance1)
+                        for (
+                            _index, pool_id, block_number, block_hash,
+                            balance0, balance1,
+                        ) in publishable
+                    ),
+                    columns=5,
+                    suffix=(
+                        " ON CONFLICT(pool_id,block_number) DO UPDATE SET "
+                        "block_hash=excluded.block_hash,balance0=excluded.balance0,"
+                        "balance1=excluded.balance1"
+                    ),
+                )
+                latest: dict[str, tuple[int, str, str]] = {}
+                for (
+                    _index, pool_id, block_number, _block_hash, balance0, balance1,
+                ) in publishable:
+                    prior = latest.get(pool_id)
+                    if prior is None or prior[0] <= block_number:
+                        latest[pool_id] = (block_number, balance0, balance1)
+                metadata_updates: list[tuple[str, str]] = []
+                for pool_id, (block_number, balance0, balance1) in latest.items():
+                    pool = pools[pool_id]
+                    metadata = _decode_json(pool["metadata_json"], {})
+                    if not isinstance(metadata, dict):
+                        metadata = {}
+                    try:
+                        prior_block = int(metadata["balance_block"])
+                    except (KeyError, TypeError, ValueError):
+                        prior_block = None
+                    if prior_block is None or prior_block <= block_number:
+                        metadata.update({
+                            "balance0": balance0,
+                            "balance1": balance1,
+                            "balance_block": block_number,
+                            "balance_timestamp": int(blocks[block_number]["timestamp"]),
+                        })
+                        serialized = _json(metadata)
+                        if serialized != pool["metadata_json"]:
+                            metadata_updates.append((serialized, pool_id))
+                if metadata_updates:
+                    connection.executemany(
                         "UPDATE pools SET metadata_json=? WHERE id=?",
-                        (serialized, pool_id),
+                        metadata_updates,
                     )
                     self._mark_pool_metadata_changed()
-            removed = connection.execute(
-                "DELETE FROM pending_balances WHERE pool_id=? AND block_number=?",
-                (pool_id, int(block_number)),
-            ).rowcount
-            if removed:
+                before = connection.total_changes
+                connection.executemany(
+                    "DELETE FROM pending_balances "
+                    "WHERE pool_id=? AND block_number=? AND block_hash=?",
+                    (
+                        (pool_id, block_number, block_hash)
+                        for (
+                            _index, pool_id, block_number, block_hash,
+                            _balance0, _balance1,
+                        ) in publishable
+                    ),
+                )
+                removed = connection.total_changes - before
+                if removed != len(publishable):
+                    raise MarketStoreError(
+                        "pending balance set changed during atomic publication"
+                    )
                 self._bump(connection, "pending_balances", -removed)
-            self._next_revision(connection)
+                self._next_revision(connection)
+        return outcomes
 
-    def mark_v3_balance_error(
-        self, pool_id: str, block_number: int, error: str, *, delay: float,
+    def mark_v3_balance_errors(
+        self, errors: Sequence[tuple[str, int, str, str, float]],
     ) -> None:
+        if not errors:
+            return
+        now = time.time()
         with self.transaction() as connection:
-            connection.execute(
-                "UPDATE pending_balances SET attempts=attempts+1,next_attempt=?,last_error=? "
-                "WHERE pool_id=? AND block_number=?",
-                (time.time() + max(0.0, delay), str(error)[:1000], pool_id.lower(), int(block_number)),
+            connection.executemany(
+                "UPDATE pending_balances SET attempts=attempts+1,"
+                "next_attempt=?,last_error=? "
+                "WHERE pool_id=? AND block_number=? AND block_hash=?",
+                (
+                    (
+                        now + max(0.0, delay), str(error)[:1000],
+                        pool_id.lower(), int(block_number), block_hash.lower(),
+                    )
+                    for pool_id, block_number, block_hash, error, delay in errors
+                ),
             )
 
     def _rollback_search_index(

--- a/src/rhpools/lp_math.py
+++ b/src/rhpools/lp_math.py
@@ -121,6 +121,39 @@ def principal_raw(liquidity: int, sqrt: int, lo: int, hi: int) -> tuple[int, int
     return amount0, amount1
 
 
+def fee_growth_amount(liquidity: int, current: int, previous: int) -> int:
+    """Convert wrapped Q128 fee growth into floor-rounded token units."""
+    return liquidity * ((current - previous) & _MAX_UINT256) // (1 << 128)
+
+
+def fee_claim(
+    liquidity: int,
+    fee_growth0_last: int,
+    fee_growth1_last: int,
+    owed0: int,
+    owed1: int,
+    global0: int,
+    global1: int,
+    lower_outside0: int,
+    lower_outside1: int,
+    upper_outside0: int,
+    upper_outside1: int,
+    tick: int,
+    lower: int,
+    upper: int,
+) -> tuple[int, int, int, int]:
+    """Return total claim and still-lazy fees using V3 uint256 wrapping."""
+    below0 = lower_outside0 if tick >= lower else (global0 - lower_outside0) & _MAX_UINT256
+    below1 = lower_outside1 if tick >= lower else (global1 - lower_outside1) & _MAX_UINT256
+    above0 = upper_outside0 if tick < upper else (global0 - upper_outside0) & _MAX_UINT256
+    above1 = upper_outside1 if tick < upper else (global1 - upper_outside1) & _MAX_UINT256
+    inside0 = (global0 - below0 - above0) & _MAX_UINT256
+    inside1 = (global1 - below1 - above1) & _MAX_UINT256
+    lazy0 = fee_growth_amount(liquidity, inside0, fee_growth0_last)
+    lazy1 = fee_growth_amount(liquidity, inside1, fee_growth1_last)
+    return owed0 + lazy0, owed1 + lazy1, lazy0, lazy1
+
+
 __all__ = [
     "MAX_SQRT_RATIO",
     "MAX_TICK",
@@ -129,6 +162,8 @@ __all__ = [
     "Q96",
     "amount0_delta",
     "amount1_delta",
+    "fee_claim",
+    "fee_growth_amount",
     "principal_raw",
     "sqrt_ratio_at_tick",
     "tick_at_sqrt_price_x96",

--- a/src/rhpools/lp_rpc.py
+++ b/src/rhpools/lp_rpc.py
@@ -63,6 +63,19 @@ class _SourceGate:
     seconds: list[int] = field(default_factory=lambda: [-1] * 60)
     http_window: list[int] = field(default_factory=lambda: [0] * 60)
     calls_window: list[int] = field(default_factory=lambda: [0] * 60)
+    def acquire(self, interval: float, cost: int) -> None:
+        """Acquire response capacity only when this request may start."""
+        while True:
+            self.slots.acquire()
+            with self.lock:
+                now = time.monotonic()
+                delay = self.next_at - now
+                if delay <= 0:
+                    self.next_at = now + interval * cost
+                    return
+            self.slots.release()
+            time.sleep(delay)
+
 
     def record(self, calls: int) -> None:
         """Count attempted HTTP requests and batch items, including failures."""
@@ -280,7 +293,7 @@ def _capability(method: str, params: Sequence[Any], lane: str) -> str:
     if (
         state_method
         and tag not in (None, "latest", "pending", "safe", "finalized")
-        and lane in {"history", "backfill", "maintenance", "enrichment"}
+        and lane in {"history", "backfill", "maintenance", "enrichment", "balance"}
     ):
         return "history_state"
     if state_method:
@@ -301,16 +314,22 @@ class _Registry:
         }
         self._states[("logs", _EXPLORER_SOURCE.name)] = _SourceState()
         self._verified_sources: set[str] = set()
-        self._clients: dict[str, requests.Session] = {}
+        self._verification_locks: dict[str, threading.Lock] = {}
+        self._clients: dict[
+            tuple[str, tuple[tuple[str, str], ...]], requests.Session
+        ] = {}
         self._active: dict[str, str] = {}
         self._lock = threading.RLock()
+        self._requests_drained = threading.Condition(self._lock)
+        self._active_requests = 0
         self._closed = False
 
     def _session(self, source: _Source) -> requests.Session:
         with self._lock:
             if self._closed:
                 raise self.error_type("RPC provider registry is closed")
-            session = self._clients.get(source.name)
+            key = (source.url, source.headers)
+            session = self._clients.get(key)
             if session is None:
                 session = requests.Session()
                 session.headers.update({
@@ -319,12 +338,33 @@ class _Registry:
                     **dict(source.headers),
                 })
                 adapter = HTTPAdapter(
-                    pool_connections=2, pool_maxsize=MAX_SOURCE_CONCURRENCY, max_retries=0, pool_block=True,
+                    pool_connections=2, pool_maxsize=MAX_SOURCE_CONCURRENCY,
+                    max_retries=0, pool_block=True,
                 )
                 session.mount("http://", adapter)
                 session.mount("https://", adapter)
-                self._clients[source.name] = session
+                self._clients[key] = session
             return session
+
+    def _acquire_session(self, source: _Source) -> requests.Session:
+        with self._lock:
+            session = self._session(source)
+            self._active_requests += 1
+            return session
+
+    def _release_session(self) -> None:
+        with self._requests_drained:
+            self._active_requests -= 1
+            if self._active_requests == 0:
+                self._requests_drained.notify_all()
+
+    def _verification_lock(self, source: _Source) -> threading.Lock:
+        with self._lock:
+            lock = self._verification_locks.get(source.url)
+            if lock is None:
+                lock = threading.Lock()
+                self._verification_locks[source.url] = lock
+            return lock
 
     def candidates(self, capability: str) -> tuple[_Source, ...]:
         sources = self.sources[capability]
@@ -452,10 +492,12 @@ class _Registry:
         return result
 
     def close(self) -> None:
-        with self._lock:
+        with self._requests_drained:
             if self._closed:
                 return
             self._closed = True
+            while self._active_requests:
+                self._requests_drained.wait()
             sessions = list(self._clients.values())
             self._clients.clear()
         for session in sessions:
@@ -608,6 +650,11 @@ class _WssPreferredRpc:
         # socket that is optimized for individual latency-sensitive calls.
         return self._fallback.batch(calls, allow_reverts=allow_reverts)
 
+    def batch_results(
+        self, calls: Iterable[tuple[str, Sequence[Any]]],
+    ) -> list[Any | Exception]:
+        return self._fallback.batch_results(calls)
+
     def status(self) -> dict[str, Any]:
         return self._fallback.status()
 
@@ -642,6 +689,20 @@ class RoutedRpc:
         except TypeError:
             return self._registry.error_type(message)
 
+    def _check_open(self) -> None:
+        with self._lock:
+            if self._closed:
+                raise self._error("RPC lane is closed")
+
+    def _reserve_ids(self, count: int) -> range:
+        with self._lock:
+            if self._closed:
+                raise self._error("RPC lane is closed")
+            first = self._request_id + 1
+            self._request_id += count
+            return range(first, first + count)
+
+
     @staticmethod
     def _is_execution_revert(method: str, error: Any) -> bool:
         if method not in {"eth_call", "eth_estimateGas"} or not isinstance(error, Mapping):
@@ -658,24 +719,26 @@ class RoutedRpc:
 
 
     def _post(self, source: _Source, payload: Any) -> Any:
-        response: requests.Response | None = None
+        body = json.dumps(payload, separators=(",", ":"))
+        calls = len(payload) if isinstance(payload, list) else 1
+        hostname = (urlsplit(source.url).hostname or "").lower()
+        cost = calls if hostname == "edge.goldsky.com" else 1
         gate = _gate(source.url)
-        with gate.slots:
-            with gate.lock:
-                delay = gate.next_at - time.monotonic()
-                if delay > 0:
-                    time.sleep(delay)
-                calls = len(payload) if isinstance(payload, list) else 1
-                cost = calls if (urlsplit(source.url).hostname or "").lower() == "edge.goldsky.com" else 1
-                gate.next_at = time.monotonic() + _minimum_interval(source.url) * cost
-                gate.record(calls)
+        gate.acquire(_minimum_interval(source.url), cost)
+        response: requests.Response | None = None
+        session: requests.Session | None = None
+        try:
+            session = self._registry._acquire_session(source)
+            gate.record(calls)
             try:
-                response = self._registry._session(source).post(
-                    source.url, data=json.dumps(payload, separators=(",", ":")),
-                    timeout=(2.0, self._timeout), stream=True,
+                response = session.post(
+                    source.url, data=body, timeout=(2.0, self._timeout),
+                    stream=True,
                 )
                 response.raise_for_status()
-                raw = response.raw.read(MAX_RPC_RESPONSE_BYTES + 1, decode_content=True)
+                raw = response.raw.read(
+                    MAX_RPC_RESPONSE_BYTES + 1, decode_content=True,
+                )
             except requests.RequestException as exc:
                 raise self._error(
                     f"{source.name} transport: {type(exc).__name__}"
@@ -683,11 +746,17 @@ class RoutedRpc:
             finally:
                 if response is not None:
                     response.close()
+        finally:
+            if session is not None:
+                self._registry._release_session()
+            gate.slots.release()
         if len(raw) > MAX_RPC_RESPONSE_BYTES:
-            raise self._error(f"{source.name} response exceeds {MAX_RPC_RESPONSE_BYTES} bytes")
+            raise self._error(
+                f"{source.name} response exceeds {MAX_RPC_RESPONSE_BYTES} bytes"
+            )
         try:
             return json.loads(raw)
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        except (UnicodeDecodeError, json.JSONDecodeError):
             raise self._error(f"{source.name} returned invalid JSON") from None
 
     def _validate_item(
@@ -717,19 +786,28 @@ class RoutedRpc:
     def _ensure_chain(self, source: _Source) -> None:
         if self._registry.verified(source):
             return
-        self._request_id += 1
-        request_id = self._request_id
-        raw = self._post(source, {
-            "jsonrpc": "2.0", "id": request_id, "method": "eth_chainId", "params": [],
-        })
-        result = self._validate_item(source, raw, request_id, "eth_chainId")
-        try:
-            chain_id = int(str(result), 16)
-        except (TypeError, ValueError) as exc:
-            raise self._error(f"{source.name} returned malformed chain id") from None
-        if chain_id != CHAIN_ID:
-            raise self._error(f"{source.name} is chain {chain_id}, expected {CHAIN_ID}")
-        self._registry.mark_verified(source)
+        with self._registry._verification_lock(source):
+            if self._registry.verified(source):
+                return
+            request_id = self._reserve_ids(1).start
+            raw = self._post(source, {
+                "jsonrpc": "2.0", "id": request_id,
+                "method": "eth_chainId", "params": [],
+            })
+            result = self._validate_item(
+                source, raw, request_id, "eth_chainId",
+            )
+            try:
+                chain_id = int(str(result), 16)
+            except (TypeError, ValueError):
+                raise self._error(
+                    f"{source.name} returned malformed chain id"
+                ) from None
+            if chain_id != CHAIN_ID:
+                raise self._error(
+                    f"{source.name} is chain {chain_id}, expected {CHAIN_ID}"
+                )
+            self._registry.mark_verified(source)
 
     @staticmethod
     def _log_matches(query: Mapping[str, Any], row: Mapping[str, Any]) -> bool:
@@ -778,7 +856,6 @@ class RoutedRpc:
         if len(addresses) * len(topics) > 16:
             raise self._error("blockscout explorer log filter exceeds 16 bounded queries")
         result: dict[tuple[str, str, str], dict[str, Any]] = {}
-        session = self._registry._session(_EXPLORER_SOURCE)
         gate = _gate(_EXPLORER)
         for address in addresses:
             for topic in topics:
@@ -793,24 +870,28 @@ class RoutedRpc:
                 for index, expected in enumerate((query.get("topics") or ())[1:], 1):
                     if isinstance(expected, str):
                         params[f"topic{index}"] = expected
+                gate.acquire(0.20, 1)
                 response: requests.Response | None = None
-                with gate.lock:
-                    delay = gate.next_at - time.monotonic()
-                    if delay > 0:
-                        time.sleep(delay)
-                    try:
-                        response = session.get(
-                            _EXPLORER, params=params,
-                            timeout=(2.0, self._timeout), stream=True,
-                        )
-                        response.raise_for_status()
-                        raw = response.raw.read(
-                            MAX_RPC_RESPONSE_BYTES + 1, decode_content=True,
-                        )
-                    finally:
-                        gate.next_at = time.monotonic() + 0.20
-                        if response is not None:
-                            response.close()
+                session: requests.Session | None = None
+                try:
+                    session = self._registry._acquire_session(
+                        _EXPLORER_SOURCE
+                    )
+                    gate.record(0)
+                    response = session.get(
+                        _EXPLORER, params=params,
+                        timeout=(2.0, self._timeout), stream=True,
+                    )
+                    response.raise_for_status()
+                    raw = response.raw.read(
+                        MAX_RPC_RESPONSE_BYTES + 1, decode_content=True,
+                    )
+                finally:
+                    if response is not None:
+                        response.close()
+                    if session is not None:
+                        self._registry._release_session()
+                    gate.slots.release()
                 if len(raw) > MAX_RPC_RESPONSE_BYTES:
                     raise self._error("blockscout explorer response is oversized")
                 payload = json.loads(raw)
@@ -868,8 +949,7 @@ class RoutedRpc:
             targets.append(number)
         if not targets:
             return False
-        self._request_id += 1
-        request_id = self._request_id
+        request_id = self._reserve_ids(1).start
         raw = self._post(source, {
             "jsonrpc": "2.0", "id": request_id,
             "method": "eth_blockNumber", "params": [],
@@ -884,67 +964,85 @@ class RoutedRpc:
         return max(targets) <= head_number
 
     def call(self, method: str, params: Sequence[Any] | None = None) -> Any:
+        self._check_open()
         values = list(params or ())
         capability = _capability(method, values, self._lane)
         sources = self._registry.candidates(capability)
         if not sources and not self._registry.sources[capability]:
             raise self._error(
-                f"{capability} RPC unavailable; configure LP_RPC_{capability.upper()}_URLS"
+                f"{capability} RPC unavailable; "
+                f"configure LP_RPC_{capability.upper()}_URLS"
             )
         failures: list[str] = []
-        with self._lock:
-            if self._closed:
-                raise self._error("RPC lane is closed")
-            for source in sources:
-                if not self._registry.can_try(source, capability):
-                    continue
-                started = time.monotonic()
-                try:
-                    self._ensure_chain(source)
-                    if capability == "logs" and not self._local_log_range_eligible(
+        for source in sources:
+            if not self._registry.can_try(source, capability):
+                continue
+            started = time.monotonic()
+            try:
+                self._ensure_chain(source)
+                if (
+                    capability == "logs"
+                    and not self._local_log_range_eligible(
                         source, [(method, values)],
-                    ):
-                        continue
-                    self._request_id += 1
-                    request_id = self._request_id
-                    raw = self._post(source, {
-                        "jsonrpc": "2.0", "id": request_id,
-                        "method": method, "params": values,
-                    })
-                    result = self._validate_item(source, raw, request_id, method)
-                    if method == "eth_chainId" and int(str(result), 16) != CHAIN_ID:
-                        raise self._error(f"{source.name} changed chain identity")
-                except _ExecutionReverted as exc:
-                    self._registry.success(
-                        source, capability, exc.method, time.monotonic() - started,
                     )
-                    raise exc.error from None
-                except Exception as exc:
-                    self._registry.failure(source, capability, exc)
-                    failures.append(self._registry._safe_error(source, exc))
+                ):
                     continue
+                request_id = self._reserve_ids(1).start
+                raw = self._post(source, {
+                    "jsonrpc": "2.0", "id": request_id,
+                    "method": method, "params": values,
+                })
+                result = self._validate_item(
+                    source, raw, request_id, method,
+                )
+                if (
+                    method == "eth_chainId"
+                    and int(str(result), 16) != CHAIN_ID
+                ):
+                    raise self._error(
+                        f"{source.name} changed chain identity"
+                    )
+            except _ExecutionReverted as exc:
                 self._registry.success(
-                    source, capability, method, time.monotonic() - started,
+                    source, capability, exc.method,
+                    time.monotonic() - started,
+                )
+                raise exc.error from None
+            except Exception as exc:
+                self._registry.failure(source, capability, exc)
+                failures.append(self._registry._safe_error(source, exc))
+                continue
+            self._registry.success(
+                source, capability, method, time.monotonic() - started,
+            )
+            return result
+        if (
+            capability == "logs"
+            and self._registry.can_try(_EXPLORER_SOURCE, capability)
+        ):
+            started = time.monotonic()
+            try:
+                result = self._explorer_logs(values)
+            except Exception as exc:
+                self._registry.failure(
+                    _EXPLORER_SOURCE, capability, exc,
+                )
+                failures.append(
+                    self._registry._safe_error(_EXPLORER_SOURCE, exc)
+                )
+            else:
+                self._registry.success(
+                    _EXPLORER_SOURCE, capability, method,
+                    time.monotonic() - started,
                 )
                 return result
-            if capability == "logs" and self._registry.can_try(_EXPLORER_SOURCE, capability):
-                started = time.monotonic()
-                try:
-                    result = self._explorer_logs(values)
-                except Exception as exc:
-                    self._registry.failure(_EXPLORER_SOURCE, capability, exc)
-                    failures.append(
-                        self._registry._safe_error(_EXPLORER_SOURCE, exc)
-                    )
-                else:
-                    self._registry.success(
-                        _EXPLORER_SOURCE, capability, method,
-                        time.monotonic() - started,
-                    )
-                    return result
         if not failures:
-            raise self._error(f"{capability} RPC deferred during provider cooldown")
-        raise self._error(f"{capability} RPC exhausted: " + "; ".join(failures))
+            raise self._error(
+                f"{capability} RPC deferred during provider cooldown"
+            )
+        raise self._error(
+            f"{capability} RPC exhausted: " + "; ".join(failures)
+        )
 
     def batch(
         self, calls: Iterable[tuple[str, Sequence[Any]]], *,
@@ -955,83 +1053,182 @@ class RoutedRpc:
             return []
         if len(specifications) > MAX_BATCH_CALLS:
             raise ValueError(f"RPC batch exceeds {MAX_BATCH_CALLS} calls")
+        results = self._run_batch(
+            specifications, allow_reverts=allow_reverts,
+            stop_on_error=True,
+        )
+        for result in results:
+            if isinstance(result, Exception):
+                raise result
+        return results
+
+    def batch_results(
+        self, calls: Iterable[tuple[str, Sequence[Any]]],
+    ) -> list[Any | Exception]:
+        specifications = [(method, list(params)) for method, params in calls]
+        if not specifications:
+            return []
+        if len(specifications) > MAX_BATCH_CALLS:
+            raise ValueError(f"RPC batch exceeds {MAX_BATCH_CALLS} calls")
+        return self._run_batch(
+            specifications, allow_reverts=False, stop_on_error=False,
+        )
+
+    def _run_batch(
+        self, specifications: list[tuple[str, list[Any]]], *,
+        allow_reverts: bool,
+        stop_on_error: bool,
+    ) -> list[Any | Exception]:
+        self._check_open()
         capabilities = {
             _capability(method, params, self._lane)
             for method, params in specifications
         }
         if len(capabilities) != 1:
-            grouped: dict[str, list[tuple[int, tuple[str, list[Any]]]]] = {}
+            grouped: dict[
+                str, list[tuple[int, tuple[str, list[Any]]]]
+            ] = {}
             for index, specification in enumerate(specifications):
                 capability = _capability(
                     specification[0], specification[1], self._lane,
                 )
-                grouped.setdefault(capability, []).append((index, specification))
-            output: list[Any] = [None] * len(specifications)
-            for group in grouped.values():
-                results = self.batch(
-                    (specification for _index, specification in group),
-                    allow_reverts=allow_reverts,
+                grouped.setdefault(capability, []).append(
+                    (index, specification)
                 )
+            output: list[Any | Exception] = [None] * len(specifications)
+            for group in grouped.values():
+                results = self._run_batch(
+                    [specification for _index, specification in group],
+                    allow_reverts=allow_reverts,
+                    stop_on_error=stop_on_error,
+                )
+                if stop_on_error:
+                    for result in results:
+                        if isinstance(result, Exception):
+                            raise result
                 for (index, _specification), result in zip(group, results):
                     output[index] = result
             return output
+
         capability = capabilities.pop()
         sources = self._registry.candidates(capability)
         if not sources and not self._registry.sources[capability]:
-            raise self._error(
-                f"{capability} RPC unavailable; configure LP_RPC_{capability.upper()}_URLS"
+            failure = self._error(
+                f"{capability} RPC unavailable; "
+                f"configure LP_RPC_{capability.upper()}_URLS"
             )
-        failures: list[str] = []
-        with self._lock:
-            if self._closed:
-                raise self._error("RPC lane is closed")
-            for source in sources:
-                if not self._registry.can_try(source, capability):
+            return [
+                self._error(str(failure)) for _item in specifications
+            ]
+        output = [None] * len(specifications)
+        pending = list(enumerate(specifications))
+        failure_messages: dict[int, list[str]] = {
+            index: [] for index in range(len(specifications))
+        }
+        failure_codes: dict[int, int] = {}
+
+        def remember(
+            attempted: Iterable[
+                tuple[int, tuple[str, list[Any]]]
+            ],
+            source: _Source,
+            exc: Exception,
+        ) -> None:
+            message = self._registry._safe_error(source, exc)
+            code = getattr(exc, "code", None)
+            for index, _specification in attempted:
+                failure_messages[index].append(message)
+                if isinstance(code, int):
+                    failure_codes[index] = code
+
+        for source in sources:
+            if not pending:
+                break
+            if not self._registry.can_try(source, capability):
+                continue
+            started = time.monotonic()
+            attempted = pending
+            attempted_specs = [
+                specification for _index, specification in attempted
+            ]
+            try:
+                self._ensure_chain(source)
+                if (
+                    capability == "logs"
+                    and not self._local_log_range_eligible(
+                        source, attempted_specs,
+                    )
+                ):
                     continue
-                started = time.monotonic()
+                request_ids = self._reserve_ids(len(attempted))
+                payload = [
+                    {
+                        "jsonrpc": "2.0", "id": request_id,
+                        "method": method, "params": params,
+                    }
+                    for request_id, (
+                        _index, (method, params)
+                    ) in zip(request_ids, attempted)
+                ]
+                raw = self._post(source, payload)
+                if not isinstance(raw, list):
+                    raise self._error(
+                        f"{source.name} returned non-list batch response"
+                    )
+                by_id = {
+                    item.get("id"): item
+                    for item in raw if isinstance(item, Mapping)
+                }
+            except Exception as exc:
+                self._registry.failure(source, capability, exc)
+                remember(attempted, source, exc)
+                continue
+
+            unresolved: list[
+                tuple[int, tuple[str, list[Any]]]
+            ] = []
+            first_failure: Exception | None = None
+            for request_id, (
+                index, (method, params)
+            ) in zip(request_ids, attempted):
                 try:
-                    self._ensure_chain(source)
-                    if capability == "logs" and not self._local_log_range_eligible(
-                        source, specifications,
-                    ):
-                        continue
-                    payload = []
-                    ids = []
-                    for method, params in specifications:
-                        self._request_id += 1
-                        ids.append(self._request_id)
-                        payload.append({
-                            "jsonrpc": "2.0", "id": self._request_id,
-                            "method": method, "params": params,
-                        })
-                    raw = self._post(source, payload)
-                    if not isinstance(raw, list):
-                        raise self._error(f"{source.name} returned non-list batch response")
-                    by_id = {item.get("id"): item for item in raw if isinstance(item, Mapping)}
-                    output = [
-                        self._validate_item(
-                            source, by_id.get(request_id), request_id, method,
-                            allow_revert=allow_reverts,
-                        )
-                        for request_id, (method, _params) in zip(ids, specifications)
-                    ]
+                    output[index] = self._validate_item(
+                        source, by_id.get(request_id), request_id, method,
+                        allow_revert=allow_reverts,
+                    )
                 except _ExecutionReverted as exc:
-                    self._registry.success(
-                        source, capability, exc.method, time.monotonic() - started,
-                    )
-                    raise exc.error from None
+                    output[index] = exc.error
                 except Exception as exc:
-                    self._registry.failure(source, capability, exc)
-                    failures.append(self._registry._safe_error(source, exc))
-                    continue
-                for method, _params in specifications:
-                    self._registry.success(
-                        source, capability, method, time.monotonic() - started,
-                    )
-                return output
-        if not failures:
-            raise self._error(f"{capability} RPC deferred during provider cooldown")
-        raise self._error(f"{capability} RPC exhausted: " + "; ".join(failures))
+                    unresolved.append((index, (method, params)))
+                    remember(((index, (method, params)),), source, exc)
+                    if first_failure is None:
+                        first_failure = exc
+            if unresolved:
+                assert first_failure is not None
+                self._registry.failure(
+                    source, capability, first_failure,
+                )
+                pending = unresolved
+                continue
+            for _index, (method, _params) in attempted:
+                self._registry.success(
+                    source, capability, method,
+                    time.monotonic() - started,
+                )
+            pending = []
+
+        for index, _specification in pending:
+            messages = failure_messages[index]
+            if messages:
+                output[index] = self._error(
+                    f"{capability} RPC exhausted: " + "; ".join(messages),
+                    code=failure_codes.get(index),
+                )
+            else:
+                output[index] = self._error(
+                    f"{capability} RPC deferred during provider cooldown"
+                )
+        return output
 
     def status(self) -> dict[str, Any]:
         return self._registry.status()

--- a/src/rhpools/lp_rpc.py
+++ b/src/rhpools/lp_rpc.py
@@ -340,23 +340,43 @@ class _Registry:
             return self._states[(capability, source.name)].retry_at <= time.monotonic()
 
     @staticmethod
-    def _safe_error(source: _Source, exc: BaseException) -> str:
-        text = str(exc).replace(source.url, source.name)
+    def _redact_text(source: _Source, value: str) -> str:
+        text = value.replace(source.url, source.name)
         parsed = urlsplit(source.url)
-        values = [value for _key, value in parse_qsl(parsed.query)]
-        values.extend(value for _key, value in source.headers)
+        secrets = [item for _key, item in parse_qsl(parsed.query)]
+        secrets.extend(item for _key, item in source.headers)
         if parsed.password:
-            values.append(parsed.password)
+            secrets.append(parsed.password)
         # Path-key providers (e.g. /v2/<key>) and query-key providers must
         # remain redacted even when a remote error echoes just the key.
         if "/v2/" in parsed.path:
-            values.append(unquote(parsed.path.split("/v2/", 1)[1]))
-        for value in values:
-            if len(value) >= 4:
-                text = text.replace(value, "<redacted>")
-                if value.startswith("Bearer "):
-                    text = text.replace(value[7:], "<redacted>")
-        text = _URL_RE.sub("<redacted-url>", text)
+            secrets.append(unquote(parsed.path.split("/v2/", 1)[1]))
+        for secret in secrets:
+            if len(secret) >= 4:
+                text = text.replace(secret, "<redacted>")
+                if secret.startswith("Bearer "):
+                    text = text.replace(secret[7:], "<redacted>")
+        return _URL_RE.sub("<redacted-url>", text)
+
+    @classmethod
+    def _safe_payload(cls, source: _Source, value: Any) -> Any:
+        """Redact provider credentials without discarding JSON-RPC error ABI."""
+        if isinstance(value, Mapping):
+            return {
+                cls._redact_text(source, str(key)): cls._safe_payload(source, item)
+                for key, item in value.items()
+            }
+        if isinstance(value, list):
+            return [cls._safe_payload(source, item) for item in value]
+        if isinstance(value, str):
+            return cls._redact_text(source, value)
+        if value is None or isinstance(value, (bool, int, float)):
+            return value
+        return cls._redact_text(source, str(value))
+
+    @classmethod
+    def _safe_error(cls, source: _Source, exc: BaseException) -> str:
+        text = cls._redact_text(source, str(exc))
         return f"{type(exc).__name__}: {text}"[:500]
 
     def success(
@@ -579,11 +599,14 @@ class _WssPreferredRpc:
         except Exception:
             return self._fallback.call(method, params)
 
-    def batch(self, calls: Iterable[tuple[str, Sequence[Any]]]) -> list[Any]:
+    def batch(
+        self, calls: Iterable[tuple[str, Sequence[Any]]], *,
+        allow_reverts: bool = False,
+    ) -> list[Any]:
         # Bulk snapshots must use capability-specific providers and their
         # shared concurrency/rate budgets, not the public head-subscription
         # socket that is optimized for individual latency-sensitive calls.
-        return self._fallback.batch(calls)
+        return self._fallback.batch(calls, allow_reverts=allow_reverts)
 
     def status(self) -> dict[str, Any]:
         return self._fallback.status()
@@ -619,6 +642,21 @@ class RoutedRpc:
         except TypeError:
             return self._registry.error_type(message)
 
+    @staticmethod
+    def _is_execution_revert(method: str, error: Any) -> bool:
+        if method not in {"eth_call", "eth_estimateGas"} or not isinstance(error, Mapping):
+            return False
+        code = error.get("code")
+        message = str(error.get("message") or "")
+        return (
+            code == 3
+            or (
+                code in {-32000, -32015}
+                and message.lower().startswith("execution reverted")
+            )
+        )
+
+
     def _post(self, source: _Source, payload: Any) -> Any:
         response: requests.Response | None = None
         gate = _gate(source.url)
@@ -652,26 +690,24 @@ class RoutedRpc:
         except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise self._error(f"{source.name} returned invalid JSON") from None
 
-    def _validate_item(self, source: _Source, item: Any, request_id: int, method: str) -> Any:
+    def _validate_item(
+        self, source: _Source, item: Any, request_id: int, method: str, *,
+        allow_revert: bool = False,
+    ) -> Any:
         if not isinstance(item, Mapping) or item.get("id") != request_id:
             raise self._error(f"{source.name} returned malformed {method} response")
         error = item.get("error")
         if error is not None:
+            if allow_revert and self._is_execution_revert(method, error):
+                return {"error": self._registry._safe_payload(source, error)}
             code = error.get("code") if isinstance(error, Mapping) else None
-            message = error.get("message") if isinstance(error, Mapping) else error
             # Pinned NFT lifecycle reads need the ABI revert payload, not just
             # its message. Keep the full error while redacting provider secrets.
             failure = self._error(
                 f"{source.name} {method}: {self._registry._safe_error(source, RuntimeError(str(error)))}",
                 code=code if isinstance(code, int) else None,
             )
-            if method in {"eth_call", "eth_estimateGas"} and (
-                code == 3
-                or (
-                    code in {-32000, -32015}
-                    and str(message).lower().startswith("execution reverted")
-                )
-            ):
+            if self._is_execution_revert(method, error):
                 raise _ExecutionReverted(failure, method)
             raise failure
         if "result" not in item:
@@ -910,15 +946,35 @@ class RoutedRpc:
             raise self._error(f"{capability} RPC deferred during provider cooldown")
         raise self._error(f"{capability} RPC exhausted: " + "; ".join(failures))
 
-    def batch(self, calls: Iterable[tuple[str, Sequence[Any]]]) -> list[Any]:
+    def batch(
+        self, calls: Iterable[tuple[str, Sequence[Any]]], *,
+        allow_reverts: bool = False,
+    ) -> list[Any]:
         specifications = [(method, list(params)) for method, params in calls]
         if not specifications:
             return []
         if len(specifications) > MAX_BATCH_CALLS:
             raise ValueError(f"RPC batch exceeds {MAX_BATCH_CALLS} calls")
-        capabilities = {_capability(method, params, self._lane) for method, params in specifications}
+        capabilities = {
+            _capability(method, params, self._lane)
+            for method, params in specifications
+        }
         if len(capabilities) != 1:
-            return [self.call(method, params) for method, params in specifications]
+            grouped: dict[str, list[tuple[int, tuple[str, list[Any]]]]] = {}
+            for index, specification in enumerate(specifications):
+                capability = _capability(
+                    specification[0], specification[1], self._lane,
+                )
+                grouped.setdefault(capability, []).append((index, specification))
+            output: list[Any] = [None] * len(specifications)
+            for group in grouped.values():
+                results = self.batch(
+                    (specification for _index, specification in group),
+                    allow_reverts=allow_reverts,
+                )
+                for (index, _specification), result in zip(group, results):
+                    output[index] = result
+            return output
         capability = capabilities.pop()
         sources = self._registry.candidates(capability)
         if not sources and not self._registry.sources[capability]:
@@ -953,7 +1009,10 @@ class RoutedRpc:
                         raise self._error(f"{source.name} returned non-list batch response")
                     by_id = {item.get("id"): item for item in raw if isinstance(item, Mapping)}
                     output = [
-                        self._validate_item(source, by_id.get(request_id), request_id, method)
+                        self._validate_item(
+                            source, by_id.get(request_id), request_id, method,
+                            allow_revert=allow_reverts,
+                        )
                         for request_id, (method, _params) in zip(ids, specifications)
                     ]
                 except _ExecutionReverted as exc:

--- a/src/rhpools/static/lp_terminal.js
+++ b/src/rhpools/static/lp_terminal.js
@@ -132,6 +132,7 @@
     streamRetryMs: 1_000,
     aggregateController: null,
     aggregateGeneration: 0,
+    statusController: null,
     refreshTimer: null,
     historyTimer: null,
     tapeController: null,
@@ -1819,6 +1820,17 @@
     }
   }
 
+  async function refreshStatus() {
+    if (state.hidden || state.statusController) return;
+    const controller = new AbortController();
+    state.statusController = controller;
+    try {
+      await loadResource("status", "/status", {}, controller, applyStatus);
+    } finally {
+      if (state.statusController === controller) state.statusController = null;
+    }
+  }
+
   function ownersPanelActive() {
     return !state.hidden && state.ownersVisible && elements.modal.hidden && elements.poolInspector.hidden;
   }
@@ -1955,14 +1967,8 @@
     if (elements.modal.hidden && elements.poolInspector.hidden) {
       requests.push(loadResource("overview", "/overview", { window: state.window }, controller, (payload) => {
         state.overview = payload;
-        if (payload.status && typeof payload.status === "object") {
-          applyStatus(payload.status);
-          healthSuccess("status");
-        }
         scheduleRender("overview", renderOverview);
       }));
-    } else {
-      requests.push(loadResource("status", "/status", {}, controller, applyStatus));
     }
     if (poolPanelActive()) refreshPools();
     await Promise.all(requests);
@@ -2728,6 +2734,10 @@
       state.historyTimer = null;
       clearTimeout(state.filterTimer);
       if (state.aggregateController) state.aggregateController.abort();
+      if (state.statusController) {
+        state.statusController.abort();
+        state.statusController = null;
+      }
       abortPoolRequests();
       if (state.tapeController) state.tapeController.abort();
       if (state.ownerController) {
@@ -2742,6 +2752,7 @@
       return;
     }
     if (state.renderQueue.size && !state.renderFrame) state.renderFrame = requestAnimationFrame(flushRenders);
+    refreshStatus();
     reloadTape("resume");
     renderAllTables();
     refreshAggregates("resume");
@@ -3181,7 +3192,11 @@
   renderOverview();
   renderAllTables();
   updateClock();
-  setInterval(updateClock, 1_000);
+  refreshStatus();
+  setInterval(() => {
+    updateClock();
+    refreshStatus();
+  }, 1_000);
   reloadTape("initial");
   const initialOwner = String(initialUrl.searchParams.get("owner") || "").toLowerCase();
   if (ADDRESS_RE.test(initialOwner)) openOwner(initialOwner, null, "replace");

--- a/src/rhpools/static/lp_terminal.js
+++ b/src/rhpools/static/lp_terminal.js
@@ -1266,6 +1266,7 @@
     }
     const parentMismatch = previous && previous.hash && block.parent_hash
       && state.canonicalBlocks.has(String(previous.hash))
+      && finite(block.number) === finite(previous.number) + 1
       && String(previous.hash) !== String(block.parent_hash)
       && String(previous.hash) !== String(block.hash);
     let canonical = null;

--- a/src/rhpools/workbench_market.py
+++ b/src/rhpools/workbench_market.py
@@ -29,7 +29,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from eth_utils import keccak
 
-from .lp_math import MAX_TICK, principal_raw, sqrt_ratio_at_tick
+from .lp_math import MAX_TICK, fee_claim, principal_raw, sqrt_ratio_at_tick
 from .lp_chain import CHAIN_ID
 from . import _mc
 from .lp_market_protocols import resolve_v4_tick_spacing
@@ -333,35 +333,8 @@ def _usd_price(token0: str, token1: str, token1_per_token0: float | None) -> flo
     if token0 == USDG and token1 != USDG:
         return 1.0 / token1_per_token0 if token1_per_token0 else None
     return None
-_UINT256_MASK = (1 << 256) - 1
 
 
-def _v3_fee_claim(
-    liquidity: int,
-    fee_growth0_last: int,
-    fee_growth1_last: int,
-    owed0: int,
-    owed1: int,
-    global0: int,
-    global1: int,
-    lower_outside0: int,
-    lower_outside1: int,
-    upper_outside0: int,
-    upper_outside1: int,
-    tick: int,
-    lower: int,
-    upper: int,
-) -> tuple[int, int, int, int]:
-    """Return total claim and still-lazy fees using V3 uint256 wrapping."""
-    below0 = lower_outside0 if tick >= lower else (global0 - lower_outside0) & _UINT256_MASK
-    below1 = lower_outside1 if tick >= lower else (global1 - lower_outside1) & _UINT256_MASK
-    above0 = upper_outside0 if tick < upper else (global0 - upper_outside0) & _UINT256_MASK
-    above1 = upper_outside1 if tick < upper else (global1 - upper_outside1) & _UINT256_MASK
-    inside0 = (global0 - below0 - above0) & _UINT256_MASK
-    inside1 = (global1 - below1 - above1) & _UINT256_MASK
-    lazy0 = liquidity * ((inside0 - fee_growth0_last) & _UINT256_MASK) // (1 << 128)
-    lazy1 = liquidity * ((inside1 - fee_growth1_last) & _UINT256_MASK) // (1 << 128)
-    return owed0 + lazy0, owed1 + lazy1, lazy0, lazy1
 
 
 def _interval_amounts(
@@ -3390,7 +3363,7 @@ class MarketService:
                 upper_fees = selection.participant_tick_fees.get(upper)
                 if lower_fees is None or upper_fees is None:
                     continue
-                claim0, claim1, lazy0, lazy1 = _v3_fee_claim(
+                claim0, claim1, lazy0, lazy1 = fee_claim(
                     int(state["liquidity"]),
                     int(state["fee_growth0_last"]),
                     int(state["fee_growth1_last"]),

--- a/tests/test_accounting_cache_regression.py
+++ b/tests/test_accounting_cache_regression.py
@@ -165,3 +165,184 @@ def test_pool_stats_respects_an_existing_reader_snapshot(inventory):
     assert book.pool_stats([POOL_ID])[POOL_ID]["observed_principal_usd"] == pytest.approx(
         before["observed_principal_usd"] * 2
     )
+
+
+APPEND_POSITION = "v4:deferred-append"
+
+
+def accounting_header(number):
+    return {
+        "number": hex(number),
+        "hash": "0x" + f"{number:064x}",
+        "parentHash": "0x" + f"{number - 1:064x}",
+        "timestamp": hex(1_700_000_000 + number),
+    }
+
+
+def accounting_state(liquidity):
+    return {
+        "liquidity": str(liquidity),
+        "tokens_owed0": "0",
+        "tokens_owed1": "0",
+        "claims_empty": True,
+    }
+
+
+def accounting_event(block, kind, liquidity_delta, before, after, usd):
+    adding = kind == "add"
+    cashflow = -100 if adding else 100
+    return {
+        "block_number": int(block["number"], 16),
+        "block_hash": block["hash"],
+        "tx_hash": "0x" + f"{int(block['number'], 16):064x}",
+        "tx_index": 0,
+        "log_index": 0,
+        "timestamp": int(block["timestamp"], 16),
+        "pool_id": None,
+        "protocol": "v4",
+        "kind": kind,
+        "owner": OWNER,
+        "custody": OWNER,
+        "position_key": APPEND_POSITION,
+        "token_id": "42",
+        "tick_lower": -10,
+        "tick_upper": 10,
+        "liquidity": str(after),
+        "liquidity_delta": str(liquidity_delta),
+        "amount0": "0",
+        "amount1": "0",
+        "cashflow0": str(cashflow),
+        "cashflow1": "0",
+        "fee_amount0": "0",
+        "fee_amount1": "0",
+        "deposit_usd": usd if adding else 0.0,
+        "withdrawal_usd": 0.0 if adding else usd,
+        "fees_usd": 0.0,
+        "accounting_basis": "complete v4 trace",
+        "identity_basis": "verified_owner",
+        "data": {
+            "position_before": accounting_state(before),
+            "position_after": accounting_state(after),
+            "trace_complete": True,
+            "fees_accrued_exact": True,
+            "principal_delta_exact": True,
+            "principal_delta": {
+                "amount0": str(cashflow),
+                "amount1": "0",
+            },
+        },
+    }
+
+
+def accounting_history():
+    blocks = [accounting_header(number) for number in range(100, 104)]
+    events = [
+        accounting_event(blocks[0], "add", 100, 0, 100, 1.0),
+        accounting_event(blocks[1], "remove", -100, 100, 0, 2.0),
+        accounting_event(blocks[2], "add", 200, 0, 200, 3.0),
+        accounting_event(blocks[3], "remove", -200, 200, 0, 4.0),
+    ]
+    return blocks, events
+
+
+def drain_accounting(book):
+    while book.project_pending(limit=32):
+        pass
+
+
+def accounting_projection(store):
+    reader = store.read()
+    return {
+        "positions": [
+            tuple(row) for row in reader.execute(
+                "SELECT * FROM lp_accounting_positions ORDER BY position_key"
+            )
+        ],
+        "episodes": [
+            tuple(row) for row in reader.execute(
+                "SELECT * FROM lp_accounting_episodes ORDER BY id"
+            )
+        ],
+        "effects": [
+            tuple(row) for row in reader.execute(
+                "SELECT * FROM lp_accounting_effects ORDER BY event_id"
+            )
+        ],
+        "ownership": [
+            tuple(row) for row in reader.execute(
+                "SELECT * FROM lp_ownership_intervals "
+                "ORDER BY position_key,ordinal"
+            )
+        ],
+    }
+
+
+def test_deferred_later_block_append_matches_full_synchronous_replay(tmp_path):
+    deferred = MarketStore(tmp_path / "deferred-append.sqlite")
+    full = MarketStore(tmp_path / "full-replay.sqlite")
+    deferred_book = AccountBook(deferred, deferred=True).install()
+    AccountBook(full).install()
+    try:
+        blocks, events = accounting_history()
+        deferred.ingest(blocks[:2], events[:2])
+        drain_accounting(deferred_book)
+        deferred.ingest(blocks[2:3], events[2:3])
+
+        drain_accounting(deferred_book)
+
+        full_blocks, full_events = accounting_history()
+        full.ingest(full_blocks[:3], full_events[:3])
+        assert accounting_projection(deferred) == accounting_projection(full)
+        assert deferred.read().execute(
+            "SELECT COUNT(*) FROM lp_accounting_effects"
+        ).fetchone()[0] == 3
+        assert deferred.read().execute(
+            "SELECT COUNT(*) FROM lp_accounting_episodes"
+        ).fetchone()[0] == 2
+    finally:
+        full.close()
+        deferred.close()
+
+
+def test_older_enrichment_mixed_with_new_events_forces_full_replay(tmp_path):
+    deferred = MarketStore(tmp_path / "mixed-deferred.sqlite")
+    synchronous = MarketStore(tmp_path / "mixed-synchronous.sqlite")
+    deferred_book = AccountBook(deferred, deferred=True).install()
+    AccountBook(synchronous).install()
+    try:
+        blocks, events = accounting_history()
+        inserted = deferred.ingest(blocks[:2], events[:2])
+        first_event_id = int(inserted[0]["id"])
+        drain_accounting(deferred_book)
+        deferred.ingest(blocks[2:3], events[2:3])
+
+        deferred.enrich([{
+            "id": first_event_id,
+            "deposit_usd": 9.0,
+            "accounting_basis": "same-order financial enrichment",
+        }])
+        deferred.ingest(blocks[3:], events[3:])
+        drain_accounting(deferred_book)
+
+        sync_blocks, sync_events = accounting_history()
+        sync_inserted = synchronous.ingest(sync_blocks[:2], sync_events[:2])
+        synchronous.ingest(sync_blocks[2:3], sync_events[2:3])
+        synchronous.enrich([{
+            "id": int(sync_inserted[0]["id"]),
+            "deposit_usd": 9.0,
+            "accounting_basis": "same-order financial enrichment",
+        }])
+        synchronous.ingest(sync_blocks[3:], sync_events[3:])
+
+        assert accounting_projection(deferred) == accounting_projection(
+            synchronous
+        )
+        first_episode = deferred.read().execute(
+            "SELECT deposit_usd FROM lp_accounting_episodes "
+            "WHERE position_key=? AND ordinal=1",
+            (APPEND_POSITION,),
+        ).fetchone()
+        assert first_episode["deposit_usd"] == pytest.approx(9.0)
+    finally:
+        synchronous.close()
+        deferred.close()

--- a/tests/test_identity_replay_queue.py
+++ b/tests/test_identity_replay_queue.py
@@ -7,6 +7,7 @@ def test_migrated_identity_queue_preserves_data_and_ready_order(tmp_path, monkey
     now = 1_700_000_000
     monkeypatch.setattr("rhpools.lp_market_index.time.time", lambda: now)
     path = tmp_path / "market.sqlite"
+    columns = "tx_hash,block_number,block_hash,attempts,next_attempt,last_error,created_at,updated_at"
     store = MarketStore(path)
     with store.transaction() as conn:
         store._set_metadata(conn, "epoch", 7)
@@ -25,7 +26,9 @@ def test_migrated_identity_queue_preserves_data_and_ready_order(tmp_path, monkey
                 (19, 0), (20, now), (21, -1), (22, now + 60), (23, now - 20),
             )
         )
-        conn.executemany("INSERT INTO pending_enrichment VALUES(?,?,?,?,?,?,?,?)", rows)
+        conn.executemany(
+            f"INSERT INTO pending_enrichment({columns}) VALUES(?,?,?,?,?,?,?,?)", rows,
+        )
         # Reconstruct the previous queue schema, then use the ordinary open path.
         conn.execute("DROP INDEX pending_enrichment_identity_immediate_idx")
         conn.execute("DROP INDEX pending_enrichment_identity_retry_ready_idx")
@@ -34,9 +37,10 @@ def test_migrated_identity_queue_preserves_data_and_ready_order(tmp_path, monkey
             "ON pending_enrichment(block_number,tx_hash,next_attempt) "
             "WHERE last_error GLOB 'pool_identity_pending:*'"
         )
+        conn.execute("ALTER TABLE pending_enrichment DROP COLUMN generation")
         conn.execute("PRAGMA user_version=3")
     before = [tuple(row) for row in store.read().execute(
-        "SELECT * FROM pending_enrichment ORDER BY block_number,tx_hash"
+        f"SELECT {columns} FROM pending_enrichment ORDER BY block_number,tx_hash"
     )]
     store.close()
 
@@ -45,7 +49,7 @@ def test_migrated_identity_queue_preserves_data_and_ready_order(tmp_path, monkey
     indexer.store = store
     try:
         assert [tuple(row) for row in store.read().execute(
-            "SELECT * FROM pending_enrichment ORDER BY block_number,tx_hash"
+            f"SELECT {columns} FROM pending_enrichment ORDER BY block_number,tx_hash"
         )] == before
         status = store.status()
         assert status["epoch"] == 7

--- a/tests/test_lp_market_claims.py
+++ b/tests/test_lp_market_claims.py
@@ -4,7 +4,9 @@ from copy import deepcopy
 import pytest
 
 from rhpools.lp_market_claims import fetch_position_claims
-from rhpools.lp_market_protocols import _selector, _v3_position_key, _v4_position_key
+from rhpools.lp_market_protocols import (
+    _selector, _v3_position_key, _v4_position_key, core_position_key,
+)
 from rhpools.lp_market_store import CanonicalConflict
 from test_lp_market_service import (
     TOKEN, V3, header, ingest_effects, lp_effect, pools, position_state, service, swap,
@@ -25,10 +27,12 @@ def test_lazy_fees_unlock_open_equity_and_net_pnl_at_a_canonical_pin(tmp_path, p
             opened_block, protocol, "add", 1_000_000, (1_000, 1_000),
             position_state(0), position_state(1_000_000),
         )
-        opened["position_key"] = (
+        raw_key = (
             _v3_position_key(TOKEN, -10, 10) if protocol == "v3"
             else _v4_position_key(TOKEN, -10, 10, "0x" + "00" * 32)
         )
+        opened["position_key"] = core_position_key(protocol, opened["pool_id"], raw_key)
+        opened["data"]["core_position_key"] = raw_key
         opened.update(fee_amount0="0", fee_amount1="0")
         opened["data"].update(
             trace_complete=True, fees_accrued_exact=True, principal_delta_exact=True,

--- a/tests/test_lp_market_claims.py
+++ b/tests/test_lp_market_claims.py
@@ -1,0 +1,167 @@
+"""Current claims must unlock exact equity without another LP action."""
+from copy import deepcopy
+
+import pytest
+
+from rhpools.lp_market_claims import fetch_position_claims
+from rhpools.lp_market_protocols import _selector, _v3_position_key, _v4_position_key
+from rhpools.lp_market_store import CanonicalConflict
+from test_lp_market_service import (
+    TOKEN, V3, header, ingest_effects, lp_effect, pools, position_state, service, swap,
+)
+
+
+def abi(*words):
+    return "0x" + "".join((word % (1 << 256)).to_bytes(32, "big").hex() for word in words)
+
+
+@pytest.mark.parametrize("protocol", ["v3", "v4"])
+def test_lazy_fees_unlock_open_equity_and_net_pnl_at_a_canonical_pin(tmp_path, protocol):
+    app = service(tmp_path / "claims.sqlite")
+    try:
+        app.store.upsert_pools(pools())
+        opened_block, pin = header(100, 1_000), header(101, 1_001)
+        opened = lp_effect(
+            opened_block, protocol, "add", 1_000_000, (1_000, 1_000),
+            position_state(0), position_state(1_000_000),
+        )
+        opened["position_key"] = (
+            _v3_position_key(TOKEN, -10, 10) if protocol == "v3"
+            else _v4_position_key(TOKEN, -10, 10, "0x" + "00" * 32)
+        )
+        opened.update(fee_amount0="0", fee_amount1="0")
+        opened["data"].update(
+            trace_complete=True, fees_accrued_exact=True, principal_delta_exact=True,
+            principal_delta={"amount0": "-1000", "amount1": "-1000"},
+        )
+        app.store.ingest([opened_block, pin], [opened], cursor={
+            "from_block": 100, "to_block": 101, "block_number": 101,
+            "block_hash": pin["hash"], "timestamp": 1_001,
+        }, transactions=[{
+            "tx_hash": opened["tx_hash"], "block_number": 100,
+            "block_hash": opened_block["hash"], "payer": TOKEN, "gas_usd": 0.01,
+        }])
+        position = dict(app.store.read().execute("SELECT * FROM lp_accounting_positions").fetchone())
+        before = app.book.owner(TOKEN, {"window": "all"})["summary"]
+        assert before["net_pnl_usd"] is None
+
+        responses = {
+            _selector("positions(bytes32)"): abi(1_000_000, 0, 0, 0, 0),
+            _selector("slot0()"): abi(1 << 96, 0, 0, 0, 0, 0, 1),
+            _selector("liquidity()"): abi(1_000_000),
+            _selector("feeGrowthGlobal0X128()"): abi(1 << 128),
+            _selector("feeGrowthGlobal1X128()"): abi(2 << 128),
+            _selector("ticks(int24)"): abi(1_000_000, 0, 0, 0, 0, 0, 0, 1),
+            _selector("getPositionInfo(bytes32,bytes32)"): abi(1_000_000, 0, 0),
+            _selector("getSlot0(bytes32)"): abi(1 << 96, 0, 0, 3_000),
+            _selector("getLiquidity(bytes32)"): abi(1_000_000),
+            _selector("getFeeGrowthInside(bytes32,int24,int24)"): abi(1 << 128, 2 << 128),
+        }
+
+        class PinnedRpc:
+            block_hash = pin["hash"]
+
+            def batch(self, calls, **_kwargs):
+                return [responses[params[0]["data"][:10]] for _method, params in calls]
+
+            def call(self, _method, _params):
+                return {**pin, "hash": self.block_hash}
+
+        client = PinnedRpc()
+        claims = fetch_position_claims(app.store, app.book, app.prices, client, [position])
+        assert app.book.publish_claims(claims)
+        detail = app.book.owner(TOKEN, {"window": "all"})
+        assert detail["summary"]["net_pnl_usd"] == pytest.approx(2.988998)
+        assert detail["positions"][0]["equity_usd"] == pytest.approx(3.000998)
+        assert detail["positions"][0]["valuation_block"] == 101
+
+        corrected = deepcopy(opened)
+        corrected.update(amount0="2000", cashflow0="-2000")
+        corrected["data"]["principal_delta"]["amount0"] = "-2000"
+        app.store.enrich([corrected])
+        assert app.book.owner(TOKEN, {"window": "all"})["summary"]["net_pnl_usd"] is None
+        assert not app.book.publish_claims(claims)
+        position = dict(app.store.read().execute("SELECT * FROM lp_accounting_positions").fetchone())
+        refreshed = fetch_position_claims(app.store, app.book, app.prices, client, [position])
+        assert app.book.publish_claims(refreshed)
+        assert app.book.owner(TOKEN, {"window": "all"})["summary"]["net_pnl_usd"] == pytest.approx(2.987998)
+
+        pin = header(102, 1_002)
+        app.store.ingest([pin], [], cursor={
+            "from_block": 102, "to_block": 102, "block_number": 102,
+            "block_hash": pin["hash"], "timestamp": 1_002,
+        })
+        client.block_hash = pin["hash"]
+        responses[_selector("liquidity()")] = abi(0)
+        responses[_selector("getLiquidity(bytes32)")] = abi(0)
+        for selector in ("slot0()", "getSlot0(bytes32)"):
+            responses[_selector(selector)] = abi((1 << 160) - 1, 887271, 0, 0, 0, 0, 1)
+        empty = fetch_position_claims(app.store, app.book, app.prices, client, [position])
+        # A prior trusted mark is usable; the empty pool's arbitrary limit is not.
+        assert empty[0]["price0_usd"] is None or empty[0]["price0_usd"] == pytest.approx(1.0)
+
+        client.block_hash = "0x" + "ff" * 32
+        with pytest.raises(CanonicalConflict):
+            fetch_position_claims(app.store, app.book, app.prices, client, [position])
+        app.store.rollback(100)
+        assert app.book.owner(TOKEN, {"window": "all"})["summary"]["net_pnl_usd"] is None
+    finally:
+        app.close()
+
+
+def test_every_wallet_on_a_full_owner_page_receives_recovery_work(tmp_path):
+    app = service(tmp_path / "visible-wallets.sqlite")
+    try:
+        owners = [f"0x{number:040x}" for number in range(1, 201)]
+        app.claims.request(owners)
+        scheduled = [app.claims._next()[0] for _ in owners]
+        assert set(scheduled) == set(owners)
+    finally:
+        app.close()
+
+
+def test_rollback_does_not_publish_orphan_prices_for_surviving_claims(tmp_path):
+    app = service(tmp_path / "claim-rollback.sqlite")
+    try:
+        app.store.upsert_pools(pools())
+        blocks = [header(100 + index, 1_000 + index) for index in range(4)]
+        opened = lp_effect(
+            blocks[0], "v3", "add", 1_000, (1_000, 1_000),
+            position_state(0), position_state(1_000),
+        )
+        removed = lp_effect(
+            blocks[1], "v3", "remove", -1_000, (1_000, 1_000),
+            position_state(1_000), position_state(0, 1_200, 1_000),
+        )
+        ingest_effects(app, blocks[:2], [opened, removed])
+        canonical = swap(blocks[2], V3, "v3")
+        canonical["sqrt_price_x96"] = str(2 << 96)
+        app.store.ingest([blocks[2]], [canonical])
+        position = dict(app.store.read().execute("SELECT * FROM lp_accounting_positions").fetchone())
+        claim = {
+            "position_key": position["position_key"], "epoch": 0,
+            "block_number": 102, "block_hash": blocks[2]["hash"], "timestamp": 1_002,
+            "position_last_block": position["last_block"],
+            "position_last_tx_index": position["last_tx_index"],
+            "position_last_log_index": position["last_log_index"],
+            "position_pending_principal0": position["pending_principal0"],
+            "position_pending_principal1": position["pending_principal1"],
+            "position_pending_known": position["pending_known"],
+            "position_state_json": position["state_json"],
+            "liquidity": "0", "sqrt_price_x96": str(2 << 96), "tick": 13_863,
+            "price0_usd": 4.0, "price1_usd": 1.0, "claim0": "1200", "claim1": "1000",
+        }
+        assert app.book.publish_claims([claim])
+        params = {"window": "all", "identity_scope": "wallets"}
+        verified = app.book.owner_candidates(params)["rows"][0]["gross_pnl_usd"]
+        assert verified == pytest.approx(0.0038)
+        orphan = swap(blocks[3], V3, "v3")
+        orphan["sqrt_price_x96"] = str(3 << 96)
+        app.store.ingest([blocks[3]], [orphan])
+        app.store.rollback(102)
+        assert app.book.owner_candidates(params)["rows"][0]["gross_pnl_usd"] is None
+        claim["epoch"] = app.store.status()["epoch"]
+        assert app.book.publish_claims([claim])
+        assert app.book.owner_candidates(params)["rows"][0]["gross_pnl_usd"] == pytest.approx(verified)
+    finally:
+        app.close()

--- a/tests/test_lp_market_index.py
+++ b/tests/test_lp_market_index.py
@@ -611,6 +611,7 @@ def test_live_gap_and_v4_trace_cannot_block_v3_position_accounting(
 def test_small_trace_refills_rotate_history_requested_and_recent(monkeypatch):
     from concurrent.futures import Future
 
+    monkeypatch.setattr("rhpools.lp_market_index.ENRICH_TRACE_INFLIGHT_LIMIT", 8)
     store = MarketStore(":memory:")
     scanner = indexer(store)
     numbers = [*range(1, 257), 500, 699, 700, 701]
@@ -1007,10 +1008,6 @@ def test_history_defers_cold_pool_identity_to_current_canonical_state(monkeypatc
         )
 
         assert scanner._resolve_deferred_pool_identities_once() is True
-        assert scanner._resolve_deferred_pool_identities_once() is True
-        assert rpc.call_tags
-        assert set(rpc.call_tags) == {hex(current_block)}
-        assert rpc.current_header_reads >= 2
 
         event = store.read().execute(
             "SELECT pool_id,protocol,kind FROM events WHERE tx_hash=?",
@@ -1372,6 +1369,161 @@ def test_metadata_and_balance_batches_isolate_invalid_tokens(tmp_path):
         ] == [(reverting_pool, 1)]
         assert store.status()["pending_balances"] == 1
     finally:
+        scanner.close()
+        store.close()
+
+
+def test_balance_multicall_keeps_pins_failures_and_zero_distinct(tmp_path):
+    from eth_abi import decode as abi_decode, encode as abi_encode
+
+    token, quote, invalid = ("0x" + byte * 20 for byte in ("11", "22", "33"))
+    healthy_pool, reverting_pool = ("0x" + byte * 20 for byte in ("44", "55"))
+    blocks = {header(number)["hash"]: number for number in (9, 10)}
+
+    class SnapshotRpc(StaticRpc):
+        def batch(self, calls, *, allow_reverts=False):
+            return [self.call(method, params) for method, params in calls]
+
+        def call(self, method, params):
+            if method != "eth_call":
+                return super().call(method, params)
+            request, pin = params
+            assert pin["requireCanonical"] is True
+            number = blocks[pin["blockHash"]]
+            packed = abi_decode(
+                ["(address,bool,bytes)[]"], bytes.fromhex(request["data"][10:]),
+            )[0]
+            values = []
+            for target, _allow_failure, _data in packed:
+                if target == invalid and number == 9:
+                    values.append((False, b""))
+                else:
+                    value = 0 if number == 10 and target == token else number * 100
+                    values.append((True, value.to_bytes(32, "big")))
+            return "0x" + abi_encode(["(bool,bytes)[]"], [values]).hex()
+
+    store = MarketStore(tmp_path / "pinned-balances.sqlite")
+    scanner = indexer(store, SnapshotRpc(), v3_balances=True)
+    try:
+        store.upsert_pools([
+            {
+                "id": pool_id, "protocol": "v3", "address": pool_id,
+                "token0": asset, "token1": quote,
+            }
+            for pool_id, asset in (
+                (healthy_pool, token), (reverting_pool, invalid),
+            )
+        ])
+        store.ingest([header(9), header(10)], [])
+        for number in (9, 10):
+            store.queue_v3_balances(
+                [healthy_pool, reverting_pool], number, header(number)["hash"],
+            )
+        scanner._balances_once()
+        assert [
+            tuple(row) for row in store.read().execute(
+                "SELECT pool_id,block_number,balance0,balance1 FROM pool_balances "
+                "ORDER BY pool_id,block_number"
+            )
+        ] == [
+            (healthy_pool, 9, "900", "900"),
+            (healthy_pool, 10, "0", "1000"),
+            (reverting_pool, 10, "1000", "1000"),
+        ]
+        assert [
+            tuple(row) for row in store.read().execute(
+                "SELECT pool_id,block_number FROM pending_balances"
+            )
+        ] == [(reverting_pool, 9)]
+        metadata = json.loads(store.pool(healthy_pool)["metadata_json"])
+        assert (metadata["balance_block"], metadata["balance0"]) == (10, "0")
+    finally:
+        scanner.close()
+        store.close()
+
+def test_balance_lane_ignores_projection_checkpoint_and_isolates_reorg(
+    tmp_path, monkeypatch,
+):
+    token0, token1 = ("0x" + byte * 20 for byte in ("11", "22"))
+    healthy_pool, orphaned_pool = ("0x" + byte * 20 for byte in ("33", "44"))
+    checkpoint_started = threading.Event()
+    release_checkpoint = threading.Event()
+    balance_started = threading.Event()
+    release_balance = threading.Event()
+    created = {}
+
+    class LaneRpc:
+        def __init__(self, lane):
+            self.lane = lane
+
+        def call(self, method, params):
+            if method == "eth_chainId":
+                return hex(4663)
+            if method == "eth_call":
+                return hex(1_000_000)
+            raise AssertionError((self.lane, method))
+
+        def batch(self, calls, *, allow_reverts=False):
+            if self.lane == "balance":
+                balance_started.set()
+                assert release_balance.wait(2)
+            return [self.call(method, params) for method, params in calls]
+
+        def close(self):
+            pass
+
+    def factory(lane):
+        client = LaneRpc(lane)
+        created.setdefault(lane, []).append(client)
+        return client
+
+    def blocked_checkpoint():
+        checkpoint_started.set()
+        assert release_checkpoint.wait(2)
+
+    store = MarketStore(tmp_path / "balance-reorg.sqlite")
+    scanner = indexer(store, factory, v3_balances=True)
+    healthy_block = header(10)
+    orphaned_block = header(11, parent=healthy_block["hash"])
+    store.upsert_pools([
+        {
+            "id": pool_id, "protocol": "v3", "address": pool_id,
+            "token0": token0, "token1": token1,
+        }
+        for pool_id in (healthy_pool, orphaned_pool)
+    ])
+    store.ingest([healthy_block, orphaned_block], [])
+    store.queue_v3_balances([healthy_pool], 10, healthy_block["hash"])
+    store.queue_v3_balances([orphaned_pool], 11, orphaned_block["hash"])
+    monkeypatch.setattr(store, "checkpoint", blocked_checkpoint)
+    scanner._initialized.set()
+    workers = [
+        threading.Thread(target=scanner._projection_run),
+        threading.Thread(target=scanner._balance_run),
+    ]
+    scanner._threads.extend(workers)
+    for worker in workers:
+        worker.start()
+    try:
+        assert checkpoint_started.wait(1)
+        assert balance_started.wait(1), (
+            "balance RPC waited for the projection checkpoint"
+        )
+        store.rollback(10)
+        release_balance.set()
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and store.status()["pending_balances"]:
+            time.sleep(0.01)
+        assert [
+            tuple(row) for row in store.read().execute(
+                "SELECT pool_id,block_number FROM pool_balances "
+                "ORDER BY pool_id,block_number"
+            )
+        ] == [(healthy_pool, 10)]
+        assert store.status()["pending_balances"] == 0
+    finally:
+        release_balance.set()
+        release_checkpoint.set()
         scanner.close()
         store.close()
 

--- a/tests/test_lp_market_index.py
+++ b/tests/test_lp_market_index.py
@@ -648,12 +648,15 @@ def test_history_progress_is_independent_of_unrunnable_enrichment(monkeypatch):
     )
     monkeypatch.setattr(scanner, "_decode", lambda *_args, **_kwargs: [])
     try:
-        assert scanner._scan_history_once() is True
         cursor = store.cursor("history")
+        while not cursor["complete"]:
+            previous_next = cursor["next_to"]
+            assert scanner._scan_history_once() is True
+            cursor = store.cursor("history")
+            assert previous_next > cursor["next_to"] >= 399
         assert cursor["next_to"] == 399
         assert cursor["complete"] is True
-        status = scanner.runtime_status()["history_scan"]
-        assert status["blocks"] == 100
+        assert store.status()["pending_enrichment"] == 5_000
     finally:
         scanner.close()
         store.close()
@@ -681,8 +684,7 @@ def test_recent_ledger_gap_yields_history_until_live_progresses():
         assert scanner._scan_live_once() is True
         assert store.cursor("live")["block_number"] > 500
         assert scanner._scan_history_once() is True
-        assert store.cursor("history")["next_to"] == 399
-        assert store.cursor("history")["complete"] is True
+        assert store.cursor("history")["next_to"] < 499
     finally:
         scanner.close()
         store.close()

--- a/tests/test_lp_market_index.py
+++ b/tests/test_lp_market_index.py
@@ -10,9 +10,12 @@ import pytest
 
 from rhpools.lp_market_index import (
     FACTORY_SELECTOR,
+    FEE_SELECTOR,
     GET_PAIR_SELECTOR,
+    TICK_SPACING_SELECTOR,
     TOKEN0_SELECTOR,
     TOKEN1_SELECTOR,
+    V4_POOL_KEYS_SELECTOR,
     MarketIndexer,
     RpcError,
 )
@@ -23,6 +26,7 @@ from rhpools.lp_market_protocols import (
     POOL_MANAGER,
     TRANSFER_TOPIC,
     V4_MODIFY_LIQUIDITY_TOPIC,
+    V4_POSITION_MANAGER,
 )
 
 
@@ -772,8 +776,8 @@ def test_history_progress_is_independent_of_unrunnable_enrichment(monkeypatch):
         store.close()
 
 
-@pytest.mark.parametrize("live_head", [501, 1_100])
-def test_recent_ledger_gap_yields_history_until_live_progresses(live_head):
+def test_history_prioritizes_large_live_gaps_without_starving_at_tip():
+    live_head = 1_100
     store = MarketStore(":memory:")
     scanner = indexer(store, StaticRpc(live_head))
     scanner._history_verified = True
@@ -795,10 +799,19 @@ def test_recent_ledger_gap_yields_history_until_live_progresses(live_head):
         assert scanner._scan_live_once() is True
         assert store.cursor("live")["block_number"] > 500
         while store.cursor("live")["block_number"] < live_head:
-            assert scanner._scan_history_once() is False
             assert scanner._scan_live_once() is True
-        assert scanner._scan_history_once() is True
-        assert store.cursor("history")["next_to"] < 499
+        for number in range(live_head + 1, live_head + 4):
+            # A continuously advancing head is never exactly equal to the
+            # durable cursor when the history worker gets scheduled.
+            scanner._set_runtime("head", head=number)
+            previous = store.cursor("history")["next_to"]
+            assert scanner._scan_history_once() is True
+            assert store.cursor("history")["next_to"] < previous
+            tip = header(number)
+            store.ingest([tip], [], lane="live", cursor={
+                "block_number": number, "block_hash": tip["hash"],
+                "timestamp": int(tip["timestamp"], 16),
+            })
     finally:
         scanner.close()
         store.close()
@@ -841,13 +854,23 @@ def test_live_health_publishes_while_another_lane_holds_writer():
 def test_requested_identity_replay_keeps_regular_enrichment_interest(monkeypatch):
     store = MarketStore(":memory:")
     scanner = indexer(store)
-    identity_marker = scanner._encode_pool_identity_marker({
-        "addresses": ["0x" + "12" * 20],
-        "logs": [],
-    })
+    def identity_marker(number):
+        block = header(number)
+        return scanner._encode_pool_identity_marker({
+            "addresses": ["0x" + "12" * 20],
+            "logs": [{
+                "address": "0x" + "12" * 20,
+                "topics": [V2_SYNC_TOPIC],
+                "data": "0x" + f"{123:064x}{456:064x}",
+                "blockNumber": block["number"], "blockHash": block["hash"],
+                "transactionHash": "0x" + f"{number:064x}",
+                "transactionIndex": "0x0", "logIndex": "0x0",
+            }],
+        })
     target_tx = "0x" + f"{50:064x}"
     regular_tx = "0x" + f"{51:064x}"
     identity_numbers = [*range(1, 33), 50, *range(68, 100)]
+    store.ingest([header(number) for number in sorted([*identity_numbers, 51])], [])
     now = time.time()
     with store.transaction() as connection:
         connection.executemany(
@@ -861,7 +884,7 @@ def test_requested_identity_replay_keeps_regular_enrichment_interest(monkeypatch
                     header(number)["hash"],
                     0,
                     0,
-                    identity_marker,
+                    identity_marker(number),
                     now,
                     now,
                 )
@@ -941,6 +964,8 @@ def test_history_defers_cold_pool_identity_to_current_canonical_state(monkeypatc
                 if target == spoof_pool:
                     return word("0x" + "00" * 20)
                 if target == valid_pool:
+                    if selector in {FEE_SELECTOR, TICK_SPACING_SELECTOR}:
+                        raise RpcError("execution reverted", code=3)
                     return {
                         FACTORY_SELECTOR: word(factory),
                         TOKEN0_SELECTOR: word(token0),
@@ -1040,6 +1065,375 @@ def test_history_defers_cold_pool_identity_to_current_canonical_state(monkeypatc
     finally:
         scanner.close()
         store.close()
+
+
+def test_deferred_identity_batch_preserves_transient_part_of_mixed_row(
+    monkeypatch,
+):
+    valid_pool = "0x" + "12" * 20
+    invalid_pool = "0x" + "13" * 20
+    transient_v4 = "0x" + "14" * 32
+    token0 = "0x" + "21" * 20
+    token1 = "0x" + "23" * 20
+    factory = sorted(V2_FACTORIES)[0]
+    tx_hash = "0x" + "31" * 32
+    block = header(9)
+
+    def address_word(address):
+        return "0x" + address[2:].rjust(64, "0")
+
+    def sync_log(address, index):
+        return {
+            "address": address,
+            "topics": [V2_SYNC_TOPIC],
+            "data": "0x" + f"{123:064x}{456:064x}",
+            "blockNumber": block["number"],
+            "blockHash": block["hash"],
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x0",
+            "logIndex": hex(index),
+            "removed": False,
+        }
+
+    v4_log = {
+        "address": POOL_MANAGER,
+        "topics": [
+            V4_MODIFY_LIQUIDITY_TOPIC,
+            transient_v4,
+            "0x" + f"{int('0x' + '45' * 20, 16):064x}",
+        ],
+        "data": "0x" + "".join(
+            f"{value & ((1 << 256) - 1):064x}"
+            for value in (-10, 10, 100, 7)
+        ),
+        "blockNumber": block["number"],
+        "blockHash": block["hash"],
+        "transactionHash": tx_hash,
+        "transactionIndex": "0x0",
+        "logIndex": "0x2",
+        "removed": False,
+    }
+
+    class MixedIdentityRpc(StaticRpc):
+        def __init__(self):
+            super().__init__(100)
+
+        def call(self, method, params):
+            if method == "eth_call":
+                request, tag = params
+                assert tag == hex(self.head)
+                target = request["to"].lower()
+                selector = request["data"][:10]
+                if target == V4_POSITION_MANAGER:
+                    return "0x" + "00" * 160
+                if target == invalid_pool:
+                    return address_word("0x" + "00" * 20)
+                if target == valid_pool:
+                    if selector in {FEE_SELECTOR, TICK_SPACING_SELECTOR}:
+                        raise RpcError("execution reverted", code=3)
+                    return {
+                        FACTORY_SELECTOR: address_word(factory),
+                        TOKEN0_SELECTOR: address_word(token0),
+                        TOKEN1_SELECTOR: address_word(token1),
+                    }[selector]
+                if target == factory and selector == GET_PAIR_SELECTOR:
+                    return address_word(valid_pool)
+                raise AssertionError((target, selector))
+            if method in {
+                "eth_getTransactionByHash", "eth_getTransactionReceipt",
+            }:
+                raise RpcError("transaction transport unavailable")
+            return super().call(method, params)
+
+    store = MarketStore(":memory:")
+    scanner = indexer(store, MixedIdentityRpc())
+    monkeypatch.setattr(scanner, "_seed_deferred_v4_pool_identities", lambda: 0)
+    logs = [sync_log(valid_pool, 0), sync_log(invalid_pool, 1), v4_log]
+    try:
+        store.ingest([block], [])
+        with store.transaction() as connection:
+            assert scanner._queue_deferred_pool_identities(
+                connection, logs, (),
+            ) == 1
+
+        assert scanner._resolve_deferred_pool_identities_once() is True
+
+        event = store.read().execute(
+            "SELECT pool_id,protocol FROM events WHERE tx_hash=?",
+            (tx_hash,),
+        ).fetchone()
+        assert tuple(event) == (valid_pool, "v2")
+        assert store.pool(valid_pool) is not None
+        assert store.pool(invalid_pool) is None
+        assert store.pool(transient_v4) is None
+        pending = store.read().execute(
+            "SELECT next_attempt,last_error FROM pending_enrichment "
+            "WHERE tx_hash=?",
+            (tx_hash,),
+        ).fetchone()
+        marker = scanner._pool_identity_marker(pending["last_error"])
+        assert marker["addresses"] == [transient_v4]
+        assert len(marker["logs"]) == 1
+        assert pending["next_attempt"] > time.time()
+    finally:
+        scanner.close()
+        store.close()
+
+
+def test_deferred_identity_batch_keeps_all_rows_when_anchor_changes(monkeypatch):
+    pools = ("0x" + "31" * 20, "0x" + "32" * 20)
+    tokens = {
+        pools[0]: ("0x" + "41" * 20, "0x" + "42" * 20),
+        pools[1]: ("0x" + "43" * 20, "0x" + "44" * 20),
+    }
+    factory = sorted(V2_FACTORIES)[0]
+    transactions = ("0x" + "51" * 32, "0x" + "52" * 32)
+    current_number = 100
+
+    def address_word(address):
+        return "0x" + address[2:].rjust(64, "0")
+
+    def sync_log(pool_id, tx_hash, number):
+        block = header(number)
+        return {
+            "address": pool_id,
+            "topics": [V2_SYNC_TOPIC],
+            "data": "0x" + f"{123:064x}{456:064x}",
+            "blockNumber": block["number"],
+            "blockHash": block["hash"],
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x0",
+            "logIndex": "0x0",
+            "removed": False,
+        }
+
+    membership = {
+        GET_PAIR_SELECTOR
+        + token0[2:].rjust(64, "0")
+        + token1[2:].rjust(64, "0"): pool_id
+        for pool_id, (token0, token1) in tokens.items()
+    }
+
+    class ReorgingIdentityRpc(StaticRpc):
+        def __init__(self):
+            super().__init__(current_number)
+            self.current_reads = 0
+
+        def call(self, method, params):
+            if method == "eth_getBlockByNumber":
+                number = int(params[0], 16)
+                block = header(number)
+                if number == current_number:
+                    self.current_reads += 1
+                    if self.current_reads > 1:
+                        block["hash"] = "0x" + "aa" * 32
+                return block
+            if method == "eth_call":
+                request, tag = params
+                assert tag == hex(current_number)
+                target = request["to"].lower()
+                selector = request["data"][:10]
+                if target in tokens:
+                    if selector in {FEE_SELECTOR, TICK_SPACING_SELECTOR}:
+                        raise RpcError("execution reverted", code=3)
+                    token0, token1 = tokens[target]
+                    return {
+                        FACTORY_SELECTOR: address_word(factory),
+                        TOKEN0_SELECTOR: address_word(token0),
+                        TOKEN1_SELECTOR: address_word(token1),
+                    }[selector]
+                if target == factory:
+                    return address_word(membership[request["data"]])
+                raise AssertionError((target, selector))
+            return super().call(method, params)
+
+    store = MarketStore(":memory:")
+    scanner = indexer(store, ReorgingIdentityRpc())
+    monkeypatch.setattr(scanner, "_seed_deferred_v4_pool_identities", lambda: 0)
+    logs = [
+        sync_log(pool_id, tx_hash, number)
+        for pool_id, tx_hash, number in zip(pools, transactions, (9, 10))
+    ]
+    try:
+        store.ingest([header(9), header(10)], [])
+        with store.transaction() as connection:
+            assert scanner._queue_deferred_pool_identities(
+                connection, logs, (),
+            ) == 2
+
+        assert scanner._resolve_deferred_pool_identities_once() is True
+
+        assert store.read().execute(
+            "SELECT COUNT(*) FROM events WHERE tx_hash IN (?,?)",
+            transactions,
+        ).fetchone()[0] == 0
+        assert all(store.pool(pool_id) is None for pool_id in pools)
+        queued = store.read().execute(
+            "SELECT next_attempt,last_error FROM pending_enrichment "
+            "WHERE tx_hash IN (?,?) ORDER BY tx_hash",
+            transactions,
+        ).fetchall()
+        assert len(queued) == 2
+        assert all(row["next_attempt"] > time.time() for row in queued)
+        assert all(
+            scanner._pool_identity_marker(row["last_error"]) is not None
+            for row in queued
+        )
+    finally:
+        scanner.close()
+        store.close()
+
+
+def test_v4_identity_batch_replays_duplicates_and_yields_to_current_lane(
+    monkeypatch,
+):
+    from eth_utils import keccak
+
+    token0 = "0x" + "11" * 20
+    token1 = "0x" + "22" * 20
+    hook = "0x" + "33" * 20
+    current_token1 = "0x" + "44" * 20
+
+    def pool_key(second_token):
+        values = (token0, second_token, 3000, 8, hook)
+        raw = b"".join(
+            (value if isinstance(value, int) else int(value, 16)).to_bytes(
+                32, "big",
+            )
+            for value in values
+        )
+        return "0x" + keccak(raw).hex(), raw
+
+    duplicate_pool, duplicate_key = pool_key(token1)
+    current_pool, current_key = pool_key(current_token1)
+    invalid_pool = "0x" + "99" * 32
+    transactions = {
+        duplicate_pool: ("0x" + "61" * 32, "0x" + "62" * 32),
+        invalid_pool: ("0x" + "63" * 32,),
+        current_pool: ("0x" + "64" * 32,),
+    }
+
+    def v4_log(pool_id, tx_hash, number):
+        block = header(number)
+
+        def word(value):
+            return f"{value & ((1 << 256) - 1):064x}"
+
+        return {
+            "address": POOL_MANAGER,
+            "topics": [
+                V4_MODIFY_LIQUIDITY_TOPIC,
+                pool_id,
+                "0x" + word(int("0x" + "55" * 20, 16)),
+            ],
+            "data": "0x" + "".join(
+                word(value) for value in (-10, 10, 100, 7)
+            ),
+            "blockNumber": block["number"],
+            "blockHash": block["hash"],
+            "transactionHash": tx_hash,
+            "transactionIndex": "0x0",
+            "logIndex": "0x0",
+            "removed": False,
+        }
+
+    logs = [
+        v4_log(duplicate_pool, transactions[duplicate_pool][0], 9),
+        v4_log(duplicate_pool, transactions[duplicate_pool][1], 10),
+        v4_log(invalid_pool, transactions[invalid_pool][0], 11),
+        v4_log(current_pool, transactions[current_pool][0], 12),
+    ]
+    getter_results = {
+        V4_POOL_KEYS_SELECTOR + duplicate_pool[2:52] + "00" * 7:
+            duplicate_key,
+        V4_POOL_KEYS_SELECTOR + invalid_pool[2:52] + "00" * 7:
+            duplicate_key,
+        V4_POOL_KEYS_SELECTOR + current_pool[2:52] + "00" * 7:
+            current_key,
+    }
+    invalid_tx = {
+        "hash": transactions[invalid_pool][0],
+        "blockHash": header(11)["hash"],
+        "blockNumber": header(11)["number"],
+        "input": "0x",
+    }
+    invalid_receipt = {
+        "transactionHash": transactions[invalid_pool][0],
+        "blockHash": header(11)["hash"],
+        "logs": [logs[2]],
+    }
+
+    class V4IdentityRpc(StaticRpc):
+        def __init__(self):
+            super().__init__(100)
+
+        def call(self, method, params):
+            if method == "eth_call":
+                request, tag = params
+                assert tag == hex(self.head)
+                if request["to"].lower() != V4_POSITION_MANAGER:
+                    raise AssertionError(request["to"])
+                return "0x" + getter_results[request["data"]].hex()
+            if method == "eth_getTransactionByHash":
+                assert params == [transactions[invalid_pool][0]]
+                return invalid_tx
+            if method == "eth_getTransactionReceipt":
+                assert params == [transactions[invalid_pool][0]]
+                return invalid_receipt
+            return super().call(method, params)
+
+    store = MarketStore(":memory:")
+    scanner = indexer(store, V4IdentityRpc())
+    monkeypatch.setattr(scanner, "_seed_deferred_v4_pool_identities", lambda: 0)
+    try:
+        store.ingest([header(number) for number in range(9, 13)], [])
+        with store.transaction() as connection:
+            assert scanner._queue_deferred_pool_identities(
+                connection, logs, (),
+            ) == 4
+        with scanner._current_receipt_lock:
+            scanner._current_pool_pending.add(current_pool)
+
+        assert scanner._resolve_deferred_pool_identities_once() is True
+
+        replayed = store.read().execute(
+            "SELECT tx_hash,pool_id FROM events WHERE tx_hash IN (?,?,?,?) "
+            "ORDER BY tx_hash",
+            tuple(
+                tx_hash
+                for pool_transactions in transactions.values()
+                for tx_hash in pool_transactions
+            ),
+        ).fetchall()
+        assert [tuple(row) for row in replayed] == [
+            (transactions[duplicate_pool][0], duplicate_pool),
+            (transactions[duplicate_pool][1], duplicate_pool),
+            (transactions[invalid_pool][0], invalid_pool),
+        ]
+        assert store.pool(duplicate_pool)["source"] == "PositionManager.poolKeys"
+        assert store.pool(invalid_pool) is None
+        waiting = store.read().execute(
+            "SELECT tx_hash,last_error FROM pending_enrichment "
+            "WHERE last_error GLOB 'pool_identity_pending:*'"
+        ).fetchall()
+        assert [row["tx_hash"] for row in waiting] == [
+            transactions[current_pool][0]
+        ]
+        marker = scanner._pool_identity_marker(waiting[0]["last_error"])
+        assert marker["addresses"] == [current_pool]
+
+        with scanner._current_receipt_lock:
+            scanner._current_pool_pending.remove(current_pool)
+        assert scanner._resolve_deferred_pool_identities_once() is True
+        assert store.read().execute(
+            "SELECT pool_id FROM events WHERE tx_hash=?",
+            (transactions[current_pool][0],),
+        ).fetchone()["pool_id"] == current_pool
+        assert store.pool(current_pool)["source"] == "PositionManager.poolKeys"
+    finally:
+        scanner.close()
+        store.close()
+
 
 
 @pytest.mark.parametrize("lane", ["live", "history"])

--- a/tests/test_lp_market_index.py
+++ b/tests/test_lp_market_index.py
@@ -999,6 +999,14 @@ def test_scans_durably_replay_unregistered_v4_pool_keys(
         marker = scanner._pool_identity_marker(queued["last_error"])
         assert marker["addresses"] == [pool_id]
         assert store.pool(pool_id) is None
+        store.mark_enrichment_error(tx_hash, queued["last_error"], delay=60)
+        waiting = dict(store.read().execute(
+            "SELECT * FROM pending_enrichment WHERE tx_hash=?", (tx_hash,),
+        ).fetchone())
+        assert scanner._resolve_deferred_pool_identities_once() is False
+        assert dict(store.read().execute(
+            "SELECT * FROM pending_enrichment WHERE tx_hash=?", (tx_hash,),
+        ).fetchone()) == waiting
         # Simulate a database populated by an older indexer, before durable
         # V4 identity markers existed. Restart seeding must recover it too.
         with store.transaction() as connection:
@@ -1008,6 +1016,11 @@ def test_scans_durably_replay_unregistered_v4_pool_keys(
             ).rowcount
             store._bump(connection, "pending_enrichment", -removed)
         assert scanner._pending_pool_identity_replays() == []
+        scanner.close()
+        scanner = MarketIndexer(
+            store, market, "http://unused.invalid", rpc=IdentityRpc(),
+            history_disk_reserve_bytes=0,
+        )
 
         assert scanner._resolve_deferred_pool_identities_once() is True
         pool = store.pool(pool_id)

--- a/tests/test_lp_market_index.py
+++ b/tests/test_lp_market_index.py
@@ -14,6 +14,7 @@ from rhpools.lp_market_index import (
     TOKEN0_SELECTOR,
     TOKEN1_SELECTOR,
     MarketIndexer,
+    RpcError,
 )
 from rhpools.lp_market_store import CanonicalConflict, MarketStore
 from rhpools.lp_market_protocols import (
@@ -69,8 +70,19 @@ class StaticRpc:
             return []
         raise AssertionError(method)
 
-    def batch(self, calls):
-        return [self.call(method, params) for method, params in calls]
+    def batch(self, calls, *, allow_reverts=False):
+        results = []
+        for method, params in calls:
+            try:
+                results.append(self.call(method, params))
+            except RpcError as exc:
+                if allow_reverts and method == "eth_call" and (
+                    exc.code == 3 or "execution reverted" in str(exc).lower()
+                ):
+                    results.append({"error": str(exc)})
+                else:
+                    raise
+        return results
 
 
 class Market:
@@ -484,46 +496,116 @@ def test_live_parent_mismatch_rolls_back_to_canonical_ancestor():
         store.close()
 
 
-def test_missing_trace_capability_defers_lane_without_rewriting_jobs():
-    class NoTraceRpc(StaticRpc):
+@pytest.mark.parametrize("blocked_trace", [False, True], ids=["unavailable-trace", "slow-trace"])
+def test_live_gap_and_v4_trace_cannot_block_v3_position_accounting(
+    tmp_path, blocked_trace,
+):
+    from eth_abi import encode
+    from rhpools.lp_market_protocols import (
+        LIQUIDITY_SELECTOR, POSITIONS_SELECTOR, SLOT0_SELECTOR, V3_MINT_TOPIC,
+    )
+    from rhpools.lp_market_service import LPMarketService
+    from rhpools.workbench_market import USDG, UNISWAP_V3_FACTORY
+
+    owner, pool, token = ("0x" + byte * 20 for byte in ("11", "22", "33"))
+    v4_tx, v3_tx = ("0x" + byte * 32 for byte in ("ab", "cd"))
+    trace_started, release_trace = threading.Event(), threading.Event()
+    blocks = {tx: header(n) for tx, n in ((v4_tx, 20), (v3_tx, 21))}
+    raw_logs = {}
+    for tx_hash, block in blocks.items():
+        raw_logs[tx_hash] = {
+            "blockNumber": block["number"], "blockHash": block["hash"],
+            "transactionHash": tx_hash, "transactionIndex": "0x0", "logIndex": "0x0",
+            "address": POOL_MANAGER if tx_hash == v4_tx else pool,
+            "topics": (
+                [V4_MODIFY_LIQUIDITY_TOPIC, "0x" + "44" * 32, "0x" + owner[2:].zfill(64)]
+                if tx_hash == v4_tx else [
+                    V3_MINT_TOPIC, "0x" + owner[2:].zfill(64),
+                    "0x" + "00" * 32, "0x" + f"{10:064x}",
+                ]
+            ),
+            "data": "0x" + encode(
+                ["address", "uint128", "uint256", "uint256"],
+                [owner, 10, 1_000_000, 2_000_000],
+            ).hex(),
+        }
+
+    class ReceiptRpc(StaticRpc):
         @staticmethod
         def status():
-            return {
-                "trace": {
-                    "active": None,
-                    "configured": False,
-                    "sources": [],
-                },
-            }
+            return {"trace": {"active": None, "configured": False, "sources": []}}
 
-    store = MarketStore(":memory:")
-    scanner = indexer(store, NoTraceRpc())
-    block = header(10)
-    pending_event = {
-        "block_number": 10,
-        "block_hash": block["hash"],
-        "tx_hash": "0x" + "ab" * 32,
-        "tx_index": 0,
-        "log_index": 0,
-        "timestamp": int(block["timestamp"], 16),
-        "pool_id": None,
-        "protocol": "v3",
-        "kind": "add",
-        "owner": "0x" + "11" * 20,
-        "data": {},
-    }
-    store.ingest([block], [pending_event])
+        def call(self, method, params):
+            if method == "eth_getTransactionReceipt":
+                tx_hash = params[0]
+                block = blocks[tx_hash]
+                return {
+                    "transactionHash": tx_hash, "blockNumber": block["number"],
+                    "blockHash": block["hash"], "transactionIndex": "0x0",
+                    "status": "0x1", "from": owner, "gasUsed": hex(21_000),
+                    "effectiveGasPrice": hex(1_000_000_000),
+                    "logs": [raw_logs[tx_hash]],
+                }
+            if method == "eth_getTransactionByHash":
+                return {"hash": params[0], "from": owner, "gasPrice": hex(1_000_000_000)}
+            if method == "debug_traceTransaction":
+                assert params[0] == v4_tx
+                trace_started.set()
+                if blocked_trace:
+                    assert release_trace.wait(5)
+                raise RpcError("trace RPC unavailable")
+            if method == "eth_call":
+                selector = params[0]["data"][:10]
+                if selector == POSITIONS_SELECTOR:
+                    values = [10, 0, 0, 3, 5] if params[1] == "0x15" else [0] * 5
+                elif selector == SLOT0_SELECTOR:
+                    values = [1 << 96, 0, 0, 1, 1, 0, 1]
+                elif selector == LIQUIDITY_SELECTOR:
+                    values = [1_000]
+                else:
+                    raise AssertionError(selector)
+                return "0x" + encode(["uint256"] * len(values), values).hex()
+            return super().call(method, params)
+
+    app = LPMarketService(Market(), "http://unused.invalid", tmp_path / "receipts.sqlite", start=False)
+    scanner = indexer(app.store, ReceiptRpc())
     try:
-        assert scanner._enrich_once() is False
-        row = store.read().execute(
-            "SELECT attempts,last_error FROM pending_enrichment",
-        ).fetchone()
-        assert (row["attempts"], row["last_error"]) == (0, None)
-        status = scanner.runtime_status()
-        assert status["enrichment_deferred"] is True
+        app.store.upsert_pools([{
+            "id": pool, "address": pool, "protocol": "v3",
+            "token0": token, "token1": USDG, "decimals0": 6, "decimals1": 6,
+            "symbol0": "ASSET", "symbol1": "USDG", "fee_ppm": 3_000,
+            "tick_spacing": 1, "factory": UNISWAP_V3_FACTORY,
+            "created_block": 1, "source": "factory-live",
+            "metadata_json": {"discovery_basis": "factory_creation_event"},
+        }])
+        events = scanner._decode("live", [raw_logs[v3_tx]], {21: blocks[v3_tx]}, resolve_unknown=False)
+        app.store.ingest(list(blocks.values()), [
+            {**indexed_event(20, "ab"), "protocol": "v4"}, *events,
+        ], cursor={"block_number": 21, "block_hash": blocks[v3_tx]["hash"]})
+        assert app.book.positions({"pool": pool})["rows"][0]["liquidity"] is None
+        scanner._publish_current_block(header(2_000), (), source="test")
+        scanner._initialized.set()
+        worker = threading.Thread(target=scanner._enrichment_run)
+        scanner._threads.append(worker)
+        worker.start()
+        assert trace_started.wait(2)
+        deadline = time.monotonic() + 3
+        while True:
+            position = app.book.positions({"pool": pool})["rows"][0]
+            if position["liquidity"] == "10" or time.monotonic() >= deadline:
+                break
+            time.sleep(0.01)
+        assert (
+            position["liquidity"], position["tokens_owed0"], position["tokens_owed1"],
+        ) == ("10", "3", "5")
+        assert position["coverage"]["history"] == "full"
+        assert [row["tx_hash"] for row in app.store.read().execute(
+            "SELECT tx_hash FROM pending_enrichment"
+        )] == [v4_tx]
     finally:
+        release_trace.set()
         scanner.close()
-        store.close()
+        app.close()
 
 
 def test_history_progress_is_independent_of_unrunnable_enrichment(monkeypatch):
@@ -974,7 +1056,7 @@ def test_interval_headers_and_logs_use_overlapping_bounded_lanes():
                 return hex(4663)
             raise AssertionError(method)
 
-        def batch(self, calls):
+        def batch(self, calls, *, allow_reverts=False):
             if self.lane == "live" and self.ordinal == 1:
                 header_started.set()
                 assert log_started.wait(1)
@@ -1010,7 +1092,7 @@ def test_interval_end_is_rechecked_after_logs_before_commit():
                 return block
             return super().call(method, params)
 
-        def batch(self, calls):
+        def batch(self, calls, *, allow_reverts=False):
             return [
                 header(int(params[0], 16))
                 if method == "eth_getBlockByNumber"

--- a/tests/test_lp_market_index.py
+++ b/tests/test_lp_market_index.py
@@ -721,9 +721,10 @@ def test_history_progress_is_independent_of_unrunnable_enrichment(monkeypatch):
         store.close()
 
 
-def test_recent_ledger_gap_yields_history_until_live_progresses():
+@pytest.mark.parametrize("live_head", [501, 1_100])
+def test_recent_ledger_gap_yields_history_until_live_progresses(live_head):
     store = MarketStore(":memory:")
-    scanner = indexer(store, StaticRpc(1_100))
+    scanner = indexer(store, StaticRpc(live_head))
     scanner._history_verified = True
     anchor = header(500)
     store.ingest([anchor], [], lane="history", cursor={
@@ -736,12 +737,15 @@ def test_recent_ledger_gap_yields_history_until_live_progresses():
         "block_number": 500, "block_hash": anchor["hash"],
         "timestamp": int(anchor["timestamp"], 16),
     })
-    scanner._set_runtime("head", head=1_100)
+    scanner._set_runtime("head", head=live_head)
     try:
         assert scanner._scan_history_once() is False
         assert store.cursor("history")["next_to"] == 499
         assert scanner._scan_live_once() is True
         assert store.cursor("live")["block_number"] > 500
+        while store.cursor("live")["block_number"] < live_head:
+            assert scanner._scan_history_once() is False
+            assert scanner._scan_live_once() is True
         assert scanner._scan_history_once() is True
         assert store.cursor("history")["next_to"] < 499
     finally:

--- a/tests/test_lp_market_index.py
+++ b/tests/test_lp_market_index.py
@@ -1258,5 +1258,261 @@ def test_metadata_and_balance_batches_isolate_invalid_tokens(tmp_path):
         store.close()
 
 
+def test_v4_receipt_trace_and_pinned_state_produce_exact_financial_evidence():
+    from eth_abi import encode
+    from eth_utils import keccak
+    from rhpools.lp_market_protocols import (
+        MODIFY_LIQUIDITY_SELECTOR,
+        STATE_VIEW_LIQUIDITY_SELECTOR,
+        STATE_VIEW_POSITION_SELECTOR,
+        STATE_VIEW_SLOT0_SELECTOR,
+        V4_POSITION_MANAGER,
+    )
+
+    token0, token1 = ("0x" + byte * 20 for byte in ("11", "22"))
+    owner = "0x" + "33" * 20
+    hook = "0x" + "00" * 20
+    fee, spacing, token_id = 3_000, 8, 42
+    observed = header(10)
+    tx_hash = "0x" + "44" * 32
+    pool_id = "0x" + keccak(encode(
+        ["address", "address", "uint24", "int24", "address"],
+        [token0, token1, fee, spacing, hook],
+    )).hex()
+
+    def topic(value):
+        return "0x" + f"{value:064x}"
+
+    common = {
+        "blockNumber": observed["number"],
+        "blockHash": observed["hash"],
+        "transactionHash": tx_hash,
+        "transactionIndex": "0x0",
+    }
+    core = {
+        **common,
+        "address": POOL_MANAGER,
+        "logIndex": "0x0",
+        "topics": [
+            V4_MODIFY_LIQUIDITY_TOPIC,
+            pool_id,
+            topic(int(V4_POSITION_MANAGER, 16)),
+        ],
+        "data": "0x" + encode(
+            ["int24", "int24", "int256", "bytes32"],
+            [-60, 60, 100, token_id.to_bytes(32, "big")],
+        ).hex(),
+    }
+    transfer = {
+        **common,
+        "address": V4_POSITION_MANAGER,
+        "logIndex": "0x1",
+        "topics": [
+            TRANSFER_TOPIC,
+            topic(0),
+            topic(int(owner, 16)),
+            topic(token_id),
+        ],
+        "data": "0x",
+    }
+    calldata = MODIFY_LIQUIDITY_SELECTOR + encode(
+        [
+            "(address,address,uint24,int24,address)",
+            "(int24,int24,int256,bytes32)",
+            "bytes",
+        ],
+        [
+            (token0, token1, fee, spacing, hook),
+            (-60, 60, 100, token_id.to_bytes(32, "big")),
+            b"",
+        ],
+    ).hex()
+    mask = (1 << 128) - 1
+
+    def balance_delta(amount0, amount1):
+        return (
+            ((amount0 & mask) << 128) | (amount1 & mask)
+        ).to_bytes(32, "big").hex()
+
+    trace = {
+        "type": "CALL",
+        "from": V4_POSITION_MANAGER,
+        "to": POOL_MANAGER,
+        "input": calldata,
+        "output": "0x" + balance_delta(-1_000, -2_000) + balance_delta(3, 5),
+        "logs": [core],
+    }
+    receipt = {
+        "transactionHash": tx_hash,
+        "blockNumber": observed["number"],
+        "blockHash": observed["hash"],
+        "transactionIndex": "0x0",
+        "status": "0x1",
+        "from": owner,
+        "gasUsed": hex(21_000),
+        "effectiveGasPrice": hex(1_000_000_000),
+        "logs": [core, transfer],
+    }
+
+    class EnrichmentRpc(StaticRpc):
+        def call(self, method, params):
+            if method == "eth_getTransactionReceipt":
+                return receipt
+            if method == "eth_getTransactionByHash":
+                raise AssertionError("complete receipt must not fetch a body")
+            if method == "debug_traceTransaction":
+                return trace
+            if method == "eth_getBlockByNumber":
+                return observed
+            if method == "eth_call":
+                calldata_ = params[0]["data"]
+                if calldata_.startswith(STATE_VIEW_POSITION_SELECTOR):
+                    values = [100, 1, 2]
+                elif calldata_.startswith(STATE_VIEW_SLOT0_SELECTOR):
+                    values = [1 << 96, 0, 0, fee]
+                elif calldata_.startswith(STATE_VIEW_LIQUIDITY_SELECTOR):
+                    values = [1_000]
+                else:
+                    raise AssertionError(calldata_)
+                return "0x" + encode(
+                    ["uint256"] * len(values), values,
+                ).hex()
+            return super().call(method, params)
+
+    store = MarketStore(":memory:")
+    rpc = EnrichmentRpc()
+    scanner = indexer(store, rpc)
+    try:
+        store.upsert_pools([{
+            "id": pool_id,
+            "protocol": "v4",
+            "address": POOL_MANAGER,
+            "token0": token0,
+            "token1": token1,
+            "fee_ppm": fee,
+            "tick_spacing": spacing,
+            "hook": hook,
+            "factory": POOL_MANAGER,
+            "source": "test",
+        }])
+        pending = {
+            "tx_hash": tx_hash,
+            "block_number": 10,
+            "block_hash": observed["hash"],
+            "attempts": 0,
+            "generation": 0,
+        }
+        _row, events, gas, error = scanner._enrich_transactions([pending])[0]
+        assert error is None
+        action = next(row for row in events if row["protocol"] == "v4")
+        assert (
+            action["cashflow0"],
+            action["cashflow1"],
+            action["fee_amount0"],
+            action["fee_amount1"],
+        ) == ("-1000", "-2000", "3", "5")
+        assert action["data"]["trace_complete"] is True
+        assert action["data"]["position_before"]["absence_basis"] == (
+            "same_receipt_verified_v4_manager_mint"
+        )
+        assert action["data"]["position_after"]["liquidity"] == "100"
+        assert action["data"]["pool_state_before"]["liquidity"] == "1000"
+        assert gas["payer"] == owner
+        assert gas["gas_native"] == str(21_000 * 1_000_000_000)
+    finally:
+        scanner.close()
+        store.close()
+
+
+def test_v4_zero_state_requires_same_receipt_burn_proof():
+    from eth_abi import encode
+    from rhpools.lp_market_protocols import (
+        V4_POSITION_MANAGER,
+        decode_position_state_results,
+        nft_position_key,
+        position_state_requests,
+    )
+
+    owner = "0x" + "11" * 20
+    block_hash = "0x" + "22" * 32
+    tx_hash = "0x" + "33" * 32
+    pool_id = "0x" + "44" * 32
+    core_key = "0x" + "55" * 32
+    token_id = 42
+    position_key = nft_position_key(V4_POSITION_MANAGER, token_id)
+    common = {
+        "block_number": 10,
+        "block_hash": block_hash,
+        "tx_hash": tx_hash,
+        "tx_index": 0,
+        "timestamp": 1_000,
+        "pool_id": pool_id,
+        "owner": owner,
+        "custody": V4_POSITION_MANAGER,
+        "position_key": position_key,
+        "token_id": str(token_id),
+        "tick_lower": -60,
+        "tick_upper": 60,
+    }
+    action = {
+        **common,
+        "protocol": "v4",
+        "kind": "remove",
+        "log_index": 0,
+        "liquidity_delta": "-100",
+        "data": {"core_position_key": core_key},
+    }
+    burn = {
+        **common,
+        "protocol": "nft",
+        "kind": "transfer",
+        "log_index": 1,
+        "liquidity_delta": None,
+        "data": {
+            "manager_protocol": "v4",
+            "prior_owner": owner,
+            "new_owner": "0x" + "00" * 20,
+            "burn": True,
+            "core_position_key": core_key,
+        },
+    }
+    requests = [
+        request
+        for request in position_state_requests([action, burn])
+        if request["correlation"]["decoder"] == "v4_state_view_position"
+    ]
+    results = [
+        "0x" + encode(
+            ["uint128", "uint256", "uint256"],
+            [100, 1, 2]
+            if request["correlation"]["field"] == "position_before"
+            else [0, 0, 0],
+        ).hex()
+        for request in requests
+    ]
+    updates = decode_position_state_results(requests, results)
+    assert updates
+    for update in updates:
+        assert update["data"]["position_after"]["exists"] is None
+        assert update["data"]["position_after"]["nft_exists"] is False
+        assert update["data"]["position_after"]["nft_absence_basis"] == (
+            "same_receipt_verified_v4_manager_burn"
+        )
+
+    unproven_requests = [
+        request
+        for request in position_state_requests([action])
+        if request["correlation"]["decoder"] == "v4_state_view_position"
+    ]
+    unproven = decode_position_state_results(
+        unproven_requests,
+        ["0x" + encode(
+            ["uint128", "uint256", "uint256"], [0, 0, 0],
+        ).hex()] * len(unproven_requests),
+    )
+    assert unproven[0]["data"]["position_after"]["exists"] is None
+    assert "nft_exists" not in unproven[0]["data"]["position_after"]
+
+
 
 

--- a/tests/test_lp_market_index.py
+++ b/tests/test_lp_market_index.py
@@ -608,6 +608,56 @@ def test_live_gap_and_v4_trace_cannot_block_v3_position_accounting(
         app.close()
 
 
+def test_small_trace_refills_rotate_history_requested_and_recent(monkeypatch):
+    from concurrent.futures import Future
+
+    store = MarketStore(":memory:")
+    scanner = indexer(store)
+    numbers = [*range(1, 257), 500, 699, 700, 701]
+    store.ingest([header(number) for number in numbers], [
+        {
+            **indexed_event(number, "11"),
+            "tx_hash": header(number)["hash"],
+            "protocol": "v3" if number == 701 else "v4",
+        }
+        for number in numbers
+    ])
+    store.prioritize_enrichment([header(500)["hash"]])
+    submitted = {False: [], True: []}
+
+    def capture(lane):
+        def submit(_function, rows):
+            submitted[lane].append(tuple(rows))
+            return Future()
+
+        return submit
+
+    monkeypatch.setattr(scanner._enrichment_executor, "submit", capture(False))
+    monkeypatch.setattr(scanner._trace_enrichment_executor, "submit", capture(True))
+    occupied = tuple(dict(row) for row in store.read().execute(
+        "SELECT * FROM pending_enrichment WHERE block_number<=6 ORDER BY block_number",
+    ))
+    scanner._enrichment_jobs[tuple(row["tx_hash"] for row in occupied)] = (
+        occupied, Future(), time.monotonic(), True,
+    )
+    try:
+        scanner._fill_enrichment_jobs()
+        first_trace = tuple(row for batch in submitted[True] for row in batch)
+        first_regular = tuple(row for batch in submitted[False] for row in batch)
+        assert [row["block_number"] for row in first_trace] == [7, 500]
+        assert [row["block_number"] for row in first_regular] == [701]
+
+        first_trace_hashes = tuple(row["tx_hash"] for row in first_trace)
+        scanner._enrichment_jobs.pop(first_trace_hashes)
+        submitted[True].clear()
+        scanner._fill_enrichment_jobs(first_trace_hashes)
+        second_trace = tuple(row for batch in submitted[True] for row in batch)
+        assert [row["block_number"] for row in second_trace] == [700, 699]
+    finally:
+        scanner.close()
+        store.close()
+
+
 def test_identity_recovery_waits_for_initialization_and_outlives_blocked_accounting(
     tmp_path, monkeypatch,
 ):
@@ -783,6 +833,74 @@ def test_live_health_publishes_while_another_lane_holds_writer():
         writer.join(2)
         if publisher.ident is not None:
             publisher.join(2)
+        scanner.close()
+        store.close()
+
+
+def test_requested_identity_replay_keeps_regular_enrichment_interest(monkeypatch):
+    store = MarketStore(":memory:")
+    scanner = indexer(store)
+    identity_marker = scanner._encode_pool_identity_marker({
+        "addresses": ["0x" + "12" * 20],
+        "logs": [],
+    })
+    target_tx = "0x" + f"{50:064x}"
+    regular_tx = "0x" + f"{51:064x}"
+    identity_numbers = [*range(1, 33), 50, *range(68, 100)]
+    now = time.time()
+    with store.transaction() as connection:
+        connection.executemany(
+            "INSERT INTO pending_enrichment"
+            "(tx_hash,block_number,block_hash,attempts,next_attempt,last_error,"
+            "created_at,updated_at) VALUES(?,?,?,?,?,?,?,?)",
+            [
+                (
+                    "0x" + f"{number:064x}",
+                    number,
+                    header(number)["hash"],
+                    0,
+                    0,
+                    identity_marker,
+                    now,
+                    now,
+                )
+                for number in identity_numbers
+            ] + [
+                (
+                    regular_tx,
+                    51,
+                    header(51)["hash"],
+                    0,
+                    0,
+                    None,
+                    now,
+                    now,
+                ),
+            ],
+        )
+        store._set_metadata(
+            connection, "pending_enrichment", len(identity_numbers) + 1,
+        )
+    store.prioritize_enrichment([target_tx, regular_tx])
+
+    def unavailable(_method, _params):
+        raise RpcError("identity RPC unavailable")
+
+    monkeypatch.setattr(scanner, "_seed_deferred_v4_pool_identities", lambda: 0)
+    monkeypatch.setattr(scanner._clients["pool"], "call", unavailable)
+    scanner._pool_identity_replay_turn = 1
+    try:
+        assert scanner._resolve_deferred_pool_identities_once() is True
+        assert [
+            row["tx_hash"] for row in store.read().execute(
+                "SELECT tx_hash FROM pending_enrichment WHERE next_attempt>0",
+            )
+        ] == [target_tx]
+        assert [
+            row["tx_hash"]
+            for row in store.requested_enrichments(8, identity=False)
+        ] == [regular_tx]
+    finally:
         scanner.close()
         store.close()
 

--- a/tests/test_lp_market_index.py
+++ b/tests/test_lp_market_index.py
@@ -608,6 +608,65 @@ def test_live_gap_and_v4_trace_cannot_block_v3_position_accounting(
         app.close()
 
 
+def test_identity_recovery_waits_for_initialization_and_outlives_blocked_accounting(
+    tmp_path, monkeypatch,
+):
+    store = MarketStore(tmp_path / "market.sqlite")
+    bootstrap_started = threading.Event()
+    release_bootstrap = threading.Event()
+    accounting_started = threading.Event()
+    release_accounting = threading.Event()
+    accounting_finished = threading.Event()
+    recovery_called = threading.Event()
+    recovery_initialization = []
+
+    def project_accounting():
+        accounting_started.set()
+        release_accounting.wait()
+        accounting_finished.set()
+        return False
+
+    def recover_identities():
+        recovery_initialization.append(scanner._initialized.is_set())
+        recovery_called.set()
+        return False
+
+    scanner = indexer(
+        store,
+        accounting_projector=project_accounting,
+        accounting_recovery=recover_identities,
+    )
+    bootstrap = scanner._bootstrap
+
+    def blocked_bootstrap():
+        bootstrap_started.set()
+        release_bootstrap.wait()
+        return bootstrap()
+
+    monkeypatch.setattr(scanner, "_bootstrap", blocked_bootstrap)
+    workers = ()
+    try:
+        scanner.start(deferred=True)
+        workers = tuple(scanner._threads)
+        assert bootstrap_started.wait(2)
+        assert accounting_started.wait(2)
+        assert not recovery_called.wait(0.1)
+
+        release_bootstrap.set()
+        assert recovery_called.wait(2)
+        assert recovery_initialization
+        assert all(recovery_initialization)
+        assert not accounting_finished.is_set()
+    finally:
+        release_bootstrap.set()
+        release_accounting.set()
+        scanner.close()
+        store.close()
+
+    assert workers
+    assert all(not worker.is_alive() for worker in workers)
+
+
 def test_history_progress_is_independent_of_unrunnable_enrichment(monkeypatch):
     store = MarketStore(":memory:")
     scanner = indexer(store)

--- a/tests/test_lp_market_protocols.py
+++ b/tests/test_lp_market_protocols.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from eth_abi import encode
+from eth_utils import keccak
+
+from rhpools.lp_market_protocols import (
+    POOL_MANAGER,
+    POSITIONS_SELECTOR,
+    STATE_VIEW,
+    STATE_VIEW_POSITION_SELECTOR,
+    V3_MINT_TOPIC,
+    V4_MODIFY_LIQUIDITY_TOPIC,
+    core_position_key,
+    decode_logs,
+    position_state_requests,
+)
+
+
+def _topic(value: int) -> str:
+    return "0x" + f"{value & ((1 << 256) - 1):064x}"
+
+
+def _log(
+    *,
+    address: str,
+    block_hash: str,
+    tx_hash: str,
+    tx_index: int,
+    topics: list[str],
+    data: str,
+) -> dict:
+    return {
+        "address": address,
+        "blockNumber": "0xa",
+        "blockHash": block_hash,
+        "transactionHash": tx_hash,
+        "transactionIndex": hex(tx_index),
+        "logIndex": "0x0",
+        "topics": topics,
+        "data": data,
+    }
+
+
+def test_v3_core_source_identity_is_pool_scoped_but_state_key_stays_raw():
+    owner = "0x" + "12" * 20
+    pool_a = "0x" + "34" * 20
+    pool_b = "0x" + "56" * 20
+    block_hash = "0x" + "78" * 32
+    lower, upper = -60, 60
+    raw_key = "0x" + keccak(
+        bytes.fromhex(owner[2:])
+        + lower.to_bytes(3, "big", signed=True)
+        + upper.to_bytes(3, "big", signed=True)
+    ).hex()
+    topics = [
+        V3_MINT_TOPIC,
+        _topic(int(owner, 16)),
+        _topic(lower),
+        _topic(upper),
+    ]
+    data = "0x" + encode(
+        ["address", "uint128", "uint256", "uint256"],
+        [owner, 100, 25, 50],
+    ).hex()
+    rows = decode_logs(
+        [
+            _log(
+                address=pool_a,
+                block_hash=block_hash,
+                tx_hash="0x" + "9a" * 32,
+                tx_index=0,
+                topics=topics,
+                data=data,
+            ),
+            _log(
+                address=pool_b,
+                block_hash=block_hash,
+                tx_hash="0x" + "bc" * 32,
+                tx_index=1,
+                topics=topics,
+                data=data,
+            ),
+        ],
+        {
+            pool_a: {"id": pool_a, "address": pool_a, "protocol": "v3"},
+            pool_b: {"id": pool_b, "address": pool_b, "protocol": "v3"},
+        },
+        {10: {"hash": block_hash, "timestamp": 1_000}},
+    )
+
+    by_pool = {row["pool_id"]: row for row in rows}
+    assert by_pool[pool_a]["position_key"] == f"v3:{pool_a}:{raw_key}"
+    assert by_pool[pool_b]["position_key"] == f"v3:{pool_b}:{raw_key}"
+    assert by_pool[pool_a]["position_key"] != by_pool[pool_b]["position_key"]
+    assert {row["data"]["core_position_key"] for row in rows} == {raw_key}
+    assert core_position_key("V3", pool_a.upper(), raw_key.upper()) == (
+        f"v3:{pool_a}:{raw_key}"
+    )
+
+    requests = [
+        request
+        for request in position_state_requests(rows)
+        if request["correlation"]["decoder"] == "v3_core_position"
+    ]
+    calldata = POSITIONS_SELECTOR + raw_key[2:]
+    assert {
+        (
+            request["params"][0]["to"],
+            request["params"][0]["data"],
+            request["params"][1],
+        )
+        for request in requests
+    } == {
+        (pool_a, calldata, "0x9"),
+        (pool_a, calldata, "0xa"),
+        (pool_b, calldata, "0x9"),
+        (pool_b, calldata, "0xa"),
+    }
+
+
+def test_v4_identical_core_hashes_in_different_pools_keep_distinct_source_keys():
+    owner = "0x" + "12" * 20
+    pool_a = "0x" + "34" * 32
+    pool_b = "0x" + "56" * 32
+    block_hash = "0x" + "78" * 32
+    salt = "0x" + "9a" * 32
+    lower, upper = -60, 60
+    raw_key = "0x" + keccak(
+        bytes.fromhex(owner[2:])
+        + lower.to_bytes(3, "big", signed=True)
+        + upper.to_bytes(3, "big", signed=True)
+        + bytes.fromhex(salt[2:])
+    ).hex()
+    data = "0x" + encode(
+        ["int24", "int24", "int256", "bytes32"],
+        [lower, upper, 100, bytes.fromhex(salt[2:])],
+    ).hex()
+    rows = decode_logs(
+        [
+            _log(
+                address=POOL_MANAGER,
+                block_hash=block_hash,
+                tx_hash="0x" + "bc" * 32,
+                tx_index=0,
+                topics=[
+                    V4_MODIFY_LIQUIDITY_TOPIC,
+                    pool_a,
+                    _topic(int(owner, 16)),
+                ],
+                data=data,
+            ),
+            _log(
+                address=POOL_MANAGER,
+                block_hash=block_hash,
+                tx_hash="0x" + "de" * 32,
+                tx_index=1,
+                topics=[
+                    V4_MODIFY_LIQUIDITY_TOPIC,
+                    pool_b,
+                    _topic(int(owner, 16)),
+                ],
+                data=data,
+            ),
+        ],
+        {
+            pool_a: {"id": pool_a, "address": POOL_MANAGER, "protocol": "v4"},
+            pool_b: {"id": pool_b, "address": POOL_MANAGER, "protocol": "v4"},
+        },
+        {10: {"hash": block_hash, "timestamp": 1_000}},
+    )
+
+    by_pool = {row["pool_id"]: row for row in rows}
+    assert by_pool[pool_a]["position_key"] == f"v4:{pool_a}:{raw_key}"
+    assert by_pool[pool_b]["position_key"] == f"v4:{pool_b}:{raw_key}"
+    assert by_pool[pool_a]["position_key"] != by_pool[pool_b]["position_key"]
+    assert {row["data"]["core_position_key"] for row in rows} == {raw_key}
+
+    requests = [
+        request
+        for request in position_state_requests(rows)
+        if request["correlation"]["decoder"] == "v4_state_view_position"
+    ]
+    assert {
+        (
+            request["params"][0]["to"],
+            request["params"][0]["data"],
+            request["params"][1],
+        )
+        for request in requests
+    } == {
+        (
+            STATE_VIEW,
+            STATE_VIEW_POSITION_SELECTOR + pool_a[2:] + raw_key[2:],
+            "0x9",
+        ),
+        (
+            STATE_VIEW,
+            STATE_VIEW_POSITION_SELECTOR + pool_a[2:] + raw_key[2:],
+            "0xa",
+        ),
+        (
+            STATE_VIEW,
+            STATE_VIEW_POSITION_SELECTOR + pool_b[2:] + raw_key[2:],
+            "0x9",
+        ),
+        (
+            STATE_VIEW,
+            STATE_VIEW_POSITION_SELECTOR + pool_b[2:] + raw_key[2:],
+            "0xa",
+        ),
+    }

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -1957,6 +1957,20 @@ def test_completed_wallet_projection_is_deliverable_during_live_changes(
             assert result is not None, "completed wallets were starved by new activity"
             assert result["current_activity"]["head"] == 100
             assert TOKEN in {row["owner"] for row in result["rows"]}
+            assert app.poll_owners(params) == result, (
+                "another consumer lost the completed wallet snapshot"
+            )
+            updated = None
+            deadline = time.monotonic() + 3
+            while updated is None and time.monotonic() < deadline:
+                updated = app.poll_owners(params, result["revision"])
+                if updated is None:
+                    time.sleep(0.01)
+            assert updated is not None, "cached wallets stopped refreshing"
+            assert updated["current_activity"]["head"] == 101
+            assert "0x" + "78" * 20 in {
+                row["owner"] for row in updated["rows"]
+            }
     finally:
         release.set()
         app.close()

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -1200,7 +1200,7 @@ def test_deferred_accounting_rejects_prepared_orphan_branch(
 
 
 def test_deferred_accounting_restart_resumes_queue_and_clears_reassigned_key(
-        tmp_path, monkeypatch):
+        tmp_path):
     path = tmp_path / "market.sqlite"
     block = header(100, 1_000)
     event = lp_effect(
@@ -1217,11 +1217,6 @@ def test_deferred_accounting_restart_resumes_queue_and_clears_reassigned_key(
     PriceProjection(store)
     book = AccountBook(store, deferred=True)
 
-    def unexpected_replay(*_args, **_kwargs):
-        raise AssertionError("deferred install replayed the ledger")
-
-    monkeypatch.setattr(book, "_map_existing_events", unexpected_replay)
-    monkeypatch.setattr(book, "_rebuild_position", unexpected_replay)
     try:
         book.install()
         assert store.status()["pending_accounting"] == 1
@@ -1239,6 +1234,46 @@ def test_deferred_accounting_restart_resumes_queue_and_clears_reassigned_key(
         after = book.positions({"owner": TOKEN})["rows"]
         assert [row["position_key"] for row in after] == ["v4:after"]
         assert after[0]["liquidity"] == "1000"
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize("published_before_remap", [True, False])
+def test_prepared_remap_preserves_new_positions_gas(
+        tmp_path, monkeypatch, published_before_remap):
+    blocks = [header(100 + index, 1_000 + index) for index in range(2)]
+    opened, closed, costs = traced_v4_episode(blocks, key="before")
+    store, book = accounting_store(tmp_path / "remap.sqlite", deferred=True)
+    try:
+        inserted = store.ingest(blocks, [opened, closed], transactions=costs)
+        if published_before_remap:
+            drain_accounting(book)
+        else:
+            # An unpublished old-key insert waits across the source correction.
+            stale = book._prepare_pending("v4:before")
+        store.enrich([
+            {
+                **event, "id": row["id"], "position_key": "v4:after",
+                "data": {**event["data"], "position_key": "v4:after"},
+            }
+            for event, row in zip((opened, closed), inserted)
+        ])
+        if published_before_remap:
+            # Old-key cleanup waits across publication of the reassigned rows.
+            stale = book._prepare_pending("v4:before")
+        current = book._prepare_pending("v4:after")
+        assert current is not None and stale is not None
+        with monkeypatch.context() as publication:
+            publication.setattr(
+                book, "_prepared_pending", lambda _rows: iter((current, stale)),
+            )
+            book.project_pending()
+        drain_accounting(book)
+        rows = book.closed({"window": "all"})["rows"]
+        assert [row["position_key"] for row in rows] == ["v4:after"]
+        assert rows[0]["gross_pnl_usd"] == pytest.approx(0.1)
+        assert rows[0]["gas_usd"] == pytest.approx(0.02)
+        assert rows[0]["net_pnl_usd"] == pytest.approx(0.08)
     finally:
         store.close()
 

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -1905,6 +1905,48 @@ def test_owner_projection_is_shared_and_never_blocks_current_feed(
         app.close()
 
 
+def test_wallet_read_does_not_queue_behind_unrelated_frames(tmp_path, monkeypatch):
+    app = service(tmp_path / "market.sqlite")
+    release = threading.Event()
+    entered = [threading.Event(), threading.Event()]
+    returned = threading.Event()
+    result = {}
+    reader = None
+    original = app.frame
+
+    def slow_frame(params, *args, **kwargs):
+        entered[int(params["q"])].set()
+        assert release.wait(3)
+        return original(params, *args, **kwargs)
+
+    monkeypatch.setattr(app, "frame", slow_frame)
+    try:
+        block = header(100, int(time.time()))
+        event = lp_effect(
+            block, "v4", "add", 1_000, (1_000_000, 1_000_000),
+            position_state(0), position_state(1_000),
+        )
+        app.observe_current_block(block)
+        app.observe_current_events(block, (event,))
+        for index in range(2):
+            assert app.poll_frame({"window": "all", "q": str(index)}, -1, 0) is None
+            assert entered[index].wait(1)
+
+        def read_wallet():
+            result.update(app.owners({"window": "all", "q": TOKEN}))
+            returned.set()
+
+        reader = threading.Thread(target=read_wallet)
+        reader.start()
+        assert returned.wait(1), "wallet read queued behind unrelated frame SQL"
+        assert TOKEN in {row["owner"] for row in result["rows"]}
+    finally:
+        release.set()
+        if reader is not None:
+            reader.join(3)
+        app.close()
+
+
 @pytest.mark.parametrize("reorg", [False, True])
 def test_completed_wallet_projection_is_deliverable_during_live_changes(
         tmp_path, monkeypatch, reorg):

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -929,6 +929,32 @@ def test_late_receipts_complete_deferred_gas_and_net_results(tmp_path):
         store.close()
 
 
+def test_receipt_completion_replays_changed_price_evidence(tmp_path):
+    blocks = [header(100 + index, 1_000 + index) for index in range(2)]
+    opened, closed, transactions = traced_v4_episode(blocks)
+    store, book = accounting_store(
+        tmp_path / "receipt-repricing.sqlite", deferred=True,
+    )
+    try:
+        store.ingest(blocks, [opened, closed])
+        drain_accounting(book)
+        before = book.closed({"window": "all"})["rows"][0]
+        assert before["gross_pnl_usd"] == pytest.approx(0.1)
+
+        # Corrected source units reach PriceProjection before accounting.
+        # Receiving only receipts does not prove event values stayed fixed.
+        with store.transaction() as connection:
+            connection.execute("UPDATE pools SET decimals1=5")
+        store.enrich([], transactions=transactions)
+        drain_accounting(book)
+        after = book.closed({"window": "all"})["rows"][0]
+        assert after["gross_pnl_usd"] == pytest.approx(1.0)
+        assert after["gas_usd"] == pytest.approx(0.02)
+        assert after["net_pnl_usd"] == pytest.approx(0.98)
+    finally:
+        store.close()
+
+
 def test_visible_wallet_recovers_missed_receipt_cost_without_new_activity(tmp_path):
     blocks = [header(100 + index, 1_000 + index) for index in range(2)]
     opened, closed, transactions = traced_v4_episode(blocks, key="late-cost")

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -11,7 +11,8 @@ from rhpools.lp_market_protocols import (
     UNISWAP_V3_POSITION_MANAGER,
 )
 from rhpools.lp_market_index import V3_BIRTH_REPAIR_PREFIXES
-from rhpools.lp_market_service import LPMarketService
+from rhpools.lp_market_accounting import AccountBook
+from rhpools.lp_market_service import LPMarketService, PriceProjection
 from rhpools.lp_rpc import _WssRpc, build_rpc_factory
 from rhpools.lp_market_store import CanonicalConflict, MarketStore
 from rhpools.workbench_market import USDG, UNISWAP_V3_FACTORY
@@ -581,6 +582,409 @@ def ingest_effects(app, blocks, events):
                     for event in events]
     app.store.ingest(blocks, events, transactions=transactions)
     return transactions
+
+
+def accounting_store(path, *, deferred):
+    store = MarketStore(path)
+    PriceProjection(store)
+    book = AccountBook(store, deferred=deferred).install()
+    store.upsert_pools(pools())
+    return store, book
+
+
+def traced_v4_episode(blocks, *, owner=TOKEN, key="deferred"):
+    opened = lp_effect(
+        blocks[0], "v4", "add", 1_000, (1_000_000, 1_000_000),
+        position_state(0), position_state(1_000), key=key,
+    )
+    closed = lp_effect(
+        blocks[1], "v4", "remove", -1_000, (1_000_000, 1_000_000),
+        position_state(1_000), position_state(0), key=key,
+    )
+    for event, principal, cash, fees in (
+        (opened, (-1_000_000, -1_000_000), (-1_000_000, -1_000_000), (0, 0)),
+        (closed, (1_000_000, 1_000_000), (1_100_000, 1_000_000), (100_000, 0)),
+    ):
+        event.update(
+            owner=owner, custody=MANAGER,
+            cashflow0=str(cash[0]), cashflow1=str(cash[1]),
+            fee_amount0=str(fees[0]), fee_amount1=str(fees[1]),
+        )
+        event["data"].update(
+            trace_complete=True, fees_accrued_exact=True,
+            principal_delta_exact=True,
+            principal_delta={
+                "amount0": str(principal[0]), "amount1": str(principal[1]),
+            },
+        )
+    transactions = [
+        {
+            "tx_hash": event["tx_hash"],
+            "block_number": event["block_number"],
+            "block_hash": event["block_hash"],
+            "payer": owner,
+            "gas_usd": 0.01,
+        }
+        for event in (opened, closed)
+    ]
+    return opened, closed, transactions
+
+
+def drain_accounting(book):
+    while book.project_pending(limit=32):
+        pass
+
+
+def test_deferred_accounting_does_not_hold_writer_and_drains_same_branch_prefix(
+        tmp_path, monkeypatch):
+    blocks = [header(100 + index, 1_000 + index) for index in range(2)]
+    opened, closed, transactions = traced_v4_episode(blocks)
+    store, book = accounting_store(
+        tmp_path / "deferred.sqlite", deferred=True,
+    )
+    baseline, baseline_book = accounting_store(
+        tmp_path / "synchronous.sqlite", deferred=False,
+    )
+    derived = threading.Event()
+    release = threading.Event()
+    committed = threading.Event()
+    failures = []
+    original = book._derive
+
+    def paused(*args, **kwargs):
+        result = original(*args, **kwargs)
+        derived.set()
+        release.wait(5)
+        return result
+
+    monkeypatch.setattr(book, "_derive", paused)
+    try:
+        inserted = store.ingest(
+            blocks[:1], [opened], transactions=transactions[:1],
+        )
+        opened_id = int(inserted[0]["id"])
+        projector = threading.Thread(
+            target=lambda: book.project_pending(limit=1),
+        )
+        projector.start()
+        assert derived.wait(2)
+
+        def commit_arrival():
+            try:
+                store.ingest(
+                    blocks[1:], [closed], transactions=transactions[1:],
+                )
+                store.enrich([{
+                    "id": opened_id,
+                    "accounting_basis": "same-epoch trace enrichment",
+                }])
+            except BaseException as error:
+                failures.append(error)
+            finally:
+                committed.set()
+
+        writer = threading.Thread(target=commit_arrival)
+        writer.start()
+        assert committed.wait(2)
+        assert failures == []
+        assert store.status()["indexed_events"] == 2
+        assert store.status()["pending_accounting"] == 1
+        release.set()
+        writer.join(2)
+        projector.join(2)
+        assert not writer.is_alive()
+        assert not projector.is_alive()
+
+        prefix = book.positions({"owner": TOKEN})["rows"]
+        assert len(prefix) == 1
+        assert prefix[0]["status"] == "open"
+        assert store.status()["pending_accounting"] == 1
+        prefix_candidates = book.owner_candidates({"window": "all"})
+        assert prefix_candidates["accounting_as_of"] is None
+        prefix_owner = book.decorate_owner_activity(
+            prefix_candidates["rows"], {"window": "all"},
+        )[0]
+        assert prefix_owner["financial_pending"] is True
+        assert prefix_owner["financial_through_order"] is None
+
+        monkeypatch.setattr(book, "_derive", original)
+        drain_accounting(book)
+        baseline.ingest(blocks, [opened, closed], transactions=transactions)
+        deferred_row = book.closed({"window": "all"})["rows"][0]
+        synchronous_row = baseline_book.closed({"window": "all"})["rows"][0]
+        for field in (
+            "status", "deposit_usd", "withdrawal_usd", "fees_usd",
+            "gross_pnl_usd", "gas_usd", "net_pnl_usd",
+        ):
+            assert deferred_row[field] == synchronous_row[field]
+        assert deferred_row["net_pnl_usd"] == pytest.approx(0.08)
+        owner = book.decorate_owner_activity(
+            book.owner_candidates({"window": "all"})["rows"],
+            {"window": "all"},
+        )[0]
+        assert owner["financial_pending"] is False
+        assert owner["financial_through_order"] == {
+            "block_number": 101, "tx_index": 0, "log_index": 0,
+        }
+        assert owner["financial_through_as_of"] == 1_001
+    finally:
+        release.set()
+        baseline.close()
+        store.close()
+
+
+def test_owner_financial_boundary_uses_the_aggregate_snapshot(
+        tmp_path, monkeypatch):
+    blocks = [header(100 + index, 1_000 + index) for index in range(2)]
+    opened, closed, transactions = traced_v4_episode(
+        blocks, key="owner-snapshot",
+    )
+    store, book = accounting_store(tmp_path / "market.sqlite", deferred=True)
+    aggregate_read = threading.Event()
+    release = threading.Event()
+    failures = []
+    captured = []
+    original_gas = book._owner_gas_values
+
+    def paused_gas(*args, **kwargs):
+        result = original_gas(*args, **kwargs)
+        aggregate_read.set()
+        if not release.wait(5):
+            raise TimeoutError("test did not release owner aggregate snapshot")
+        return result
+
+    monkeypatch.setattr(book, "_owner_gas_values", paused_gas)
+    try:
+        store.ingest(
+            blocks[:1], [opened], transactions=transactions[:1],
+        )
+        drain_accounting(book)
+
+        def read_candidates():
+            try:
+                captured.append(book.owner_candidates({"window": "all"}))
+            except BaseException as error:
+                failures.append(error)
+
+        reader = threading.Thread(target=read_candidates)
+        reader.start()
+        assert aggregate_read.wait(2)
+        store.ingest(
+            blocks[1:], [closed], transactions=transactions[1:],
+        )
+        drain_accounting(book)
+        release.set()
+        reader.join(2)
+        assert not reader.is_alive()
+        assert failures == []
+
+        stale = captured[0]["rows"][0]
+        assert stale["closed_episodes"] == 0
+        assert stale["financial_pending"] is False
+        assert stale["financial_through_order"] == {
+            "block_number": 100, "tx_index": 0, "log_index": 0,
+        }
+        decorated = book.decorate_owner_activity(
+            captured[0]["rows"], {"window": "all"},
+        )[0]
+        assert decorated["closed_episodes"] == 0
+        assert decorated["financial_pending"] is True
+        assert decorated["financial_through_order"] is None
+        latest = book.owner_candidates({"window": "all"})["rows"][0]
+        assert latest["closed_episodes"] == 1
+        assert latest["financial_through_order"] == {
+            "block_number": 101, "tx_index": 0, "log_index": 0,
+        }
+    finally:
+        release.set()
+        store.close()
+
+
+def test_deferred_accounting_rejects_prepared_orphan_branch(
+        tmp_path, monkeypatch):
+    first_block = header(100, 1_000)
+    replacement_block = header(100, 1_001, branch=10_000)
+    old_event = lp_effect(
+        first_block, "v4", "add", 1_000, (1_000_000, 1_000_000),
+        position_state(0), position_state(1_000), key="reorg",
+    )
+    replacement_owner = "0x" + "78" * 20
+    replacement = lp_effect(
+        replacement_block, "v4", "add", 1_000, (1_000_000, 1_000_000),
+        position_state(0), position_state(1_000), key="reorg",
+    )
+    replacement.update(owner=replacement_owner, custody=MANAGER)
+    store, book = accounting_store(tmp_path / "market.sqlite", deferred=True)
+    derived = threading.Event()
+    release = threading.Event()
+    original = book._derive
+
+    def paused(*args, **kwargs):
+        result = original(*args, **kwargs)
+        derived.set()
+        release.wait(5)
+        return result
+
+    monkeypatch.setattr(book, "_derive", paused)
+    try:
+        store.ingest([first_block], [old_event])
+        projector = threading.Thread(
+            target=lambda: book.project_pending(limit=1),
+        )
+        projector.start()
+        assert derived.wait(2)
+        store.rollback(99)
+        store.ingest([replacement_block], [replacement])
+        release.set()
+        projector.join(2)
+        assert not projector.is_alive()
+        assert book.positions({"owner": TOKEN})["rows"] == []
+
+        monkeypatch.setattr(book, "_derive", original)
+        drain_accounting(book)
+        rows = book.positions({"owner": replacement_owner})["rows"]
+        assert len(rows) == 1
+        assert rows[0]["position_key"] == "v4:reorg"
+        assert book.positions({"owner": TOKEN})["rows"] == []
+    finally:
+        release.set()
+        store.close()
+
+
+def test_deferred_accounting_restart_resumes_queue_and_clears_reassigned_key(
+        tmp_path, monkeypatch):
+    path = tmp_path / "market.sqlite"
+    block = header(100, 1_000)
+    event = lp_effect(
+        block, "v4", "add", 1_000, (1_000_000, 1_000_000),
+        position_state(0), position_state(1_000), key="before",
+    )
+    store, _book = accounting_store(path, deferred=True)
+    inserted = store.ingest([block], [event])
+    event_id = int(inserted[0]["id"])
+    assert store.status()["pending_accounting"] == 1
+    store.close()
+
+    store = MarketStore(path)
+    PriceProjection(store)
+    book = AccountBook(store, deferred=True)
+
+    def unexpected_replay(*_args, **_kwargs):
+        raise AssertionError("deferred install replayed the ledger")
+
+    monkeypatch.setattr(book, "_map_existing_events", unexpected_replay)
+    monkeypatch.setattr(book, "_rebuild_position", unexpected_replay)
+    try:
+        book.install()
+        assert store.status()["pending_accounting"] == 1
+        drain_accounting(book)
+        before = book.positions({"owner": TOKEN})["rows"]
+        assert [row["position_key"] for row in before] == ["v4:before"]
+
+        moved = {
+            **event, "id": event_id, "position_key": "v4:after",
+            "data": {**event["data"], "position_key": "v4:after"},
+        }
+        store.enrich([moved])
+        assert store.status()["pending_accounting"] == 2
+        drain_accounting(book)
+        after = book.positions({"owner": TOKEN})["rows"]
+        assert [row["position_key"] for row in after] == ["v4:after"]
+        assert after[0]["liquidity"] == "1000"
+    finally:
+        store.close()
+
+
+def test_v4_fee_action_before_same_tx_transfer_stays_with_prior_owner(
+        tmp_path):
+    app = service(tmp_path / "market.sqlite")
+    prior_owner = "0x" + "56" * 20
+    recipient = TOKEN
+    position_key = f"nft:{MANAGER}:42"
+    opened_block = header(99, 999)
+    transferred_block = header(100, 1_000)
+    opened = lp_effect(
+        opened_block, "v4", "add", 1_000, (1_000_000, 1_000_000),
+        position_state(0), position_state(1_000), key="unused",
+    )
+    opened.update(
+        log_index=1, position_key=position_key, token_id="42",
+        owner=prior_owner, custody=MANAGER,
+        cashflow0="-1000000", cashflow1="-1000000",
+        fee_amount0="0", fee_amount1="0",
+    )
+    opened["data"].update(
+        trace_complete=True, fees_accrued_exact=True,
+        principal_delta_exact=True,
+        principal_delta={"amount0": "-1000000", "amount1": "-1000000"},
+    )
+    collected = lp_effect(
+        transferred_block, "v4", "collect", 0, (100_000, 0),
+        position_state(1_000, 100_000, 0),
+        position_state(1_000), key="unused",
+    )
+    collected.update(
+        log_index=0, position_key=position_key, token_id="42",
+        owner=prior_owner, custody=MANAGER,
+        cashflow0="100000", cashflow1="0",
+        fee_amount0="100000", fee_amount1="0",
+    )
+    collected["data"].update(
+        trace_complete=True, fees_accrued_exact=True,
+        principal_delta_exact=True,
+        principal_delta={"amount0": "0", "amount1": "0"},
+    )
+
+    def transfer(block, tx_hash, log_index, source, target, *, mint=False):
+        event = swap(block, V4, "v4", index=log_index)
+        event.update(
+            tx_hash=tx_hash, log_index=log_index, protocol="nft",
+            kind="transfer", position_key=position_key, token_id="42",
+            owner=target, custody=MANAGER, liquidity_delta=None,
+            amount0=None, amount1=None, cashflow0=None, cashflow1=None,
+            data={
+                "from": source, "to": target, "mint": mint,
+                "manager_protocol": "v4",
+            },
+        )
+        return event
+
+    minted = transfer(
+        opened_block, opened["tx_hash"], 0, "0x" + "0" * 40,
+        prior_owner, mint=True,
+    )
+    delivered = transfer(
+        transferred_block, collected["tx_hash"], 1, prior_owner, recipient,
+    )
+    try:
+        app.store.upsert_pools(pools())
+        app.store.ingest(
+            [opened_block, transferred_block],
+            [minted, opened, collected, delivered],
+            transactions=[{
+                "tx_hash": event["tx_hash"],
+                "block_number": event["block_number"],
+                "block_hash": event["block_hash"],
+                "payer": prior_owner,
+                "gas_usd": 0.01,
+            } for event in (opened, collected)],
+        )
+        prior = app.book.owner(prior_owner, {"window": "all"})
+        prior_episode = prior["positions"][0]["episodes"][0]
+        assert prior_episode["observed_collected_fees_usd"] == pytest.approx(0.1)
+        assert prior_episode["status"] == "transferred_out"
+
+        received = app.book.owner(recipient, {"window": "all"})
+        position = received["positions"][0]
+        assert position["owner"] == recipient
+        assert position["liquidity"] == "1000"
+        recipient_episode = position["episodes"][0]
+        assert recipient_episode["net_pnl_usd"] is None
+        assert "transferred_basis_unknown" in (
+            recipient_episode["coverage"]["reasons"]
+        )
+    finally:
+        app.close()
 
 
 def test_receipt_enrichment_adds_missed_logs_once_and_never_revives_orphans(tmp_path):

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -373,7 +373,10 @@ def test_protocol_input_signs_and_duplicate_delivery_survive_restart(tmp_path):
         events = [swap(blocks[0], V3, "v3"), swap(blocks[1], V4, "v4")]
         app.store.ingest(blocks, events)
         app.store.ingest(blocks, events)
-        app.store.save_v3_balance(V3, 99, blocks[0]["hash"], "100000000", "200000000")
+        app.store.queue_v3_balances([V3], 99, blocks[0]["hash"])
+        assert app.store.save_v3_balances([
+            (V3, 99, blocks[0]["hash"], "100000000", "200000000"),
+        ]) == [None]
         app.close()
         app = service(path)
         rows = {row["id"]: row for row in app.pools({"window": "1h"})["rows"]}
@@ -445,6 +448,41 @@ def test_backfill_insertion_order_does_not_reorder_live_tape(tmp_path):
     finally:
         app.close()
 
+def test_owner_tape_merges_owner_and_fallback_custody_in_canonical_order(
+        tmp_path):
+    app = service(tmp_path / "market.sqlite")
+    selected_owner = "0x" + "56" * 20
+    other_owner = "0x" + "78" * 20
+    try:
+        app.store.upsert_pools(pools())
+        now = int(time.time()) - 10
+        blocks = [header(100 + index, now + index) for index in range(3)]
+        custody = {
+            **swap(blocks[0], V3, "v3"), "kind": "add",
+            "custody": selected_owner,
+        }
+        shadowed_custody = {
+            **swap(blocks[1], V3, "v3"), "kind": "add",
+            "owner": other_owner, "custody": selected_owner,
+        }
+        owned = {
+            **swap(blocks[2], V3, "v3"), "kind": "add",
+            "owner": selected_owner,
+        }
+        app.store.ingest(blocks, [custody, shadowed_custody, owned])
+
+        rows = app.tape({
+            "window": "all", "owner": selected_owner,
+        })["rows"]
+
+        assert [row["block_number"] for row in rows] == [102, 100]
+        assert shadowed_custody["tx_hash"] not in {
+            row["tx_hash"] for row in rows
+        }
+    finally:
+        app.close()
+
+
 @pytest.mark.parametrize(
     ("recent_kind", "params", "expected_rows"),
     (
@@ -494,6 +532,42 @@ def test_underfilled_tape_stays_within_window(
     finally:
         connection.set_progress_handler(None, 0)
         app.close()
+
+def test_lp_tape_does_not_scan_dense_swap_history(tmp_path):
+    path = tmp_path / "market.sqlite"
+    seed = MarketStore(path)
+    now = int(time.time())
+    lp_block = header(100, now - 2)
+    swap_block = header(101, now - 1)
+    try:
+        seed.upsert_pools(pools())
+        lp_event = {
+            **swap(lp_block, V3, "v3"), "kind": "add",
+        }
+        seed.ingest(
+            [lp_block, swap_block],
+            [
+                lp_event,
+                *(swap(swap_block, V3, "v3", index=index)
+                  for index in range(4_000)),
+            ],
+        )
+    finally:
+        seed.close()
+
+    app = service(path)
+    status = app.status()
+    connection = app.store.read()
+    connection.set_progress_handler(lambda: 1, 2_000)
+    try:
+        result = app.tape({"window": "all", "limit": 1}, _status=status)
+        assert [row["tx_hash"] for row in result["rows"]] == [
+            lp_event["tx_hash"],
+        ]
+    finally:
+        connection.set_progress_handler(None, 0)
+        app.close()
+
 
 def test_backfilled_price_repairs_existing_flows_after_restart(tmp_path):
     path = tmp_path / "market.sqlite"
@@ -2417,6 +2491,46 @@ def test_pool_sort_keeps_unpriced_metrics_last_in_both_directions(tmp_path):
             ]
     finally:
         app.close()
+
+def test_shared_bucket_views_refresh_on_events_and_empty_window_advance(
+        tmp_path):
+    app = service(tmp_path / "market.sqlite")
+    try:
+        app.store.upsert_pools(pools())
+        first = header(100, 10_000)
+        app.store.ingest([first], [swap(first, V3, "v3")], cursor={
+            "from_block": 100, "to_block": 100, "block_number": 100,
+            "block_hash": first["hash"], "timestamp": 10_000,
+        })
+        assert app.overview({"window": "1h"})["swaps"] == 1
+        assert app.pools({
+            "window": "1h", "sort": "volume",
+        })["rows"][0]["id"] == V3
+
+        second = header(101, 10_001)
+        app.store.ingest([second], [swap(second, V4, "v4")], cursor={
+            "from_block": 101, "to_block": 101, "block_number": 101,
+            "block_hash": second["hash"], "timestamp": 10_001,
+        })
+        fee_rows = app.pools({"window": "1h", "sort": "fees"})["rows"]
+        assert [row["id"] for row in fee_rows] == [V4, V3]
+        assert app.overview({"window": "1h"})["swaps"] == 2
+
+        empty = header(102, 13_661)
+        before_empty = app.status()["events_revision"]
+        app.store.ingest([empty], [], cursor={
+            "from_block": 102, "to_block": 102, "block_number": 102,
+            "block_hash": empty["hash"], "timestamp": 13_661,
+        })
+        assert app.status()["events_revision"] == before_empty
+        assert app.overview({"window": "1h"})["swaps"] == 0
+        assert {
+            row["swaps"]
+            for row in app.pools({"window": "1h", "sort": "swaps"})["rows"]
+        } == {0}
+    finally:
+        app.close()
+
 
 
 def test_receipt_settlement_flows_are_not_v4_position_cashflows(tmp_path, monkeypatch):

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -12,6 +12,7 @@ from rhpools.lp_market_protocols import (
 )
 from rhpools.lp_market_index import V3_BIRTH_REPAIR_PREFIXES
 from rhpools.lp_market_accounting import AccountBook
+from rhpools.lp_market_claims import PositionClaims
 from rhpools.lp_market_service import LPMarketService, PriceProjection
 from rhpools.lp_rpc import _WssRpc, build_rpc_factory
 from rhpools.lp_market_store import CanonicalConflict, MarketStore
@@ -795,6 +796,33 @@ def test_source_correction_removes_stale_episode_gas(tmp_path):
         assert detail["summary"]["net_pnl_usd"] == pytest.approx(0.08)
     finally:
         store.close()
+
+def test_visible_wallet_recovers_missed_receipt_cost_without_new_activity(tmp_path):
+    blocks = [header(100 + index, 1_000 + index) for index in range(2)]
+    opened, closed, transactions = traced_v4_episode(blocks, key="late-cost")
+    store, book = accounting_store(tmp_path / "late-cost.sqlite", deferred=True)
+    try:
+        store.ingest(blocks, [opened, closed])
+        drain_accounting(book)
+        # This reproduces persisted receipt evidence whose old accounting
+        # publication missed its cost dependency.
+        store.enrich([], transactions=transactions)
+        assert book.owner(TOKEN, {"window": "all"})["summary"]["net_pnl_usd"] is None
+        book.recover_receipt_costs(
+            [row["tx_hash"] for row in transactions], epoch=-1,
+        )
+        assert book.owner(TOKEN, {"window": "all"})["summary"]["net_pnl_usd"] is None
+
+        worker = PositionClaims(store, book, None, lambda: None)
+        worker.request([TOKEN])
+        worker._refresh(*worker._next())
+        summary = book.owner(TOKEN, {"window": "all"})["summary"]
+        assert summary["gas_usd"] == pytest.approx(0.02)
+        assert summary["net_pnl_usd"] == pytest.approx(0.08)
+        assert book.closed({"window": "all"})["rows"][0]["net_pnl_usd"] == pytest.approx(0.08)
+    finally:
+        store.close()
+
 
 
 def test_deferred_accounting_does_not_hold_writer_and_drains_same_branch_prefix(

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -1900,6 +1900,17 @@ def test_owner_projection_is_shared_and_never_blocks_current_feed(
             "window": "all", "sort": "activity", "limit": 200,
         }) == envelope
         assert calls == 1
+
+        from types import SimpleNamespace
+        from rhpools import lp_market_claims
+        expired = time.monotonic() + 181
+        monkeypatch.setattr(
+            lp_market_claims, "time", SimpleNamespace(monotonic=lambda: expired),
+        )
+        assert app.claims._next() is None
+        assert app.poll_owners(params, after_revision=envelope["revision"]) is None
+        assert app.claims._next()[0] in {row["owner"] for row in envelope["rows"]}
+        assert calls == 1
     finally:
         release.set()
         app.close()

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -635,6 +635,15 @@ def drain_accounting(book):
         pass
 
 
+def owner_open(block, owner, key):
+    event = lp_effect(
+        block, "v4", "add", 1_000, (1_000_000, 1_000_000),
+        position_state(0), position_state(1_000), key=key,
+    )
+    event.update(owner=owner, custody=MANAGER)
+    return event
+
+
 def test_deferred_accounting_does_not_hold_writer_and_drains_same_branch_prefix(
         tmp_path, monkeypatch):
     blocks = [header(100 + index, 1_000 + index) for index in range(2)]
@@ -892,6 +901,279 @@ def test_deferred_accounting_restart_resumes_queue_and_clears_reassigned_key(
         assert [row["position_key"] for row in after] == ["v4:after"]
         assert after[0]["liquidity"] == "1000"
     finally:
+        store.close()
+
+
+def test_deferred_nft_transfer_hints_mark_both_wallets_pending(
+        tmp_path):
+    sender = "0x" + "56" * 20
+    recipient = "0x" + "78" * 20
+    bystander = "0x" + "9a" * 20
+    blocks = [header(100 + index, 1_000 + index) for index in range(4)]
+    seeds = [
+        owner_open(blocks[0], sender, "sender-seed"),
+        owner_open(blocks[1], recipient, "recipient-seed"),
+        owner_open(blocks[2], bystander, "bystander-seed"),
+    ]
+    store, book = accounting_store(tmp_path / "market.sqlite", deferred=True)
+    position_key = f"nft:{MANAGER}:42"
+    try:
+        store.ingest(blocks[:3], seeds)
+        drain_accounting(book)
+        transfer = swap(blocks[3], V4, "v4")
+        transfer.update(
+            protocol="nft", kind="transfer", position_key=position_key,
+            token_id="42", owner=recipient, custody=MANAGER,
+            liquidity=None, liquidity_delta=None, amount0=None, amount1=None,
+            cashflow0=None, cashflow1=None,
+            data={
+                "from": sender, "to": recipient,
+                "manager_protocol": "v4",
+            },
+        )
+        store.ingest(blocks[3:], [transfer])
+
+        rows = {
+            row["owner"]: row
+            for row in book.owner_candidates({
+                "window": "all", "protocol": "v4", "identity_scope": "wallets",
+            })["rows"]
+        }
+        assert all(rows[owner]["positions"] == 1 for owner in rows)
+        assert rows[sender]["financial_pending"] is True
+        assert rows[recipient]["financial_pending"] is True
+        assert rows[bystander]["financial_pending"] is False
+    finally:
+        store.close()
+
+
+def test_historical_owner_reassignment_survives_identity_cursor(
+        tmp_path, monkeypatch):
+    prior_owner = "0x" + "56" * 20
+    reassigned_owner = "0x" + "78" * 20
+    blocks = [header(100 + index, 1_000 + index) for index in range(2)]
+    original = owner_open(blocks[0], prior_owner, "reassigned")
+    other = owner_open(blocks[1], reassigned_owner, "existing")
+    store, book = accounting_store(tmp_path / "market.sqlite", deferred=True)
+    position_key = str(original["position_key"])
+    try:
+        inserted = store.ingest(blocks, [original, other])
+        event_id = int(inserted[0]["id"])
+        drain_accounting(book)
+        with store.transaction() as conn:
+            book._queue_position_keys(
+                conn, {position_key: (100, 0, 0)},
+            )
+            conn.execute(
+                "UPDATE lp_accounting_pending SET identity_cursor=? "
+                "WHERE position_key=?",
+                (event_id, position_key),
+            )
+            conn.execute(
+                "DELETE FROM lp_accounting_pending_identities "
+                "WHERE position_key=?",
+                (position_key,),
+            )
+
+        store.enrich([{
+            **original, "id": event_id, "owner": reassigned_owner,
+        }])
+        pending = store.read().execute(
+            "SELECT identities_ready,identity_cursor "
+            "FROM lp_accounting_pending WHERE position_key=?",
+            (position_key,),
+        ).fetchone()
+        hinted_owners = {
+            str(row[0])
+            for row in store.read().execute(
+                "SELECT identity "
+                "FROM lp_accounting_pending_identities "
+                "WHERE position_key=? AND kind='owner'",
+                (position_key,),
+            ).fetchall()
+        }
+        assert (
+            int(pending["identities_ready"]),
+            int(pending["identity_cursor"]),
+        ) == (0, event_id)
+        assert hinted_owners == {reassigned_owner}
+
+        monkeypatch.setattr(book, "_prepare_pending", lambda _key: None)
+        assert book.project_pending(limit=1) is True
+        ready = store.read().execute(
+            "SELECT identities_ready FROM lp_accounting_pending "
+            "WHERE position_key=?",
+            (position_key,),
+        ).fetchone()
+        rows = {
+            row["owner"]: row
+            for row in book.owner_candidates({"window": "all"})["rows"]
+        }
+        assert int(ready["identities_ready"]) == 1
+        assert rows[prior_owner]["financial_pending"] is True
+        assert rows[reassigned_owner]["financial_pending"] is True
+    finally:
+        store.close()
+
+
+def test_legacy_pending_identity_recovery_resumes_after_restart(
+        tmp_path, monkeypatch):
+    path = tmp_path / "market.sqlite"
+    queued_owner = "0x" + "56" * 20
+    unrelated_owner = "0x" + "78" * 20
+    blocks = [header(100 + index, 1_000 + index) for index in range(2)]
+    queued = owner_open(blocks[0], queued_owner, "legacy")
+    unrelated = owner_open(blocks[1], unrelated_owner, "unrelated")
+    store, book = accounting_store(path, deferred=True)
+    position_key = str(queued["position_key"])
+    store.ingest(blocks, [queued, unrelated])
+    drain_accounting(book)
+    with store.transaction() as conn:
+        book._queue_position_keys(conn, {position_key: (100, 0, 0)})
+        conn.execute(
+            "DELETE FROM lp_accounting_pending_identities "
+            "WHERE position_key=?",
+            (position_key,),
+        )
+    store.close()
+
+    store = MarketStore(path)
+    PriceProjection(store)
+    book = AccountBook(store, deferred=True)
+
+    def unexpected_replay(*_args, **_kwargs):
+        raise AssertionError("deferred restart replayed the ledger")
+
+    monkeypatch.setattr(book, "_map_existing_events", unexpected_replay)
+    monkeypatch.setattr(book, "_rebuild_position", unexpected_replay)
+    try:
+        book.install()
+        before = {
+            row["owner"]: row
+            for row in book.owner_candidates({"window": "all"})["rows"]
+        }
+        assert before[queued_owner]["positions"] == 1
+        assert before[unrelated_owner]["positions"] == 1
+        assert before[queued_owner]["financial_pending"] is True
+        assert before[unrelated_owner]["financial_pending"] is True
+
+        monkeypatch.setattr(book, "_prepare_pending", lambda _key: None)
+        assert book.project_pending(limit=1) is True
+        pending = store.read().execute(
+            "SELECT identities_ready FROM lp_accounting_pending "
+            "WHERE position_key=?",
+            (position_key,),
+        ).fetchone()
+        after = {
+            row["owner"]: row
+            for row in book.owner_candidates({"window": "all"})["rows"]
+        }
+        assert int(pending["identities_ready"]) == 1
+        assert after[queued_owner]["financial_pending"] is True
+        assert after[unrelated_owner]["financial_pending"] is False
+    finally:
+        store.close()
+
+
+def test_pending_identity_recovery_rejects_orphan_epoch(
+        tmp_path, monkeypatch):
+    old_owner = "0x" + "56" * 20
+    replacement_owner = "0x" + "78" * 20
+    old_block = header(100, 1_000)
+    replacement_block = header(100, 1_001, branch=10_000)
+    old_event = owner_open(old_block, old_owner, "identity-reorg")
+    replacement = owner_open(
+        replacement_block, replacement_owner, "identity-reorg",
+    )
+    store, book = accounting_store(tmp_path / "market.sqlite", deferred=True)
+    position_key = str(old_event["position_key"])
+    prepared = threading.Event()
+    release = threading.Event()
+    failures = []
+    original_prepare = book._prepare_pending_identity_hints
+
+    def paused_prepare():
+        result = original_prepare()
+        prepared.set()
+        if not release.wait(5):
+            raise TimeoutError("test did not release identity recovery")
+        return result
+
+    def recover():
+        try:
+            book.project_pending(limit=1)
+        except BaseException as error:
+            failures.append(error)
+
+    monkeypatch.setattr(
+        book, "_prepare_pending_identity_hints", paused_prepare,
+    )
+    monkeypatch.setattr(book, "_prepare_pending", lambda _key: None)
+    try:
+        store.ingest([old_block], [old_event])
+        with store.transaction() as conn:
+            conn.execute(
+                "UPDATE lp_accounting_pending SET identities_ready=0,"
+                "identity_cursor=0 WHERE position_key=?",
+                (position_key,),
+            )
+            conn.execute(
+                "DELETE FROM lp_accounting_pending_identities "
+                "WHERE position_key=?",
+                (position_key,),
+            )
+        projector = threading.Thread(target=recover)
+        projector.start()
+        assert prepared.wait(2)
+        store.rollback(99)
+        store.ingest([replacement_block], [replacement])
+        release.set()
+        projector.join(2)
+        assert not projector.is_alive()
+        assert failures == []
+
+        hinted_owners = {
+            str(row[0])
+            for row in store.read().execute(
+                "SELECT identity "
+                "FROM lp_accounting_pending_identities "
+                "WHERE position_key=? AND kind='owner'",
+                (position_key,),
+            ).fetchall()
+        }
+        pending = store.read().execute(
+            "SELECT identities_ready,identity_cursor "
+            "FROM lp_accounting_pending WHERE position_key=?",
+            (position_key,),
+        ).fetchone()
+        assert hinted_owners == {replacement_owner}
+        assert (
+            int(pending["identities_ready"]),
+            int(pending["identity_cursor"]),
+        ) == (0, 0)
+
+        monkeypatch.setattr(
+            book, "_prepare_pending_identity_hints", original_prepare,
+        )
+        assert book._recover_pending_identities() is True
+        final_owners = {
+            str(row[0])
+            for row in store.read().execute(
+                "SELECT identity "
+                "FROM lp_accounting_pending_identities "
+                "WHERE position_key=? AND kind='owner'",
+                (position_key,),
+            ).fetchall()
+        }
+        ready = store.read().execute(
+            "SELECT identities_ready FROM lp_accounting_pending "
+            "WHERE position_key=?",
+            (position_key,),
+        ).fetchone()
+        assert final_owners == {replacement_owner}
+        assert int(ready["identities_ready"]) == 1
+    finally:
+        release.set()
         store.close()
 
 

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -871,6 +871,64 @@ def test_source_correction_removes_stale_episode_gas(tmp_path):
     finally:
         store.close()
 
+def test_episode_basis_correction_preserves_financial_history(tmp_path):
+    blocks = [header(100 + index, 1_000 + index) for index in range(2)]
+    opened, closed, transactions = traced_v4_episode(
+        blocks, key="basis-only-replay",
+    )
+    store, book = accounting_store(
+        tmp_path / "basis-only-replay.sqlite", deferred=True,
+    )
+    try:
+        inserted = store.ingest(
+            blocks, [opened, closed], transactions=transactions,
+        )
+        drain_accounting(book)
+        before = book.closed({"window": "all"})["rows"][0]
+        assert before["gas_usd"] == pytest.approx(0.02)
+
+        store.enrich([{
+            "id": int(inserted[1]["id"]),
+            "data": {"cashflow_basis": "corrected-source-basis"},
+        }])
+        drain_accounting(book)
+
+        after = book.closed({"window": "all"})["rows"][0]
+        assert after["id"] == before["id"]
+        assert after["accounting_basis"] == "corrected-source-basis"
+        for field in (
+            "deposit_usd", "withdrawal_usd", "fees_usd", "gross_pnl_usd",
+            "gas_usd", "net_pnl_usd",
+        ):
+            assert after[field] == pytest.approx(before[field])
+    finally:
+        store.close()
+
+
+def test_late_receipts_complete_deferred_gas_and_net_results(tmp_path):
+    blocks = [header(100 + index, 1_000 + index) for index in range(2)]
+    opened, closed, transactions = traced_v4_episode(
+        blocks, key="receipt-only",
+    )
+    store, book = accounting_store(
+        tmp_path / "receipt-only.sqlite", deferred=True,
+    )
+    try:
+        store.ingest(blocks, [opened, closed])
+        drain_accounting(book)
+        assert book.closed({"window": "all"})["rows"][0]["gas_usd"] is None
+
+        store.enrich([], transactions=transactions)
+
+        drain_accounting(book)
+        after = book.closed({"window": "all"})["rows"][0]
+        assert after["gas_usd"] == pytest.approx(0.02)
+        assert after["net_pnl_usd"] == pytest.approx(0.08)
+        assert store.status()["pending_accounting"] == 0
+    finally:
+        store.close()
+
+
 def test_visible_wallet_recovers_missed_receipt_cost_without_new_activity(tmp_path):
     blocks = [header(100 + index, 1_000 + index) for index in range(2)]
     opened, closed, transactions = traced_v4_episode(blocks, key="late-cost")

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -644,6 +644,159 @@ def owner_open(block, owner, key):
     return event
 
 
+def test_backfill_preserves_published_episode_ids_and_returns(tmp_path):
+    path = tmp_path / "stable-episodes.sqlite"
+    store, book = accounting_store(path, deferred=True)
+    try:
+        recent_blocks = [header(200 + index, 2_000 + index) for index in range(2)]
+        recent_open, recent_close, recent_gas = traced_v4_episode(recent_blocks)
+        store.ingest(
+            recent_blocks, [recent_open, recent_close],
+            transactions=[{**row, "gas_usd": None} for row in recent_gas],
+        )
+        drain_accounting(book)
+        recent = book.closed({"window": "all"})["rows"][0]
+        assert recent["net_pnl_usd"] is None
+        store.enrich([recent_open, recent_close], transactions=recent_gas)
+        drain_accounting(book)
+        recent = book.closed({"window": "all"})["rows"][0]
+        assert recent["net_pnl_usd"] == pytest.approx(0.08)
+
+        older_blocks = [header(100 + index, 1_000 + index) for index in range(2)]
+        older_open, older_close, older_gas = traced_v4_episode(older_blocks)
+        store.ingest(
+            older_blocks, [older_open, older_close], transactions=older_gas, lane="backfill",
+        )
+        drain_accounting(book)
+        published = {
+            int(row["opened_at"]): row
+            for row in book.closed({"window": "all"})["rows"]
+        }
+        assert published[2000]["id"] == recent["id"]
+        assert published[2000]["net_pnl_usd"] == pytest.approx(
+            recent["net_pnl_usd"],
+        )
+        assert published[1000]["id"] != recent["id"]
+        assert published[1000]["net_pnl_usd"] == pytest.approx(0.08)
+        ids = {block: row["id"] for block, row in published.items()}
+
+        orphan_block = header(202, 2_002)
+        orphan = lp_effect(
+            orphan_block, "v4", "checkpoint", 0, (0, 0),
+            position_state(0), position_state(0), key="deferred",
+        )
+        store.ingest([orphan_block], [orphan], transactions=[{
+            "tx_hash": orphan["tx_hash"],
+            "block_number": orphan["block_number"],
+            "block_hash": orphan["block_hash"],
+            "payer": TOKEN,
+            "gas_usd": 0.01,
+        }])
+        store.rollback(201)
+        store.close()
+
+        store, book = accounting_store(path, deferred=True)
+        drain_accounting(book)
+        replayed = {
+            int(row["opened_at"]): row
+            for row in book.closed({"window": "all"})["rows"]
+        }
+        assert {block: row["id"] for block, row in replayed.items()} == ids
+        assert all(
+            row["net_pnl_usd"] == pytest.approx(0.08)
+            for row in replayed.values()
+        )
+        owner_episodes = {
+            int(row["opened_at"]): row
+            for position in book.owner(TOKEN, {"window": "all"})["positions"]
+            for row in position["episodes"]
+        }
+        assert {
+            block: row["id"] for block, row in owner_episodes.items()
+        } == ids
+        assert all(
+            row["net_pnl_usd"] == pytest.approx(0.08)
+            for row in owner_episodes.values()
+        )
+    finally:
+        store.close()
+
+
+def test_source_correction_removes_stale_episode_gas(tmp_path):
+    blocks = [header(100 + index, 1_000 + index) for index in range(3)]
+    opened, closed, transactions = traced_v4_episode(
+        [blocks[0], blocks[2]], key="gas-correction",
+    )
+    intermediate = lp_effect(
+        blocks[1], "v4", "checkpoint", 0, (0, 0),
+        position_state(1_000), position_state(1_000), key="gas-correction",
+    )
+    intermediate.update(
+        owner=TOKEN, custody=MANAGER,
+        cashflow0="0", cashflow1="0", fee_amount0="0", fee_amount1="0",
+    )
+    intermediate["data"].update(
+        trace_complete=True, fees_accrued_exact=True,
+        principal_delta_exact=True,
+        principal_delta={"amount0": "0", "amount1": "0"},
+    )
+    transactions.insert(1, {
+        "tx_hash": intermediate["tx_hash"],
+        "block_number": intermediate["block_number"],
+        "block_hash": intermediate["block_hash"],
+        "payer": TOKEN,
+        "gas_usd": 0.01,
+    })
+    store, book = accounting_store(
+        tmp_path / "gas-correction.sqlite", deferred=True,
+    )
+    try:
+        store.ingest(
+            blocks, [opened, intermediate, closed], transactions=transactions,
+        )
+        drain_accounting(book)
+        before = book.closed({"window": "all"})["rows"][0]
+        assert before["deposit_usd"] == pytest.approx(2)
+        assert before["withdrawal_usd"] == pytest.approx(2)
+        assert before["fees_usd"] == pytest.approx(0.1)
+        assert before["gross_pnl_usd"] == pytest.approx(0.1)
+        assert before["gas_usd"] == pytest.approx(0.03)
+        assert before["net_pnl_usd"] == pytest.approx(0.07)
+
+        store.enrich([{
+            **intermediate,
+            "position_key": None,
+            "owner": None,
+            "custody": None,
+            "identity_basis": "unresolved_position",
+        }])
+        drain_accounting(book)
+
+        after = book.closed({"window": "all"})["rows"][0]
+        assert after["id"] == before["id"]
+        assert after["deposit_usd"] == pytest.approx(before["deposit_usd"])
+        assert after["withdrawal_usd"] == pytest.approx(before["withdrawal_usd"])
+        assert after["fees_usd"] == pytest.approx(before["fees_usd"])
+        assert after["gross_pnl_usd"] == pytest.approx(before["gross_pnl_usd"])
+        assert after["gas_usd"] == pytest.approx(0.02)
+        assert after["net_pnl_usd"] == pytest.approx(0.08)
+
+        detail = book.owner(TOKEN, {"window": "all"})
+        owner_episode = next(
+            row
+            for position in detail["positions"]
+            if position["position_key"] == "v4:gas-correction"
+            for row in position["episodes"]
+            if row["id"] == before["id"]
+        )
+        assert owner_episode["gas_usd"] == pytest.approx(0.02)
+        assert owner_episode["net_pnl_usd"] == pytest.approx(0.08)
+        assert detail["summary"]["gas_usd"] == pytest.approx(0.02)
+        assert detail["summary"]["net_pnl_usd"] == pytest.approx(0.08)
+    finally:
+        store.close()
+
+
 def test_deferred_accounting_does_not_hold_writer_and_drains_same_branch_prefix(
         tmp_path, monkeypatch):
     blocks = [header(100 + index, 1_000 + index) for index in range(2)]

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -947,8 +947,7 @@ def test_deferred_nft_transfer_hints_mark_both_wallets_pending(
         store.close()
 
 
-def test_historical_owner_reassignment_survives_identity_cursor(
-        tmp_path, monkeypatch):
+def test_historical_owner_reassignment_survives_identity_cursor(tmp_path):
     prior_owner = "0x" + "56" * 20
     reassigned_owner = "0x" + "78" * 20
     blocks = [header(100 + index, 1_000 + index) for index in range(2)]
@@ -998,8 +997,7 @@ def test_historical_owner_reassignment_survives_identity_cursor(
         ) == (0, event_id)
         assert hinted_owners == {reassigned_owner}
 
-        monkeypatch.setattr(book, "_prepare_pending", lambda _key: None)
-        assert book.project_pending(limit=1) is True
+        assert book.recover_pending_identities() is True
         ready = store.read().execute(
             "SELECT identities_ready FROM lp_accounting_pending "
             "WHERE position_key=?",
@@ -1057,8 +1055,7 @@ def test_legacy_pending_identity_recovery_resumes_after_restart(
         assert before[queued_owner]["financial_pending"] is True
         assert before[unrelated_owner]["financial_pending"] is True
 
-        monkeypatch.setattr(book, "_prepare_pending", lambda _key: None)
-        assert book.project_pending(limit=1) is True
+        assert book.recover_pending_identities() is True
         pending = store.read().execute(
             "SELECT identities_ready FROM lp_accounting_pending "
             "WHERE position_key=?",
@@ -1101,14 +1098,13 @@ def test_pending_identity_recovery_rejects_orphan_epoch(
 
     def recover():
         try:
-            book.project_pending(limit=1)
+            book.recover_pending_identities()
         except BaseException as error:
             failures.append(error)
 
     monkeypatch.setattr(
         book, "_prepare_pending_identity_hints", paused_prepare,
     )
-    monkeypatch.setattr(book, "_prepare_pending", lambda _key: None)
     try:
         store.ingest([old_block], [old_event])
         with store.transaction() as conn:
@@ -1155,7 +1151,7 @@ def test_pending_identity_recovery_rejects_orphan_epoch(
         monkeypatch.setattr(
             book, "_prepare_pending_identity_hints", original_prepare,
         )
-        assert book._recover_pending_identities() is True
+        assert book.recover_pending_identities() is True
         final_owners = {
             str(row[0])
             for row in store.read().execute(
@@ -1522,6 +1518,82 @@ def test_v3_manager_log_order_recovers_complete_fees_without_overstating_wallet_
         assert len(historical["ownership"]) == 1
         assert historical["ownership"][0]["acquired_by"] == "mint"
         assert historical["ownership"][0]["complete"] is True
+    finally:
+        app.close()
+
+
+def test_closed_pages_qualified_fees_and_unicode_pair_queries(tmp_path):
+    app = service(tmp_path / "market.sqlite")
+    try:
+        app.store.upsert_pools(pools())
+        keys = ("high", "unicode", "low", "incomplete")
+        blocks = [
+            header(100 + index, int(time.time()) - 120 + index)
+            for index in range(len(keys) * 2)
+        ]
+        events = []
+        transactions = []
+        for index, key in enumerate(keys):
+            opened, closed, episode_transactions = traced_v4_episode(
+                blocks[index * 2:index * 2 + 2], key=key,
+            )
+            events.extend((opened, closed))
+            transactions.extend(episode_transactions)
+        app.store.ingest(blocks, events, transactions=transactions)
+
+        with app.store.transaction() as connection:
+            for key, fees in zip(keys, (3.0, 2.0, 1.0, 99.0)):
+                connection.execute(
+                    "UPDATE lp_accounting_episodes SET fees_usd=? "
+                    "WHERE position_key=?",
+                    (fees, f"v4:{key}"),
+                )
+            connection.execute(
+                "UPDATE lp_accounting_episodes SET history_complete=0 "
+                "WHERE position_key=?",
+                ("v4:incomplete",),
+            )
+            connection.execute(
+                "UPDATE lp_accounting_episodes SET pool_id=? "
+                "WHERE position_key IN (?,?)",
+                (V3, "v4:high", "v4:low"),
+            )
+            connection.execute(
+                "UPDATE pools SET symbol0=NULL,token0=?,"
+                "symbol1=NULL,token1='' WHERE id=?",
+                ("CAFÉ%_TOKEN_LONG", V4),
+            )
+
+        page = app.book.closed({
+            "window": "all", "sort": "fees", "limit": 2, "offset": 1,
+        })
+        assert page["total"] == 4
+        assert [
+            row["position_key"] for row in page["rows"]
+        ] == ["v4:unicode", "v4:low"]
+        assert [row["fees_usd"] for row in page["rows"]] == [2.0, 1.0]
+
+        exhausted = app.book.closed({
+            "window": "all", "sort": "fees", "limit": 2, "offset": 99,
+        })
+        assert exhausted["rows"] == []
+        assert exhausted["total"] == 4
+
+        unicode_query = app.book.closed({
+            "window": "all", "sort": "fees", "q": "FÉ%_",
+        })
+        assert unicode_query["total"] == 2
+        assert [
+            row["position_key"] for row in unicode_query["rows"]
+        ] == ["v4:unicode", "v4:incomplete"]
+        assert unicode_query["rows"][0]["pair"] == "CAFÉ%_TO/?"
+        assert unicode_query["rows"][1]["fees_usd"] is None
+        assert unicode_query["rows"][1][
+            "observed_collected_fees_usd"
+        ] == 99.0
+        assert app.book.closed({
+            "window": "all", "q": "asset%_",
+        })["total"] == 0
     finally:
         app.close()
 

--- a/tests/test_lp_market_service.py
+++ b/tests/test_lp_market_service.py
@@ -1885,13 +1885,13 @@ def test_owner_summary_deduplicates_shared_transaction_costs_and_preserves_unkno
         owner2 = "0x" + "78" * 20
         blocks = [header(100 + i, int(time.time()) - 60 + i) for i in range(6)]
         opened_a = lp_effect(blocks[0], "v4", "add", 1000, (1_000_000, 1_000_000),
-                             position_state(0), position_state(1000), key="a")
+                             position_state(0), position_state(1000), key="gas-position-a")
         opened_b = lp_effect(blocks[1], "v4", "add", 1000, (1_000_000, 1_000_000),
-                             position_state(0), position_state(1000), key="b")
+                             position_state(0), position_state(1000), key="gas-position-b")
         closed_a = lp_effect(blocks[2], "v4", "remove", -1000, (1_000_000, 1_000_000),
-                             position_state(1000), position_state(0), key="a")
+                             position_state(1000), position_state(0), key="gas-position-a")
         closed_b = lp_effect(blocks[2], "v4", "remove", -1000, (1_000_000, 1_000_000),
-                             position_state(1000), position_state(0), key="b")
+                             position_state(1000), position_state(0), key="gas-position-b")
         closed_b.update(tx_hash=closed_a["tx_hash"], log_index=1)
         for event in (opened_a, opened_b, closed_a, closed_b):
             event["custody"] = MANAGER
@@ -1944,6 +1944,11 @@ def test_owner_summary_deduplicates_shared_transaction_costs_and_preserves_unkno
         assert owner_rows[TOKEN]["gas_usd"] == pytest.approx(0.03)
         assert owner_rows[TOKEN]["net_pnl_usd"] == pytest.approx(0.17)
         assert owner_rows[TOKEN]["coverage"]["cost_qualified"] is True
+        scoped = app.book.owners({
+            "window": "all", "q": "gas-position-a", "identity_scope": "wallets",
+        })["rows"][0]
+        assert scoped["gas_usd"] == pytest.approx(0.02)
+        assert scoped["net_pnl_usd"] == pytest.approx(0.08)
         assert owner_rows[owner2]["fees_usd"] is None
         assert owner_rows[owner2]["gas_usd"] is None
         assert owner_rows[owner2]["net_pnl_usd"] is None
@@ -3075,6 +3080,7 @@ def test_cold_v4_activity_resolves_only_a_complete_verified_pool_key(
     tmp_path, monkeypatch, matching_key, delivery,
 ):
     from eth_utils import keccak
+    from rhpools.lp_market_index import MarketIndexer
     from rhpools import workbench_market as market
 
     class OfflineRpc:
@@ -3083,6 +3089,14 @@ def test_cold_v4_activity_resolves_only_a_complete_verified_pool_key(
 
         def close(self):
             pass
+
+    original_init = MarketIndexer.__init__
+    monkeypatch.setattr(
+        MarketIndexer, "__init__",
+        lambda self, *args, **kwargs: original_init(
+            self, *args, rpc=OfflineRpc(), **kwargs,
+        ),
+    )
 
     universe = market._Universe((), {}, {"v2": 0, "v3": 0, "v4": 0}, (), (), {})
     monkeypatch.setattr(market, "_load_universe", lambda: universe)
@@ -3118,7 +3132,7 @@ def test_cold_v4_activity_resolves_only_a_complete_verified_pool_key(
     } for index, token in enumerate((token0, token1))]
     receipt = {
         "transactionHash": log["transactionHash"], "blockHash": block["hash"],
-        "logs": [log, *transfers],
+        "blockNumber": block["number"], "logs": [log, *transfers],
     }
     # A router supplies reversed currencies, two unrelated addresses, then
     # the fee/spacing/hook tuple. It does not embed a contiguous PoolKey.
@@ -3136,7 +3150,7 @@ def test_cold_v4_activity_resolves_only_a_complete_verified_pool_key(
         if method == "eth_getTransactionByHash":
             return transaction if from_input else None
         if method == "eth_getBlockByNumber":
-            return block
+            return {block["number"]: block, current["number"]: current}[params[0]]
         if method != "eth_call":
             raise AssertionError(method)
         if not release.wait(3):

--- a/tests/test_lp_market_store.py
+++ b/tests/test_lp_market_store.py
@@ -7,6 +7,7 @@ import pytest
 
 from rhpools.lp_market_store import CanonicalConflict, MarketStore
 from rhpools.lp_market_accounting import AccountBook
+from rhpools.lp_market_protocols import core_position_key
 
 
 def header(number: int, *, parent: str | None = None) -> dict[str, str]:
@@ -35,6 +36,53 @@ def event(block: dict[str, str], log_index: int) -> dict[str, object]:
         "token_id": "7",
         "data": {},
     }
+
+
+def v4_core_effect(
+        block, index, raw_key, kind, liquidity_delta, before, after, *,
+        cashflow=(0, 0), fees=(0, 0), deposit_usd=0.0,
+        withdrawal_usd=0.0, fees_usd=0.0):
+    row = event(block, index)
+    row.update({
+        "tx_hash": "0x" + f"{10_000 + index:064x}",
+        "pool_id": None,
+        "protocol": "v4",
+        "kind": kind,
+        "position_key": raw_key,
+        "identity_basis": "verified_owner",
+        "tick_lower": -10,
+        "tick_upper": 10,
+        "liquidity": str(after["liquidity"]),
+        "liquidity_delta": str(liquidity_delta),
+        "amount0": "0",
+        "amount1": "0",
+        "cashflow0": str(cashflow[0]),
+        "cashflow1": str(cashflow[1]),
+        "fee_amount0": str(fees[0]),
+        "fee_amount1": str(fees[1]),
+        "deposit_usd": deposit_usd,
+        "withdrawal_usd": withdrawal_usd,
+        "fees_usd": fees_usd,
+        "accounting_basis": "complete v4 trace",
+        "data": {
+            "core_position_key": raw_key,
+            "position_before": before,
+            "position_after": after,
+            "trace_complete": True,
+            "fees_accrued_exact": True,
+            "principal_delta_exact": True,
+            "principal_delta": {
+                "amount0": str(cashflow[0] - fees[0]),
+                "amount1": str(cashflow[1] - fees[1]),
+            },
+        },
+    })
+    return row
+
+
+def drain_accounting(book):
+    while book.project_pending(limit=32):
+        pass
 
 
 def test_financial_queues_do_not_starve_recent_work_or_history(tmp_path):
@@ -148,6 +196,482 @@ def test_catalog_replay_and_restart_keep_search_counts_exact(tmp_path):
         store = MarketStore(path)
         assert store.search_catalog("v3")[1] == 1
         assert store.search_catalog("BBB USDG")[1] == 1
+    finally:
+        store.close()
+
+
+def test_legacy_core_position_repair_is_bounded_resumable_and_atomic(tmp_path):
+    path = tmp_path / "core-position-repair.sqlite"
+    raw_key = "0x" + "ca" * 32
+    v3_pool = "0x" + "31" * 20
+    v4_pool = "0x" + "42" * 32
+    v3_key = core_position_key("v3", v3_pool, raw_key)
+    v4_key = core_position_key("v4", v4_pool, raw_key)
+    blocks = [header(number) for number in range(10, 16)]
+    cursor = {
+        "from_block": 10,
+        "to_block": 15,
+        "block_number": 15,
+        "block_hash": blocks[-1]["hash"],
+    }
+    rows = []
+    for index, block in enumerate(blocks):
+        protocol = "v3" if index < 3 else "v4"
+        pool_id = v3_pool if protocol == "v3" else v4_pool
+        rows.append({
+            **event(block, index),
+            "tx_hash": "0x" + f"{index + 1:064x}",
+            "pool_id": None if index == 5 else pool_id,
+            "protocol": protocol,
+            "position_key": raw_key,
+            "amount0": str(100 + index),
+            "fees_usd": index + 0.25,
+            "accounting_basis": f"evidence-{index}",
+            "data": {
+                "core_position_key": raw_key,
+                "evidence": {"trace": index, "source": "receipt"},
+            },
+        })
+
+    store = MarketStore(path)
+    try:
+        book = AccountBook(store, deferred=True).install()
+        inserted = store.ingest(blocks, rows, lane="live", cursor=cursor)
+        cursor = store.cursor("live")
+        with store.transaction() as connection:
+            connection.execute("DELETE FROM lp_accounting_pending")
+            store._set_metadata(connection, "pending_accounting", 0)
+            connection.execute(
+                "UPDATE lp_accounting_event_keys SET position_key=?",
+                (raw_key,),
+            )
+            book._queue_position_keys(connection, {raw_key: (15, 0, 5)})
+        event_ids = [int(row["id"]) for row in inserted]
+        source_before = [
+            tuple(row) for row in store.read().execute(
+                "SELECT id,block_number,block_hash,tx_hash,amount0,fees_usd,"
+                "accounting_basis,data FROM events "
+                "ORDER BY block_number,tx_index,log_index"
+            )
+        ]
+        raw_generation = int(store.read().execute(
+            "SELECT generation FROM lp_accounting_pending WHERE position_key=?",
+            (raw_key,),
+        ).fetchone()[0])
+
+        assert store.repair_legacy_core_position_keys(limit=2) is True
+        assert [
+            row["position_key"] for row in store.read().execute(
+                "SELECT position_key FROM events "
+                "ORDER BY block_number,tx_index,log_index"
+            )
+        ] == [v3_key, v3_key, raw_key, raw_key, raw_key, raw_key]
+        assert [
+            row["position_key"] for row in store.read().execute(
+                "SELECT position_key FROM lp_accounting_event_keys "
+                "ORDER BY event_id"
+            )
+        ] == [v3_key, v3_key, raw_key, raw_key, raw_key, raw_key]
+        checkpoint = store._metadata(
+            store.read(), "core_position_key_source_repair_v1", {},
+        )
+        assert checkpoint["after_position_key"] == "0x"
+        assert checkpoint["repaired_events"] == 2
+        assert {
+            row["id"] for row in store.read().execute(
+                "SELECT id FROM lp_search_entities WHERE kind='position'"
+            )
+        } == {raw_key, v3_key}
+        first_pending = {
+            row["position_key"]: int(row["generation"])
+            for row in store.read().execute(
+                "SELECT position_key,generation FROM lp_accounting_pending"
+            )
+        }
+        assert first_pending[raw_key] > raw_generation
+        assert v3_key in first_pending
+        assert store.cursor("live") == cursor
+        store.close()
+
+        store = MarketStore(path)
+        AccountBook(store, deferred=True).install()
+        checkpoint = store._metadata(
+            store.read(), "core_position_key_source_repair_v1", {},
+        )
+        assert checkpoint["after_position_key"] == "0x"
+        assert checkpoint["repaired_events"] == 2
+
+        assert store.repair_legacy_core_position_keys(limit=2) is True
+        assert [
+            row["position_key"] for row in store.read().execute(
+                "SELECT position_key FROM events "
+                "ORDER BY block_number,tx_index,log_index"
+            )
+        ] == [v3_key, v3_key, v3_key, v4_key, raw_key, raw_key]
+        assert store.repair_legacy_core_position_keys(limit=2) is True
+        checkpoint = store._metadata(
+            store.read(), "core_position_key_source_repair_v1", {},
+        )
+        assert checkpoint["after_position_key"] == raw_key
+        assert checkpoint["repaired_events"] == 5
+
+        assert store.repair_legacy_core_position_keys(limit=2) is True
+        reset_checkpoint = store._metadata(
+            store.read(), "core_position_key_source_repair_v1", {},
+        )
+        assert reset_checkpoint["after_position_key"] == "0x"
+        assert reset_checkpoint["cycles"] == 1
+        assert "exhausted_revision" not in reset_checkpoint
+        assert store.repair_legacy_core_position_keys(limit=2) is False
+        exhausted = store._metadata(
+            store.read(), "core_position_key_source_repair_v1", {},
+        )
+        assert exhausted["exhausted_revision"] == store.status()["events_revision"]
+        assert store.repair_legacy_core_position_keys(limit=2) is False
+        assert store._metadata(
+            store.read(), "core_position_key_source_repair_v1", {},
+        ) == exhausted
+
+        store.enrich([{"id": event_ids[-1], "pool_id": v4_pool}])
+        assert store.repair_legacy_core_position_keys(limit=1) is True
+        assert store.repair_legacy_core_position_keys(limit=1) is True
+        assert store.repair_legacy_core_position_keys(limit=1) is False
+        assert [
+            row["position_key"] for row in store.read().execute(
+                "SELECT position_key FROM events "
+                "ORDER BY block_number,tx_index,log_index"
+            )
+        ] == [v3_key, v3_key, v3_key, v4_key, v4_key, v4_key]
+        assert [
+            tuple(row) for row in store.read().execute(
+                "SELECT id,block_number,block_hash,tx_hash,amount0,fees_usd,"
+                "accounting_basis,data FROM events "
+                "ORDER BY block_number,tx_index,log_index"
+            )
+        ] == source_before
+        assert [
+            int(row["id"]) for row in store.read().execute(
+                "SELECT id FROM events ORDER BY block_number,tx_index,log_index"
+            )
+        ] == event_ids
+        assert {
+            row["id"] for row in store.read().execute(
+                "SELECT id FROM lp_search_entities WHERE kind='position'"
+            )
+        } == {v3_key, v4_key}
+        assert store.read().execute(
+            "SELECT 1 FROM lp_search_terms "
+            "WHERE kind='position' AND id=? LIMIT 1",
+            (raw_key,),
+        ).fetchone() is None
+        assert [
+            row["position_key"] for row in store.read().execute(
+                "SELECT position_key FROM lp_accounting_event_keys "
+                "ORDER BY event_id"
+            )
+        ] == [v3_key, v3_key, v3_key, v4_key, v4_key, v4_key]
+        pending = {
+            row["position_key"]: (
+                int(row["generation"]), int(row["requested_revision"])
+            )
+            for row in store.read().execute(
+                "SELECT position_key,generation,requested_revision "
+                "FROM lp_accounting_pending"
+            )
+        }
+        assert set(pending) == {raw_key, v3_key, v4_key}
+        assert pending[raw_key][0] > first_pending[raw_key]
+        events_revision = store.status()["events_revision"]
+        assert pending[v4_key][1] == events_revision
+        assert all(
+            0 < requested_revision <= events_revision
+            for _generation, requested_revision in pending.values()
+        )
+        assert store.cursor("live") == cursor
+        assert store.read().execute(
+            "SELECT COUNT(*) FROM events "
+            "WHERE position_key>=? AND position_key<? "
+            "AND LENGTH(position_key)=66",
+            ("0x", "0y"),
+        ).fetchone()[0] == 0
+    finally:
+        store.close()
+
+
+def test_partial_core_position_repair_unqualifies_legacy_episode_money(tmp_path):
+    raw_key = "0x" + "d1" * 32
+    first_pool = "0x" + "31" * 32
+    second_pool = "0x" + "42" * 32
+    first_key = core_position_key("v4", first_pool, raw_key)
+    second_key = core_position_key("v4", second_pool, raw_key)
+    owner = "0x" + "11" * 20
+    blocks = [header(number) for number in range(10, 14)]
+    empty = {
+        "liquidity": "0", "tokens_owed0": "0", "tokens_owed1": "0",
+        "claims_empty": True,
+    }
+    funded = {
+        "liquidity": "1000", "tokens_owed0": "0", "tokens_owed1": "0",
+        "claims_empty": True,
+    }
+    events = []
+    for offset in (0, 2):
+        events.extend([
+            v4_core_effect(
+                blocks[offset], offset, raw_key, "add", 1000, empty, funded,
+                cashflow=(-10_000_000, -10_000_000), deposit_usd=20.0,
+            ),
+            v4_core_effect(
+                blocks[offset + 1], offset + 1, raw_key, "remove", -1000,
+                funded, empty, cashflow=(11_000_000, 10_000_000),
+                fees=(1_000_000, 0), withdrawal_usd=21.0, fees_usd=1.0,
+            ),
+        ])
+    transactions = [{
+        "tx_hash": row["tx_hash"],
+        "block_number": row["block_number"],
+        "block_hash": row["block_hash"],
+        "payer": owner,
+        "gas_usd": 0.1,
+    } for row in events]
+
+    store = MarketStore(tmp_path / "partial-core-position-repair.sqlite")
+    book = AccountBook(store).install()
+    try:
+        store.upsert_pools([
+            {
+                "id": pool_id, "protocol": "v4", "address": "0x" + "22" * 20,
+                "token0": "0x" + "51" * 20, "token1": "0x" + "62" * 20,
+                "decimals0": 6, "decimals1": 6, "created_block": 10,
+            }
+            for pool_id in (first_pool, second_pool)
+        ])
+        store.ingest(blocks, events, transactions=transactions)
+
+        # AccountBook qualifies pool-aware raw keys at ingestion. Attach the
+        # canonical source scopes after projection to recreate the durable
+        # pre-scope ledger with two closed episodes under one raw identity.
+        with store.transaction() as connection:
+            connection.execute(
+                "UPDATE events SET pool_id=CASE WHEN block_number<=11 THEN ? ELSE ? END "
+                "WHERE position_key=?",
+                (first_pool, second_pool, raw_key),
+            )
+            connection.execute(
+                "UPDATE lp_accounting_episodes "
+                "SET pool_id=CASE WHEN opened_block=10 THEN ? ELSE ? END "
+                "WHERE position_key=?",
+                (first_pool, second_pool, raw_key),
+            )
+            connection.execute(
+                "UPDATE lp_accounting_positions SET pool_id=? WHERE position_key=?",
+                (second_pool, raw_key),
+            )
+
+        original = book.closed({"window": "all"})["rows"]
+        assert len(original) == 2
+        assert all(row["position_key"] == raw_key for row in original)
+        assert all(row["coverage"]["qualified"] for row in original)
+        assert all(row["coverage"]["cost_qualified"] for row in original)
+        baseline_owner = book.owner(owner, {"window": "all"})
+        assert baseline_owner["summary"]["gross_pnl_usd"] == pytest.approx(2.0)
+        assert baseline_owner["summary"]["net_pnl_usd"] == pytest.approx(1.6)
+        store.close()
+        store = MarketStore(tmp_path / "partial-core-position-repair.sqlite")
+        book = AccountBook(store, deferred=True).install()
+
+        assert store.repair_legacy_core_position_keys(limit=2) is True
+        assert book.project_pending(limit=1) is True
+
+        partial = book.closed({"window": "all"})
+        migrated = next(
+            row for row in partial["rows"] if row["position_key"] == first_key
+        )
+        unresolved = [
+            row for row in partial["rows"] if row["position_key"] == raw_key
+        ]
+        assert migrated["coverage"]["qualified"] is True
+        assert migrated["gross_pnl_usd"] == pytest.approx(1.0)
+        assert migrated["net_pnl_usd"] == pytest.approx(0.8)
+        assert unresolved
+        assert all(row["coverage"]["qualified"] is False for row in unresolved)
+        assert all(row["coverage"]["cost_qualified"] is False for row in unresolved)
+        assert all(row[field] is None for row in unresolved for field in (
+            "fees_usd", "gross_pnl_usd", "gas_usd", "net_pnl_usd", "return_pct",
+        ))
+
+        partial_owner = book.owner(owner, {"window": "all"})
+        assert partial_owner["summary"]["gross_pnl_usd"] is None
+        assert partial_owner["summary"]["net_pnl_usd"] is None
+        assert partial_owner["summary"]["fees_usd"] is None
+        assert partial_owner["summary"]["win_rate"] is None
+        assert partial_owner["coverage"]["qualified"] is False
+        owner_row = book.owners({
+            "window": "all", "identity_scope": "wallets",
+        })["rows"][0]
+        assert owner_row["gross_pnl_usd"] is None
+        assert owner_row["net_pnl_usd"] is None
+        assert owner_row["fees_usd"] is None
+        assert owner_row["volume_usd"] is None
+        assert owner_row["win_rate"] is None
+        assert owner_row["coverage"]["qualified"] is False
+
+        assert store.repair_legacy_core_position_keys(limit=2) is True
+        drain_accounting(book)
+
+        repaired = book.closed({"window": "all"})
+        assert repaired["total"] == 2
+        assert {row["position_key"] for row in repaired["rows"]} == {
+            first_key, second_key,
+        }
+        assert all(row["coverage"]["qualified"] for row in repaired["rows"])
+        assert all(row["coverage"]["cost_qualified"] for row in repaired["rows"])
+        assert all(row["gross_pnl_usd"] == pytest.approx(1.0)
+                   for row in repaired["rows"])
+        assert all(row["net_pnl_usd"] == pytest.approx(0.8)
+                   for row in repaired["rows"])
+        final_owner = book.owner(owner, {"window": "all"})
+        assert final_owner["summary"]["positions"] == 2
+        assert final_owner["summary"]["closed_episodes"] == 2
+        assert final_owner["summary"]["gross_pnl_usd"] == pytest.approx(2.0)
+        assert final_owner["summary"]["gas_usd"] == pytest.approx(0.4)
+        assert final_owner["summary"]["net_pnl_usd"] == pytest.approx(1.6)
+        assert final_owner["summary"]["fees_usd"] == pytest.approx(2.0)
+        assert final_owner["summary"]["win_rate"] == pytest.approx(100.0)
+        assert final_owner["coverage"]["qualified"] is True
+        assert final_owner["coverage"]["cost_qualified"] is True
+        final_owner_row = book.owners({
+            "window": "all", "identity_scope": "wallets",
+        })["rows"][0]
+        assert final_owner_row["gross_pnl_usd"] == pytest.approx(2.0)
+        assert final_owner_row["gas_usd"] == pytest.approx(0.4)
+        assert final_owner_row["net_pnl_usd"] == pytest.approx(1.6)
+        assert final_owner_row["fees_usd"] == pytest.approx(2.0)
+        assert final_owner_row["volume_usd"] == pytest.approx(82.0)
+        assert final_owner_row["win_rate"] == pytest.approx(100.0)
+        assert final_owner_row["coverage"]["qualified"] is True
+        assert raw_key not in {
+            row["position_key"] for row in book.positions()["rows"]
+        }
+    finally:
+        store.close()
+
+
+def test_partial_core_position_repair_does_not_double_pool_inventory(tmp_path):
+    raw_key = "0x" + "d2" * 32
+    pool_id = "0x" + "73" * 32
+    scoped_key = core_position_key("v4", pool_id, raw_key)
+    liquidity = 10**18
+    blocks = [header(number) for number in range(10, 140)]
+    empty = {
+        "liquidity": "0", "tokens_owed0": "0", "tokens_owed1": "0",
+        "claims_empty": True,
+    }
+    funded = {
+        "liquidity": str(liquidity), "tokens_owed0": "0", "tokens_owed1": "0",
+        "claims_empty": True,
+    }
+    events = [
+        v4_core_effect(
+            blocks[0], 0, raw_key, "add", liquidity, empty, funded,
+        ),
+        *[
+            v4_core_effect(
+                block, index, raw_key, "checkpoint", 0, funded, funded,
+            )
+            for index, block in enumerate(blocks[1:], 1)
+        ],
+    ]
+
+    store = MarketStore(tmp_path / "partial-core-position-inventory.sqlite")
+    book = AccountBook(store).install()
+    try:
+        store.upsert_pools([{
+            "id": pool_id, "protocol": "v4", "address": "0x" + "22" * 20,
+            "token0": "0x" + "51" * 20, "token1": "0x" + "62" * 20,
+            "decimals0": 6, "decimals1": 6, "created_block": 10,
+        }])
+        with store.transaction() as connection:
+            connection.execute(
+                "CREATE TABLE lp_pool_state("
+                "pool_id TEXT PRIMARY KEY,block_number INTEGER NOT NULL,"
+                "tx_index INTEGER NOT NULL,log_index INTEGER NOT NULL,"
+                "timestamp INTEGER NOT NULL,sqrt_price_x96 TEXT,tick INTEGER,"
+                "liquidity TEXT,price0_usd REAL,price1_usd REAL)"
+            )
+            connection.execute(
+                "INSERT INTO lp_pool_state VALUES(?,?,?,?,?,?,?,?,?,?)",
+                (
+                    pool_id, 139, 0, 129, 1_700_000_139, str(1 << 96), 0,
+                    str(liquidity), 1.0, 1.0,
+                ),
+            )
+        store.ingest(blocks, events, cursor={
+            "from_block": 10,
+            "to_block": 139,
+            "block_number": 139,
+            "block_hash": blocks[-1]["hash"],
+        })
+        with store.transaction() as connection:
+            connection.execute(
+                "UPDATE events SET pool_id=? WHERE position_key=?",
+                (pool_id, raw_key),
+            )
+            connection.execute(
+                "UPDATE lp_accounting_positions SET pool_id=? WHERE position_key=?",
+                (pool_id, raw_key),
+            )
+
+        baseline = book.pool_stats([pool_id])[pool_id]
+        assert baseline["open_positions"] == 1
+        assert baseline["complete_inventory"] is True
+        assert baseline["observed_principal_usd"] is not None
+        assert baseline["observed_principal_usd"] > 0
+        assert baseline["observed_active_tvl_usd"] == pytest.approx(
+            baseline["observed_principal_usd"],
+        )
+        store.close()
+        store = MarketStore(tmp_path / "partial-core-position-inventory.sqlite")
+        book = AccountBook(store, deferred=True).install()
+
+        assert store.repair_legacy_core_position_keys(limit=128) is True
+        assert book.project_pending(limit=1) is True
+
+        positions = {
+            row["position_key"]: row
+            for row in book.positions({"status": "open"})["rows"]
+        }
+        assert set(positions) == {raw_key, scoped_key}
+        assert positions[raw_key]["liquidity"] is None
+        assert positions[raw_key]["principal_usd"] is None
+        assert positions[raw_key]["equity_usd"] is None
+        assert positions[raw_key]["coverage"]["qualified"] is False
+        assert int(positions[scoped_key]["liquidity"]) == liquidity
+        partial = book.pool_stats([pool_id])[pool_id]
+        assert partial["open_positions"] == 2
+        assert partial["complete_inventory"] is False
+        assert partial["observed_principal_usd"] == pytest.approx(
+            baseline["observed_principal_usd"],
+        )
+        assert partial["observed_active_tvl_usd"] == pytest.approx(
+            baseline["observed_active_tvl_usd"],
+        )
+
+        assert store.repair_legacy_core_position_keys(limit=128) is True
+        drain_accounting(book)
+
+        repaired_positions = book.positions({"status": "open"})["rows"]
+        assert len(repaired_positions) == 1
+        assert repaired_positions[0]["position_key"] == scoped_key
+        repaired = book.pool_stats([pool_id])[pool_id]
+        assert repaired["open_positions"] == 1
+        assert repaired["complete_inventory"] is True
+        assert repaired["observed_principal_usd"] == pytest.approx(
+            baseline["observed_principal_usd"],
+        )
+        assert repaired["observed_active_tvl_usd"] == pytest.approx(
+            baseline["observed_active_tvl_usd"],
+        )
     finally:
         store.close()
 

--- a/tests/test_lp_market_store.py
+++ b/tests/test_lp_market_store.py
@@ -221,7 +221,6 @@ def test_schema_migrations_preserve_durable_accounting_state(tmp_path):
 
         store = MarketStore(path)
         reader = store.read()
-        assert reader.execute("PRAGMA user_version").fetchone()[0] == 7
         assert [
             tuple(row) for row in reader.execute(
                 "SELECT block_hash,position_key FROM events"
@@ -268,7 +267,6 @@ def test_schema_migrations_preserve_durable_accounting_state(tmp_path):
 
         store = MarketStore(path)
         reader = store.read()
-        assert reader.execute("PRAGMA user_version").fetchone()[0] == 7
         assert tuple(reader.execute(
             "SELECT position_key,pool_id,active_episode_id,status,"
             "history_complete,state_json FROM lp_accounting_positions"
@@ -291,7 +289,6 @@ def test_schema_migrations_preserve_durable_accounting_state(tmp_path):
         store.close()
         store = MarketStore(path)
         reader = store.read()
-        assert reader.execute("PRAGMA user_version").fetchone()[0] == 7
         assert store.pending_enrichments(1)[0]["tx_hash"] == event(block, 0)["tx_hash"]
         assert store.status()["pending_enrichment"] == 1
         assert store.cursor("live") == cursor

--- a/tests/test_lp_market_store.py
+++ b/tests/test_lp_market_store.py
@@ -792,7 +792,7 @@ def test_reopen_preserves_durable_counts_and_initializes_only_missing_counts(tmp
         store.close()
 
 
-def test_pending_append_proof_upgrade_preserves_existing_queue(tmp_path):
+def test_pending_work_mode_upgrade_preserves_existing_queue(tmp_path):
     path = tmp_path / "pending-append-upgrade.sqlite"
     connection = sqlite3.connect(path)
     connection.executescript("""
@@ -820,13 +820,13 @@ def test_pending_append_proof_upgrade_preserves_existing_queue(tmp_path):
     with MarketStore(path) as store:
         assert store.read().execute("PRAGMA user_version").fetchone()[0] == 11
         assert tuple(store.read().execute(
-            "SELECT id,position_key,generation,append_only,"
+            "SELECT id,position_key,generation,append_only,cost_only,"
             "requested_revision,requested_epoch,priority_block,"
             "priority_tx_index,priority_log_index,"
             "identities_ready,identity_cursor "
             "FROM lp_accounting_pending"
         ).fetchone()) == (
-            41, "existing-position", 7, 0, 19, 3, 10, 2, 5, 1, 123,
+            41, "existing-position", 7, 0, 0, 19, 3, 10, 2, 5, 1, 123,
         )
 
 

--- a/tests/test_lp_market_store.py
+++ b/tests/test_lp_market_store.py
@@ -85,6 +85,11 @@ def test_financial_queues_do_not_starve_recent_work_or_history(tmp_path):
             assert numbers[0] == oldest
             assert numbers[-1] == 47
             assert not {1, 9, 48}.intersection(numbers)
+        store.prioritize_enrichment("0x" + f"{number:064x}" for number in (20, 21, 48))
+        requested = store.pending_enrichments(8)
+        numbers = {row["block_number"] for row in requested}
+        assert {10, 11, 20, 21, 47} <= numbers
+        assert 48 not in numbers
 
 
 def test_bulk_ingest_preserves_conflicts_under_sqlite_parameter_limit(tmp_path):
@@ -435,41 +440,24 @@ def test_repeated_search_entities_do_not_duplicate_search_results():
         store.close()
 
 
-def test_search_batch_skips_noop_updates_and_keeps_late_enrichment():
-    store = MarketStore(":memory:")
-    initial = {
-        "position_key": "late-position",
-        "protocol": "v3",
-        "token_id": None,
-        "pool_id": None,
-    }
-    try:
-        with store.transaction() as connection:
-            store._index_event_search_batch(connection, [initial])
-        changes = store.connection.total_changes
-        with store.transaction() as connection:
-            store._index_event_search_batch(connection, [initial])
-        assert store.connection.total_changes == changes
+def test_reprojection_refreshes_new_position_search_terms():
+    with MarketStore(":memory:") as store:
+        block = header(10)
+        inserted = store.ingest([block], [event(block, 0)])
+        pool_id = "0x" + "33" * 20
+        assert store.search(pool_id) == ([], 0)
 
-        enriched = {
-            **initial,
-            "token_id": "73",
-            "pool_id": "0x" + "33" * 20,
-        }
-        with store.transaction() as connection:
-            store._index_event_search_batch(connection, [enriched])
+        def resolve_pool(_connection, events):
+            for row in events:
+                row["pool_id"] = pool_id
 
-        results, total = store.search("73")
+        store.register_projection(resolve_pool, lambda _connection, _ancestor: None)
+        store.reproject([inserted[0]["id"]])
+        results, total = store.search(pool_id)
         assert total == 1
-        assert results == [{
-            "kind": "position",
-            "id": "late-position",
-            "label": "Position 73",
-            "subtitle": "V3 POSITION · late-position",
-            "href": "/lp?q=late-position",
-        }]
-    finally:
-        store.close()
+        assert [(row["kind"], row["id"]) for row in results] == [
+            ("position", "shared-position"),
+        ]
 
 
 def test_search_batch_writes_roll_back_with_the_caller_transaction():

--- a/tests/test_lp_market_store.py
+++ b/tests/test_lp_market_store.py
@@ -140,6 +140,82 @@ def test_financial_queues_do_not_starve_recent_work_or_history(tmp_path):
         assert 48 not in numbers
 
 
+def test_enrichment_exclusions_do_not_consume_the_selection_limit(tmp_path):
+    with MarketStore(tmp_path / "enrichment-exclusions.sqlite") as store:
+        blocks = [header(number) for number in range(1, 13)]
+        store.ingest(blocks, [
+            {
+                **event(block, 0),
+                "kind": "add",
+                "tx_hash": "0x" + f"{number:064x}",
+            }
+            for number, block in enumerate(blocks, 1)
+        ])
+
+        excluded = {
+            "0x" + f"{number:064x}" for number in (1, 12)
+        }
+        selected = store.pending_enrichments(4, exclude=excluded)
+
+        assert [row["block_number"] for row in selected] == [2, 9, 10, 11]
+
+
+def test_enrichment_uses_the_newest_requested_interest(tmp_path):
+    with MarketStore(tmp_path / "enrichment-interest.sqlite") as store:
+        blocks = [header(number) for number in range(1, 13)]
+        store.ingest(blocks, [
+            {
+                **event(block, 0),
+                "kind": "add",
+                "tx_hash": "0x" + f"{number:064x}",
+            }
+            for number, block in enumerate(blocks, 1)
+        ])
+        hashes = {
+            number: "0x" + f"{number:064x}" for number in (5, 6)
+        }
+
+        store.prioritize_enrichment([hashes[5], hashes[6]])
+        selected = store.pending_enrichments(4, prioritized=True)
+        assert {row["block_number"] for row in selected} == {1, 6, 11, 12}
+
+        store.prioritize_enrichment([hashes[5]])
+        selected = store.pending_enrichments(4, prioritized=True)
+        assert {row["block_number"] for row in selected} == {1, 5, 11, 12}
+
+
+def test_requested_identity_work_preserves_the_normal_lane_interest(tmp_path):
+    with MarketStore(tmp_path / "enrichment-identity-interest.sqlite") as store:
+        blocks = [header(number) for number in range(1, 13)]
+        store.ingest(blocks, [
+            {
+                **event(block, 0),
+                "kind": "add",
+                "tx_hash": "0x" + f"{number:064x}",
+            }
+            for number, block in enumerate(blocks, 1)
+        ])
+        hashes = {
+            number: "0x" + f"{number:064x}" for number in (5, 6)
+        }
+        with store.transaction() as connection:
+            connection.execute(
+                "UPDATE pending_enrichment SET "
+                "last_error='pool_identity_pending:{}' WHERE tx_hash=?",
+                (hashes[5],),
+            )
+        store.prioritize_enrichment([hashes[5], hashes[6]])
+
+        assert [
+            row["block_number"]
+            for row in store.requested_enrichments(1, identity=True)
+        ] == [5]
+        assert [
+            row["block_number"]
+            for row in store.requested_enrichments(1)
+        ] == [6]
+
+
 def test_bulk_ingest_preserves_conflicts_under_sqlite_parameter_limit(tmp_path):
     path = tmp_path / "bounded-inserts.sqlite"
     block = header(10)

--- a/tests/test_lp_market_store.py
+++ b/tests/test_lp_market_store.py
@@ -299,6 +299,121 @@ def test_schema_migrations_preserve_durable_accounting_state(tmp_path):
         assert reader.execute(
             "SELECT value FROM lp_accounting_meta WHERE key='applied_revision'"
         ).fetchone()[0] == accounting_revision
+
+        with store.transaction() as connection:
+            connection.execute("DELETE FROM lp_accounting_pending")
+            connection.execute(
+                "INSERT INTO lp_accounting_pending("
+                "id,position_key,generation,requested_revision,requested_epoch,"
+                "priority_block,priority_tx_index,priority_log_index"
+                ") VALUES(41,'shared-position',7,19,3,10,2,5)"
+            )
+        def committed_state(connection: sqlite3.Connection) -> dict[str, object]:
+            return {
+                "events": [
+                    tuple(row) for row in connection.execute(
+                        "SELECT id,block_hash,position_key,revision FROM events"
+                    )
+                ],
+                "coverage": [
+                    tuple(row) for row in connection.execute(
+                        "SELECT lane,start_block,end_block,start_hash,end_hash "
+                        "FROM coverage_intervals"
+                    )
+                ],
+                "position": tuple(connection.execute(
+                    "SELECT position_key,pool_id,active_episode_id,status,"
+                    "history_complete,state_json FROM lp_accounting_positions"
+                ).fetchone()),
+                "event_keys": [
+                    tuple(row) for row in connection.execute(
+                        "SELECT event_id,position_key,token_id "
+                        "FROM lp_accounting_event_keys"
+                    )
+                ],
+                "accounting_meta": [
+                    tuple(row) for row in connection.execute(
+                        "SELECT key,value FROM lp_accounting_meta ORDER BY key"
+                    )
+                ],
+                "pool_generations": [
+                    tuple(row) for row in connection.execute(
+                        "SELECT pool_id,generation "
+                        "FROM lp_accounting_pool_generations ORDER BY pool_id"
+                    )
+                ],
+                "pending": tuple(connection.execute(
+                    "SELECT id,position_key,generation,requested_revision,"
+                    "requested_epoch,priority_block,priority_tx_index,"
+                    "priority_log_index FROM lp_accounting_pending"
+                ).fetchone()),
+            }
+
+        committed_before_v9 = committed_state(reader)
+        with store.transaction() as connection:
+            connection.execute("DROP TABLE lp_accounting_pending_identities")
+            connection.execute(
+                "DROP INDEX lp_accounting_pending_identity_bootstrap"
+            )
+            connection.execute("DROP INDEX lp_accounting_pending_recent")
+            connection.execute(
+                "ALTER TABLE lp_accounting_pending "
+                "RENAME TO lp_accounting_pending_v9"
+            )
+            connection.executescript("""
+                CREATE TABLE lp_accounting_pending(
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    position_key TEXT NOT NULL UNIQUE,
+                    generation INTEGER NOT NULL,
+                    requested_revision INTEGER NOT NULL,
+                    requested_epoch INTEGER NOT NULL,
+                    priority_block INTEGER NOT NULL,
+                    priority_tx_index INTEGER NOT NULL,
+                    priority_log_index INTEGER NOT NULL
+                );
+                INSERT INTO lp_accounting_pending(
+                    id,position_key,generation,requested_revision,requested_epoch,
+                    priority_block,priority_tx_index,priority_log_index
+                )
+                SELECT
+                    id,position_key,generation,requested_revision,requested_epoch,
+                    priority_block,priority_tx_index,priority_log_index
+                FROM lp_accounting_pending_v9;
+                DROP TABLE lp_accounting_pending_v9;
+                CREATE INDEX lp_accounting_pending_recent
+                    ON lp_accounting_pending(
+                        priority_block DESC,priority_tx_index DESC,
+                        priority_log_index DESC,id DESC
+                    );
+                PRAGMA user_version=8;
+            """)
+        store.close()
+
+        store = MarketStore(path)
+        reader = store.read()
+        committed_after_v9 = committed_state(reader)
+        assert committed_after_v9 == committed_before_v9
+        assert store.cursor("live") == cursor
+        assert tuple(reader.execute(
+            "SELECT identities_ready,identity_cursor "
+            "FROM lp_accounting_pending WHERE position_key='shared-position'"
+        ).fetchone()) == (0, 0)
+
+        with store.transaction() as connection:
+            store._install_accounting_pending_identities(connection)
+            store._install_accounting_pending_identities(connection)
+            connection.execute(
+                "INSERT INTO lp_accounting_pending_identities("
+                "position_key,kind,identity,protocol,pool_id,timestamp"
+                ") VALUES('shared-position','owner','0xowner','v3','',123)"
+            )
+            connection.execute(
+                "DELETE FROM lp_accounting_pending "
+                "WHERE position_key='shared-position'"
+            )
+        assert reader.execute(
+            "SELECT COUNT(*) FROM lp_accounting_pending_identities"
+        ).fetchone()[0] == 0
     finally:
         store.close()
 

--- a/tests/test_lp_market_store.py
+++ b/tests/test_lp_market_store.py
@@ -792,6 +792,44 @@ def test_reopen_preserves_durable_counts_and_initializes_only_missing_counts(tmp
         store.close()
 
 
+def test_pending_append_proof_upgrade_preserves_existing_queue(tmp_path):
+    path = tmp_path / "pending-append-upgrade.sqlite"
+    connection = sqlite3.connect(path)
+    connection.executescript("""
+        CREATE TABLE lp_accounting_pending(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            position_key TEXT NOT NULL UNIQUE,
+            generation INTEGER NOT NULL,
+            requested_revision INTEGER NOT NULL,
+            requested_epoch INTEGER NOT NULL,
+            priority_block INTEGER NOT NULL,
+            priority_tx_index INTEGER NOT NULL,
+            priority_log_index INTEGER NOT NULL,
+            identities_ready INTEGER NOT NULL DEFAULT 0,
+            identity_cursor INTEGER NOT NULL DEFAULT 0
+        );
+        INSERT INTO lp_accounting_pending(
+            id,position_key,generation,requested_revision,requested_epoch,
+            priority_block,priority_tx_index,priority_log_index,
+            identities_ready,identity_cursor
+        ) VALUES(41,'existing-position',7,19,3,10,2,5,1,123);
+        PRAGMA user_version=10;
+    """)
+    connection.close()
+
+    with MarketStore(path) as store:
+        assert store.read().execute("PRAGMA user_version").fetchone()[0] == 11
+        assert tuple(store.read().execute(
+            "SELECT id,position_key,generation,append_only,"
+            "requested_revision,requested_epoch,priority_block,"
+            "priority_tx_index,priority_log_index,"
+            "identities_ready,identity_cursor "
+            "FROM lp_accounting_pending"
+        ).fetchone()) == (
+            41, "existing-position", 7, 0, 19, 3, 10, 2, 5, 1, 123,
+        )
+
+
 def test_schema_migrations_preserve_durable_accounting_state(tmp_path):
     path = tmp_path / "schema-migration.sqlite"
     block = header(10)
@@ -948,9 +986,10 @@ def test_schema_migrations_preserve_durable_accounting_state(tmp_path):
                     )
                 ],
                 "pending": tuple(connection.execute(
-                    "SELECT id,position_key,generation,requested_revision,"
-                    "requested_epoch,priority_block,priority_tx_index,"
-                    "priority_log_index FROM lp_accounting_pending"
+                    "SELECT id,position_key,generation,append_only,"
+                    "requested_revision,requested_epoch,priority_block,"
+                    "priority_tx_index,priority_log_index "
+                    "FROM lp_accounting_pending"
                 ).fetchone()),
             }
 
@@ -1000,9 +1039,9 @@ def test_schema_migrations_preserve_durable_accounting_state(tmp_path):
         assert committed_after_v9 == committed_before_v9
         assert store.cursor("live") == cursor
         assert tuple(reader.execute(
-            "SELECT identities_ready,identity_cursor "
+            "SELECT append_only,identities_ready,identity_cursor "
             "FROM lp_accounting_pending WHERE position_key='shared-position'"
-        ).fetchone()) == (0, 0)
+        ).fetchone()) == (0, 0, 0)
 
         with store.transaction() as connection:
             store._install_accounting_pending_identities(connection)

--- a/tests/test_lp_rpc.py
+++ b/tests/test_lp_rpc.py
@@ -193,8 +193,11 @@ def test_execution_revert_in_batch_is_not_replaced_by_another_provider(monkeypat
     )
     monkeypatch.setattr(lp_rpc, "_source_list", lambda *_args: sources)
     monkeypatch.setattr(lp_rpc, "head_subscription_urls", lambda: ())
+    posts = []
+
 
     def post(_client, source, payload):
+        posts.append((source.name, payload))
         def response(item):
             result = {"jsonrpc": "2.0", "id": item["id"]}
             if item["method"] == "eth_chainId":
@@ -214,19 +217,274 @@ def test_execution_revert_in_batch_is_not_replaced_by_another_provider(monkeypat
         bad = ("eth_call", [{"to": "0x" + "1" * 40, "data": "0xbad0"}, "latest"])
         with pytest.raises(RuntimeError, match="execution reverted"):
             client.batch([good, bad])
+        output = client.batch([good, bad], allow_reverts=True)
+        assert output == [
+            "0x01",
+            {"error": {"code": -32000, "message": "execution reverted: unknown selector"}},
+        ]
+        assert [
+            source for source, payload in posts
+            if isinstance(payload, list) and any(
+                item["method"] == "eth_call" for item in payload
+            )
+        ] == ["primary", "primary"]
         assert client.batch([good]) == ["0x01"]
+        assert factory.status()["state"]["sources"][0]["state"] == "available"
     finally:
         factory.close()
 
 
+def test_allow_reverts_preserves_abi_error_but_not_provider_credentials(
+        monkeypatch):
+    credential = "secret-provider-key"
+    source = lp_rpc._Source(
+        "private", f"https://rpc.example.test/v2/{credential}",
+        (("Authorization", f"Bearer {credential}"),),
+    )
+    monkeypatch.setattr(lp_rpc, "_source_list", lambda *_args: (source,))
+    monkeypatch.setattr(lp_rpc, "head_subscription_urls", lambda: ())
+    revert_data = "0x08c379a0" + "00" * 64
+
+    def post(_client, _source, payload):
+        def response(item):
+            result = {"jsonrpc": "2.0", "id": item["id"]}
+            if item["method"] == "eth_chainId":
+                result["result"] = hex(CHAIN_ID)
+            else:
+                result["error"] = {
+                    "code": 3,
+                    "message": f"execution reverted at {source.url}?token={credential}",
+                    "data": revert_data,
+                    "details": {"authorization": f"Bearer {credential}"},
+                }
+            return result
+        return [response(item) for item in payload] if isinstance(payload, list) else response(payload)
+
+    monkeypatch.setattr(lp_rpc.RoutedRpc, "_post", post)
+    factory = lp_rpc.build_rpc_factory("", RuntimeError)
+    try:
+        result = factory("state").batch([
+            ("eth_call", [{"to": "0x" + "1" * 40, "data": "0xbad0"}, "latest"]),
+        ], allow_reverts=True)
+        assert result[0]["error"]["code"] == 3
+        assert result[0]["error"]["data"] == revert_data
+        encoded = json.dumps(result)
+        assert credential not in encoded
+        assert "<redacted>" in encoded
+    finally:
+        factory.close()
+
+
+def test_allow_reverts_fails_over_and_propagates_non_revert_failures(monkeypatch):
+    sources = (
+        lp_rpc._Source("primary", "https://primary.test/rpc"),
+        lp_rpc._Source("fallback", "https://fallback.test/rpc"),
+    )
+    monkeypatch.setattr(lp_rpc, "_source_list", lambda *_args: sources)
+    monkeypatch.setattr(lp_rpc, "head_subscription_urls", lambda: ())
+    attempted = []
+
+    def post(_client, source, payload):
+        if isinstance(payload, list):
+            attempted.append(source.name)
+
+        def response(item):
+            result = {"jsonrpc": "2.0", "id": item["id"]}
+            if item["method"] == "eth_chainId":
+                result["result"] = hex(CHAIN_ID)
+            else:
+                result["error"] = {"code": -32000, "message": "missing trie node"}
+            return result
+        return [response(item) for item in payload] if isinstance(payload, list) else response(payload)
+
+    monkeypatch.setattr(lp_rpc.RoutedRpc, "_post", post)
+    factory = lp_rpc.build_rpc_factory("", RuntimeError)
+    try:
+        with pytest.raises(RuntimeError, match="missing trie node"):
+            factory("enrichment").batch([
+                ("eth_call", [{"to": "0x" + "1" * 40, "data": "0x"}, "0x10"]),
+            ], allow_reverts=True)
+        assert attempted == ["primary", "fallback"]
+        assert [
+            source["state"]
+            for source in factory.status()["history_state"]["sources"]
+        ] == ["failed", "failed"]
+    finally:
+        factory.close()
+
+
+def test_v4_manager_owner_correlation_does_not_require_optional_aux_event():
+    from eth_abi import encode
+    from rhpools.lp_market_protocols import (
+        POOL_MANAGER, TRANSFER_TOPIC, V4_MODIFY_LIQUIDITY_TOPIC,
+        V4_POSITION_MANAGER, decode_logs, decode_position_state_results,
+        nft_position_key, position_state_requests,
+    )
+
+    block_hash = "0x" + "a" * 64
+    tx_hash = "0x" + "b" * 64
+    pool_id = "0x" + "c" * 64
+    owner = "0x" + "1" * 40
+    token_id = 42
+
+    def topic(value):
+        return "0x" + f"{value:064x}"
+
+    common = {
+        "blockNumber": "0xa", "blockHash": block_hash,
+        "transactionHash": tx_hash, "transactionIndex": "0x0",
+    }
+    logs = [
+        {
+            **common,
+            "address": V4_POSITION_MANAGER,
+            "logIndex": "0x0",
+            "topics": [
+                TRANSFER_TOPIC, topic(0), topic(int(owner, 16)), topic(token_id),
+            ],
+            "data": "0x",
+        },
+        {
+            **common,
+            "address": POOL_MANAGER,
+            "logIndex": "0x1",
+            "topics": [
+                V4_MODIFY_LIQUIDITY_TOPIC, pool_id,
+                topic(int(V4_POSITION_MANAGER, 16)),
+            ],
+            "data": "0x" + encode(
+                ["int24", "int24", "int256", "bytes32"],
+                [-60, 60, 100, token_id.to_bytes(32, "big")],
+            ).hex(),
+        },
+    ]
+    rows = decode_logs(
+        logs,
+        {pool_id: {"id": pool_id, "protocol": "v4", "address": POOL_MANAGER}},
+        {10: {"hash": block_hash, "timestamp": 1_000}},
+    )
+    action = next(row for row in rows if row["protocol"] == "v4")
+    assert action["owner"] == owner
+    assert action["position_key"] == nft_position_key(V4_POSITION_MANAGER, token_id)
+    position_requests = [
+        request for request in position_state_requests(rows)
+        if request["correlation"]["decoder"] == "v4_state_view_position"
+    ]
+    assert {
+        request["correlation"]["field"] for request in position_requests
+    } == {"position_after"}
+    assert {
+        request["correlation"]["position_before_absence_basis"]
+        for request in position_requests
+    } == {"same_receipt_verified_v4_manager_mint"}
+    state = "0x" + encode(["uint128", "uint256", "uint256"], [100, 1, 2]).hex()
+    position_updates = decode_position_state_results(
+        position_requests, [state] * len(position_requests)
+    )
+    for update in position_updates:
+        assert update["data"]["position_before"] == {
+            "exists": False,
+            "liquidity": "0",
+            "fee_growth_inside0_last_x128": "0",
+            "fee_growth_inside1_last_x128": "0",
+            "tokens_owed0": None,
+            "tokens_owed1": None,
+            "claims_empty": True,
+            "claim_model": "fees_settled_on_modify_no_tokens_owed_storage",
+            "source": "verified_v4_manager_mint_absence",
+            "pinned_block": 9,
+            "absence_basis": "same_receipt_verified_v4_manager_mint",
+        }
+        assert update["data"]["position_after"]["liquidity"] == "100"
+    assert action["identity_basis"] == "manager_transfer_same_tx"
+
+def test_repair_v4_owners_preserves_enriched_canonical_data():
+    from rhpools.lp_market_protocols import (
+        V4_POSITION_MANAGER, nft_position_key, repair_v4_owners,
+    )
+
+    owner = "0x" + "1" * 40
+    recipient = "0x" + "2" * 40
+    tx_hash = "0x" + "b" * 64
+    token_id = 42
+    position_key = nft_position_key(V4_POSITION_MANAGER, token_id)
+    core = {
+        "protocol": "v4",
+        "kind": "add",
+        "block_number": 10,
+        "block_hash": "0x" + "a" * 64,
+        "tx_hash": tx_hash,
+        "tx_index": 2,
+        "log_index": 11,
+        "owner": None,
+        "custody": V4_POSITION_MANAGER,
+        "position_key": position_key,
+        "token_id": str(token_id),
+        "liquidity_delta": "100",
+        "cashflow0": "-25",
+        "cashflow1": "-50",
+        "fee_amount0": "3",
+        "fee_amount1": "7",
+        "accounting_basis": "v4_modifyLiquidity_return",
+        "identity_basis": "verified_v4_nft_salt",
+        "data": {
+            "identity_basis": "verified_v4_nft_salt",
+            "trace_complete": True,
+            "cashflow_basis": "v4_modifyLiquidity_return",
+            "position_before": {
+                "exists": False, "liquidity": "0", "pinned_block": 9,
+            },
+            "position_after": {
+                "exists": True, "liquidity": "100", "pinned_block": 10,
+            },
+            "nested_evidence": {"paths": [[0, 1]], "return": "0x1234"},
+        },
+    }
+    transfer = {
+        "protocol": "nft",
+        "kind": "transfer",
+        "block_number": 10,
+        "block_hash": core["block_hash"],
+        "tx_hash": tx_hash,
+        "tx_index": 2,
+        "log_index": 12,
+        "owner": recipient,
+        "custody": V4_POSITION_MANAGER,
+        "position_key": position_key,
+        "token_id": str(token_id),
+        "data": {
+            "manager_protocol": "v4",
+            "prior_owner": owner,
+            "new_owner": recipient,
+            "mint": False,
+            "burn": False,
+        },
+    }
+    original = json.loads(json.dumps([core, transfer]))
+    expected = json.loads(json.dumps(core))
+    expected.update(
+        owner=owner,
+        identity_basis="manager_transfer_same_tx_prestate",
+    )
+    expected["data"]["identity_basis"] = "manager_transfer_same_tx_prestate"
+
+    repaired = repair_v4_owners([core, transfer])
+
+    assert [core, transfer] == original
+    assert repaired == [expected]
+    assert repair_v4_owners([repaired[0], transfer]) == []
+
+
+
 @pytest.mark.parametrize("lifecycle", ["mint", "burn"])
-def test_nfpm_lifecycle_absence_survives_routed_batch_fallback(
+def test_nfpm_lifecycle_absence_uses_verified_mint_and_batched_burn(
         provider, monkeypatch, tmp_path, lifecycle):
     from eth_abi import encode
     from rhpools.lp_market_index import MarketIndexer, RpcError
     from rhpools.lp_market_protocols import (
         ProtocolDecodeError, UNISWAP_V3_POSITION_MANAGER,
-        decode_position_state_results, position_state_requests,
+        decode_position_state_results, nft_position_key,
+        position_state_requests,
     )
     from rhpools.lp_market_store import MarketStore
 
@@ -241,7 +499,10 @@ def test_nfpm_lifecycle_absence_survives_routed_batch_fallback(
         [0, zero, owner, "0x" + "2" * 40, 500, -60, 60, liquidity, 0, 0, 0, 0],
     ).hex()
 
+    posts = []
+
     def post(_client, _source, payload):
+        posts.append(payload)
         def response(item):
             result = {"jsonrpc": "2.0", "id": item["id"]}
             if item["method"] == "eth_chainId":
@@ -263,6 +524,7 @@ def test_nfpm_lifecycle_absence_survives_routed_batch_fallback(
         "block_hash": "0x" + "a" * 64, "tx_hash": "0x" + "b" * 64,
         "tx_index": 0, "log_index": 1, "token_id": "42",
         "custody": UNISWAP_V3_POSITION_MANAGER,
+        "position_key": nft_position_key(UNISWAP_V3_POSITION_MANAGER, 42),
         "data": {
             "manager_protocol": "v3", "mint": lifecycle == "mint",
             "burn": lifecycle == "burn",
@@ -282,9 +544,30 @@ def test_nfpm_lifecycle_absence_survives_routed_batch_fallback(
             assert update[missing]["claims_empty"] is True
             assert update[present]["exists"] is True
             assert update[present]["liquidity"] == str(liquidity)
+            if lifecycle == "mint":
+                assert update[missing]["absence_basis"] == "same_receipt_verified_nfpm_mint"
+            eth_call_batches = [
+                payload for payload in posts
+                if isinstance(payload, list) and any(
+                    item["method"] == "eth_call" for item in payload
+                )
+            ]
+            eth_call_singles = [
+                payload for payload in posts
+                if isinstance(payload, dict) and payload["method"] == "eth_call"
+            ]
+            assert len(eth_call_batches) == 1
+            assert len(eth_call_batches[0]) == (1 if lifecycle == "mint" else 2)
+            assert eth_call_singles == []
+            assert provider.status()["history_state"]["sources"][0]["state"] == "available"
 
             event["data"].update(mint=False, burn=False)
-            with pytest.raises(ProtocolDecodeError, match="pinned eth_call failed"):
+            expected = (
+                "request/result count mismatch"
+                if lifecycle == "mint"
+                else "pinned eth_call failed"
+            )
+            with pytest.raises(ProtocolDecodeError, match=expected):
                 decode_position_state_results(position_state_requests([event]), results)
         finally:
             scanner.close()

--- a/tests/test_lp_rpc.py
+++ b/tests/test_lp_rpc.py
@@ -69,7 +69,7 @@ def test_missing_archive_state_does_not_poison_headers_or_bypass_cooldown(provid
     assert provider.status()["history_state"]["sources"][0]["state"] == "available"
 
 
-def test_slow_response_does_not_serialize_other_rpc_lanes(provider, monkeypatch):
+def test_slow_response_does_not_serialize_shared_rpc_client(provider, monkeypatch):
     slow_started = threading.Event()
     release_slow = threading.Event()
     monkeypatch.setattr(lp_rpc, "_minimum_interval", lambda _url: 0.0)
@@ -95,7 +95,7 @@ def test_slow_response_does_not_serialize_other_rpc_lanes(provider, monkeypatch)
 
     monkeypatch.setattr(provider._registry, "_session", lambda _source: SimpleNamespace(post=post))
     history = provider("history")
-    live = provider("live")
+    live = history
     with ThreadPoolExecutor(max_workers=2) as executor:
         blocked = executor.submit(history.call, "eth_getBlockByNumber", ["0x10", False])
         try:
@@ -106,6 +106,130 @@ def test_slow_response_does_not_serialize_other_rpc_lanes(provider, monkeypatch)
         finally:
             release_slow.set()
         assert blocked.result(timeout=2) == {"number": "0x10"}
+
+
+def test_concurrent_clients_share_one_chain_verification(provider, monkeypatch):
+    checks = threading.Barrier(2)
+    checked_threads = set()
+    checked_lock = threading.Lock()
+    chain_calls = 0
+    chain_calls_lock = threading.Lock()
+    verified = provider._registry.verified
+
+    def synchronized_verified(source):
+        identity = threading.get_ident()
+        with checked_lock:
+            first_check = identity not in checked_threads
+            checked_threads.add(identity)
+        if first_check:
+            checks.wait(timeout=2)
+        return verified(source)
+
+    def post(_client, _source, payload):
+        nonlocal chain_calls
+        if payload["method"] == "eth_chainId":
+            with chain_calls_lock:
+                chain_calls += 1
+            result = hex(CHAIN_ID)
+        else:
+            result = "0x200"
+        return {
+            "jsonrpc": "2.0", "id": payload["id"], "result": result,
+        }
+
+    monkeypatch.setattr(provider._registry, "verified", synchronized_verified)
+    monkeypatch.setattr(lp_rpc.RoutedRpc, "_post", post)
+    clients = (provider("live"), provider("live"))
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(
+            lambda client: client.call("eth_blockNumber"), clients,
+        ))
+    assert results == ["0x200", "0x200"]
+    assert chain_calls == 1
+
+
+def test_rate_wait_does_not_consume_response_capacity(provider, monkeypatch):
+    clock = SimpleNamespace(now=100.0)
+    gate = lp_rpc._SourceGate(next_at=101.0, started_at=100.0)
+    available_during_wait = []
+
+    def sleep(delay):
+        permits = []
+        for _index in range(lp_rpc.MAX_SOURCE_CONCURRENCY):
+            if gate.slots.acquire(blocking=False):
+                permits.append(True)
+        available_during_wait.append(len(permits))
+        for _permit in permits:
+            gate.slots.release()
+        clock.now += delay
+
+    monkeypatch.setattr(lp_rpc, "time", SimpleNamespace(
+        monotonic=lambda: clock.now, time=lambda: clock.now, sleep=sleep,
+    ))
+    monkeypatch.setattr(lp_rpc, "_gate", lambda _url: gate)
+    monkeypatch.setattr(lp_rpc, "_minimum_interval", lambda _url: 0.0)
+    response = json.dumps({
+        "jsonrpc": "2.0", "id": 1, "result": "0x200",
+    }).encode()
+    session = SimpleNamespace(post=lambda *_args, **_kwargs: SimpleNamespace(
+        raise_for_status=lambda: None,
+        raw=SimpleNamespace(read=lambda *_args, **_kwargs: response),
+        close=lambda: None,
+    ))
+    monkeypatch.setattr(provider._registry, "_session", lambda _source: session)
+
+    client = provider("live")
+    source = provider._registry.sources["head"][0]
+    assert client._post(source, {
+        "jsonrpc": "2.0", "id": 1,
+        "method": "eth_blockNumber", "params": [],
+    })["result"] == "0x200"
+    assert available_during_wait == [lp_rpc.MAX_SOURCE_CONCURRENCY]
+
+
+def test_close_waits_for_admitted_http_request(provider, monkeypatch):
+    started = threading.Event()
+    release = threading.Event()
+    close_started = threading.Event()
+    session_closed = threading.Event()
+    source = provider._registry.sources["head"][0]
+
+    def post(_url, *, data, **_kwargs):
+        payload = json.loads(data)
+        started.set()
+        if not release.wait(5):
+            raise TimeoutError("request was not released")
+        encoded = json.dumps({
+            "jsonrpc": "2.0", "id": payload["id"], "result": "0x200",
+        }).encode()
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            raw=SimpleNamespace(read=lambda *_args, **_kwargs: encoded),
+            close=lambda: None,
+        )
+
+    session = SimpleNamespace(post=post, close=session_closed.set)
+    provider._registry._clients[(source.url, source.headers)] = session
+    monkeypatch.setattr(provider._registry, "_session", lambda _source: session)
+    monkeypatch.setattr(lp_rpc, "_minimum_interval", lambda _url: 0.0)
+    provider._registry.mark_verified(source)
+    client = provider("live")
+
+    def close_factory():
+        close_started.set()
+        provider.close()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        request = executor.submit(client.call, "eth_blockNumber")
+        assert started.wait(2)
+        closing = executor.submit(close_factory)
+        assert close_started.wait(2)
+        assert not closing.done()
+        assert not session_closed.is_set()
+        release.set()
+        assert request.result(timeout=2) == "0x200"
+        closing.result(timeout=2)
+    assert session_closed.is_set()
 
 
 def test_rpc_credentials_reject_public_files_and_bad_urls_without_leaking(tmp_path, monkeypatch):
@@ -309,6 +433,185 @@ def test_allow_reverts_fails_over_and_propagates_non_revert_failures(monkeypatch
             source["state"]
             for source in factory.status()["history_state"]["sources"]
         ] == ["failed", "failed"]
+    finally:
+        factory.close()
+
+
+def test_batch_failover_does_not_repeat_healthy_siblings(monkeypatch):
+    sources = (
+        lp_rpc._Source("primary", "https://partial-primary.test/rpc"),
+        lp_rpc._Source("fallback", "https://partial-fallback.test/rpc"),
+    )
+    monkeypatch.setattr(lp_rpc, "_source_list", lambda *_args: sources)
+    monkeypatch.setattr(lp_rpc, "head_subscription_urls", lambda: ())
+    batches = []
+
+    def post(_client, source, payload):
+        def response(item):
+            result = {"jsonrpc": "2.0", "id": item["id"]}
+            if item["method"] == "eth_chainId":
+                result["result"] = hex(CHAIN_ID)
+            elif (
+                source.name == "primary"
+                and item["params"][0]["data"] == "0xbad0"
+            ):
+                result["error"] = {
+                    "code": -32000, "message": "missing trie node",
+                }
+            else:
+                result["result"] = (
+                    "0x01" if source.name == "primary" else "0x99"
+                )
+            return result
+
+        if isinstance(payload, list):
+            batches.append((
+                source.name,
+                [item["params"][0]["data"] for item in payload],
+            ))
+            return [response(item) for item in payload]
+        return response(payload)
+
+    monkeypatch.setattr(lp_rpc.RoutedRpc, "_post", post)
+    factory = lp_rpc.build_rpc_factory("", RuntimeError)
+    good = (
+        "eth_call",
+        [{"to": "0x" + "1" * 40, "data": "0x600d"}, "latest"],
+    )
+    bad = (
+        "eth_call",
+        [{"to": "0x" + "1" * 40, "data": "0xbad0"}, "latest"],
+    )
+    try:
+        assert factory("state").batch([good, bad]) == ["0x01", "0x99"]
+        assert batches == [
+            ("primary", ["0x600d", "0xbad0"]),
+            ("fallback", ["0xbad0"]),
+        ]
+    finally:
+        factory.close()
+
+
+def test_batch_results_isolates_errors_without_replaying_siblings(monkeypatch):
+    class RpcFailure(RuntimeError):
+        def __init__(self, message, *, code=None):
+            self.code = code
+            super().__init__(message)
+
+    primary_key = "primary-secret"
+    fallback_key = "fallback-secret"
+    sources = (
+        lp_rpc._Source(
+            "primary", f"https://primary.test/v2/{primary_key}",
+        ),
+        lp_rpc._Source(
+            "fallback", f"https://fallback.test/v2/{fallback_key}",
+        ),
+    )
+    monkeypatch.setattr(lp_rpc, "_source_list", lambda *_args: sources)
+    monkeypatch.setattr(lp_rpc, "head_subscription_urls", lambda: ())
+    batches = []
+
+    def post(_client, source, payload):
+        def response(item):
+            result = {"jsonrpc": "2.0", "id": item["id"]}
+            if item["method"] == "eth_chainId":
+                result["result"] = hex(CHAIN_ID)
+                return result
+            selector = item["params"][0]["data"]
+            if source.name == "primary" and selector == "0x600d":
+                result["result"] = "0x01"
+            elif source.name == "primary" and selector == "0xdead":
+                result["error"] = {
+                    "code": 3, "message": f"execution reverted {source.url}",
+                    "data": "0xdeadbeef",
+                }
+            elif source.name == "fallback" and selector == "0xfade":
+                result["result"] = "0x99"
+            else:
+                result["error"] = {
+                    "code": -32000 if source.name == "primary" else -32001,
+                    "message": f"missing state at {source.url}",
+                    "data": (
+                        "0xaaaaaaaa"
+                        if source.name == "primary"
+                        else "0xbbbbbbbb"
+                    ),
+                }
+            return result
+
+        if isinstance(payload, list):
+            batches.append((
+                source.name,
+                [item["params"][0]["data"] for item in payload],
+            ))
+            return [response(item) for item in payload]
+        return response(payload)
+
+    monkeypatch.setattr(lp_rpc.RoutedRpc, "_post", post)
+    factory = lp_rpc.build_rpc_factory("", RpcFailure)
+    calls = [
+        (
+            "eth_call",
+            [{"to": "0x" + "1" * 40, "data": selector}, "latest"],
+        )
+        for selector in ("0x600d", "0xdead", "0xfade", "0xbad0")
+    ]
+    try:
+        results = factory("state").batch_results(calls)
+        assert results[0] == "0x01"
+        assert isinstance(results[1], RpcFailure)
+        assert results[1].code == 3
+        assert "0xdeadbeef" in str(results[1])
+        assert results[2] == "0x99"
+        assert isinstance(results[3], RpcFailure)
+        assert results[3].code == -32001
+        assert "0xaaaaaaaa" in str(results[3])
+        assert "0xbbbbbbbb" in str(results[3])
+        assert primary_key not in " ".join(map(str, results))
+        assert fallback_key not in " ".join(map(str, results))
+        assert batches == [
+            ("primary", ["0x600d", "0xdead", "0xfade", "0xbad0"]),
+            ("fallback", ["0xfade", "0xbad0"]),
+        ]
+    finally:
+        factory.close()
+
+
+def test_balance_lane_routes_pinned_state_to_history_provider(monkeypatch):
+    live = lp_rpc._Source("live", "https://live-state.test/rpc")
+    historical = lp_rpc._Source(
+        "historical", "https://historical-state.test/rpc",
+    )
+    monkeypatch.setattr(
+        lp_rpc, "_source_list",
+        lambda _url, capability: (
+            (historical,) if capability == "history_state" else (live,)
+        ),
+    )
+    monkeypatch.setattr(lp_rpc, "head_subscription_urls", lambda: ())
+    attempted = []
+
+    def post(_client, source, payload):
+        attempted.append(source.name)
+        result = {
+            "jsonrpc": "2.0", "id": payload["id"],
+            "result": (
+                hex(CHAIN_ID)
+                if payload["method"] == "eth_chainId"
+                else "0x01"
+            ),
+        }
+        return result
+
+    monkeypatch.setattr(lp_rpc.RoutedRpc, "_post", post)
+    factory = lp_rpc.build_rpc_factory("", RuntimeError)
+    try:
+        assert factory("balance").call("eth_call", [
+            {"to": "0x" + "1" * 40, "data": "0x600d"},
+            {"blockHash": "0x" + "a" * 64, "requireCanonical": True},
+        ]) == "0x01"
+        assert attempted == ["historical", "historical"]
     finally:
         factory.close()
 

--- a/tests/test_workbench_market.py
+++ b/tests/test_workbench_market.py
@@ -772,8 +772,10 @@ def test_collections_and_burned_principal_do_not_manufacture_profit(
 
 
 def test_fee_claim_uses_uint256_wrapping_for_lazy_growth():
+    from rhpools.lp_math import fee_claim
+
     q128 = 1 << 128
-    claim0, claim1, lazy0, lazy1 = market._v3_fee_claim(
+    claim0, claim1, lazy0, lazy1 = fee_claim(
         3,
         (1 << 256) - q128,
         0,


### PR DESCRIPTION
## Changes
- Decouple canonical live/history ingestion, identity recovery, wallet frames and accounting without discarding durable work.
- Bound single-writer residency, batch receipt/state/identity work, and remove replay amplification.
- Admit incremental and receipt-only projections only with source-backed proofs; preserve reorg epochs, queue generations and gas attribution.
- Prepare accounting in two spawned read-only processes with four-position lookahead. The original coordinator remains the sole publisher.
- Scope stale effect deletion to its prepared position, and require the current canonical mapping before an upsert can reclaim another position's effect.

## Verification
- 222 tests pass; CI passes on Python 3.11 and 3.13 plus browser JavaScript syntax.
- Real spawned-process smoke: full episodes, receipt gas correction, stale-preparation rejection after reorg and SQLite write rejection.
- Financial reproductions: repricing gives gross 1.00, gas 0.02 and net 0.98; both overlapping remap orders retain gas 0.02 and net 0.08 rather than losing attribution.
- Final guarded production source eb5ae7b42af3 preserved the database inode, schema and canonical cursors. Service restart count is zero.
- Read-only audit found three missing effects across two positions. Queue-only repair admitted those positions without writing financial rows; the normal publisher restored all three under canonical keys. The complete post-repair event-level query found no missing effects among already-published, nonqueued positions.
- All six sampled public financial API routes returned HTTP 200. Cold aggregate endpoints still reached about 22 seconds; this does not claim every endpoint is fast.

## Final 15-minute production measurement
- Accounting: 52,876 -> 44,000 (-8,876).
- Balances: 2,316,046 -> 2,293,238 (-22,808); completion 35.75/s versus creation 10.42/s.
- Enrichment: 2,192,929 -> 2,183,836 (-9,093), including financial -3,237 and identity -5,856.
- Reprojection: 3 -> 2. Its transient backlog drained; the last-half delta was also negative.
- Every queue also shrank in the last half of the window.
- History advanced 2,984 blocks; median live lag 19 blocks, p95 74, final 39.
- Goldsky maximum 58.533 logical calls/s under the 80/s cap; no failed status samples; epoch unchanged.

Backlogs are not empty. This verifies sustained catchup while new work arrives, not instantaneous completion of historical indexing.